### PR TITLE
fix: looser `v-model` type behavior for checkbox, radio input tag

### DIFF
--- a/packages/vue-language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/vue-language-core/schemas/vue-tsconfig.schema.json
@@ -109,12 +109,6 @@
 						"": {
 							"input": true
 						},
-						"checked": {
-							"input": [
-								{ "type": "checkbox" },
-								{ "type": "radio" }
-							]
-						},
 						"value": {
 							"input": { "type": "text" },
 							"textarea": true,

--- a/packages/vue-language-core/src/utils/ts.ts
+++ b/packages/vue-language-core/src/utils/ts.ts
@@ -169,12 +169,6 @@ export function resolveVueCompilerOptions(vueOptions: Partial<VueCompilerOptions
 			'': {
 				input: true
 			},
-			checked: {
-				input: [
-					{ type: 'checkbox' },
-					{ type: 'radio' }
-				]
-			},
 			value: {
 				input: { type: 'text' },
 				textarea: true,


### PR DESCRIPTION
Fix #2415

@KaelWD proposes that the 	`v-model` type of the input tag should not correspond to `checked`: https://github.com/vuejs/language-tools/issues/1252#issuecomment-1254806581