### PR TITLE
Upgrade build target from ES2016 to ES2021

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "ES2016",
+		"target": "ES2021",
 		"lib": [
-			"WebWorker",
 			"ES2021",
 		],
 		"module": "commonjs",


### PR DESCRIPTION
Our current build target is ES2016, but the core has been relying on the WeakRef feature of ES2021, so the code actually cannot run on runtimes that do not support ES2021.

After this PR, `vue-tsc`, `@volar/vue-language-server` will explicitly only support runtimes of node 16 or above.