### PR TITLE
chore: add format test for indent sensitive cases

### DIFF
--- a/packages/vue-test-workspace/format/js template strings/input.vue
+++ b/packages/vue-test-workspace/format/js template strings/input.vue
@@ -1,0 +1,12 @@
+<script>
+const str1 = `
+txt
+`;
+
+const str2 = `
+txt	${ '' +
+str1
+}
+txt
+`;
+</script>

--- a/packages/vue-test-workspace/format/js template strings/output.vue
+++ b/packages/vue-test-workspace/format/js template strings/output.vue
@@ -1,0 +1,12 @@
+<script>
+	const str1 = `
+txt
+`;
+
+	const str2 = `
+txt	${'' +
+		str1
+		}
+txt
+`;
+</script>

--- a/packages/vue-test-workspace/format/js template strings/settings.json
+++ b/packages/vue-test-workspace/format/js template strings/settings.json
@@ -1,0 +1,5 @@
+{
+	"volar.format.initialIndent": {
+		"javascript": true
+	}
+}

--- a/packages/vue-test-workspace/format/multi-line html comment/input.vue
+++ b/packages/vue-test-workspace/format/multi-line html comment/input.vue
@@ -1,0 +1,7 @@
+<template>
+	<div></div>
+	<!--
+		hey
+	-->
+	<div></div>
+</template>

--- a/packages/vue-test-workspace/format/multi-line html comment/output.vue
+++ b/packages/vue-test-workspace/format/multi-line html comment/output.vue
@@ -1,0 +1,7 @@
+<template>
+	<div></div>
+	<!--
+		hey
+	-->
+	<div></div>
+</template>


### PR DESCRIPTION
Indentation should not be modified in some cases, such as html comments and js string templates.

Needs:
- https://github.com/volarjs/volar.js/commit/86007dcc0e1d692adc2c197f5efa835ab9d3f131
- https://github.com/volarjs/plugins/commit/0cf6d083b70c5cd2d7cc736ad3d764a4fb61b1b7
- https://github.com/volarjs/plugins/commit/a734f87f0ae8903c00e3ff2c4db3350cc2ca1e75