### PR TITLE
feat(vue-tsc): unsupport tracing

### DIFF
--- a/packages/vue-tsc/bin/vue-tsc.js
+++ b/packages/vue-tsc/bin/vue-tsc.js
@@ -14,9 +14,6 @@ fs.readFileSync = (...args) => {
 		tryReplace(/supportedJSExtensions = .*(?=;)/, s => s + '.concat([[".vue"]])');
 		tryReplace(/allSupportedExtensions = .*(?=;)/, s => s + '.concat([[".vue"]])');
 
-		// proxy startTracing, dumpTracingLegend
-		tryReplace(/ = tracingEnabled\./g, ` = require(${JSON.stringify(proxyApiPath)}).loadTsLib().`);
-
 		// proxy createProgram apis
 		tryReplace(/function createProgram\(.+\) {/, s => s + ` return require(${JSON.stringify(proxyApiPath)}).createProgram(...arguments);`);
 

--- a/packages/vue-tsc/src/index.ts
+++ b/packages/vue-tsc/src/index.ts
@@ -22,6 +22,9 @@ export function createProgram(options: ts.CreateProgramOptions) {
 	if (!options.options.noEmit && options.options.noEmitOnError)
 		throw toThrow('noEmitOnError is not supported');
 
+	if (options.options.extendedDiagnostics || options.options.generateTrace)
+		throw toThrow('--extendedDiagnostics / --generateTrace is not supported, please run `Write Virtual Files` in VSCode to write virtual files and use `--extendedDiagnostics` / `--generateTrace` via tsc instead of vue-tsc to debug.');
+
 	if (!options.host)
 		throw toThrow('!options.host');
 

--- a/packages/vue-tsc/src/index.ts
+++ b/packages/vue-tsc/src/index.ts
@@ -153,10 +153,6 @@ export function createProgram(options: ts.CreateProgramOptions) {
 	return program;
 }
 
-export function loadTsLib() {
-	return ts;
-}
-
 function toThrow(msg: string) {
 	console.error(msg);
 	return msg;


### PR DESCRIPTION
Undo #1402, Fix #2316.

The motivation is that somehow vue-tsc does not fully support tracing. Compared with tsc, vue-tsc silently lost some output, which caused some users to be unable to continue debugging.

Here's the related discussion: https://discord.com/channels/793943652350427136/1025627001102544957/threads/1058554813626982440

A more reliable method is to use the `Write Virtual Files` command + tsc instead.

cc @blake-newman.