### PR TITLE
fix: `genConstructorOverloads` when nums is 0

### DIFF
--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -791,7 +791,7 @@ function genConstructorOverloads(name = 'ConstructorOverloads', nums?: number) {
 			gen(i);
 		}
 	}
-	else {
+	else if (nums > 0) {
 		gen(nums);
 	}
 	code += `// 0\n`;

--- a/packages/vue-language-core/src/utils/localTypes.ts
+++ b/packages/vue-language-core/src/utils/localTypes.ts
@@ -141,7 +141,7 @@ export function genConstructorOverloads(name = 'ConstructorOverloads', nums?: nu
 			gen(i);
 		}
 	}
-	else {
+	else if (nums > 0) {
 		gen(nums);
 	}
 	code += `// 0\n`;

--- a/packages/vue-test-workspace/vue-tsc/#2370/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/#2370/main.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineProps<{
+	msg: string
+}>()
+
+defineEmits<{}>()
+</script>
+
+<template>
+	<div>{{ msg }}</div>
+</template>


### PR DESCRIPTION
Fixes #2370.

As for now Volar generates code like this when `defineEmits` is used with empty interface:
```ts
type __VLS_ConstructorOverloads<T> =
// 0
T extends {
} ? (
) :
// 0
{};
```
which is not valid TypeScript code. This PR skips the `nums == 0` case.