### PR TITLE
feat: add `volar.vueserver.fullCompletionList` setting

### DIFF
--- a/packages/vscode-vue/package.json
+++ b/packages/vscode-vue/package.json
@@ -418,6 +418,11 @@
 					"default": [],
 					"description": "List any additional file extensions that should be processed as Vue files (requires restart)."
 				},
+				"volar.vueserver.fullCompletionList": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enable this option if you want to get complete CompletionList in language client. (Disable for better performance)"
+				},
 				"volar.codeLens.references": {
 					"type": "boolean",
 					"default": true,

--- a/packages/vscode-vue/src/common.ts
+++ b/packages/vscode-vue/src/common.ts
@@ -171,6 +171,7 @@ async function doActivate(context: vscode.ExtensionContext, createLc: CreateLang
 				|| e.affectsConfiguration('volar.vueserver.additionalExtensions')
 				|| e.affectsConfiguration('volar.vueserver.maxFileSize')
 				|| e.affectsConfiguration('volar.vueserver.configFilePath')
+				|| e.affectsConfiguration('volar.vueserver.fullCompletionList')
 			) {
 				requestReloadVscode();
 			}
@@ -244,6 +245,10 @@ export function diagnosticModel() {
 
 function additionalExtensions() {
 	return vscode.workspace.getConfiguration('volar').get<string[]>('vueserver.additionalExtensions') ?? [];
+}
+
+function fullCompletionList() {
+	return vscode.workspace.getConfiguration('volar').get<boolean>('vueserver.fullCompletionList');
 }
 
 function getFillInitializeParams(featuresKinds: LanguageFeaturesKind[]) {
@@ -328,6 +333,7 @@ function getInitializationOptions(
 			tokenTypes: ['component'],
 			tokenModifiers: [],
 		},
+		fullCompletionList: fullCompletionList(),
 	};
 	return initializationOptions;
 }


### PR DESCRIPTION
`volar.vueserver.fullCompletionList` is used to control if the language server should filter completion items first or not for better JSON decode performance. Default false (should filter).

Implement by https://github.com/volarjs/volar.js/commit/fd0e24ca67f622aee2cad987221e21163e7aa963

Fix #2306