### PR TITLE
perf(vue-component-meta): delay init for global props list

### DIFF
--- a/packages/vue-component-meta/src/index.ts
+++ b/packages/vue-component-meta/src/index.ts
@@ -183,7 +183,7 @@ export function baseCreate(
 	});
 	const tsLs = ts.createLanguageService(proxyHost);
 	let globalPropNames: string[] = [];
-	globalPropNames = getComponentMeta(globalComponentName).props.map(prop => prop.name);
+	globalPropNames = checkerOptions.globalPropNames ?? getComponentMeta(globalComponentName).props.map(prop => prop.name);
 
 	return {
 		getExportNames,

--- a/packages/vue-component-meta/src/index.ts
+++ b/packages/vue-component-meta/src/index.ts
@@ -182,8 +182,7 @@ export function baseCreate(
 		}
 	});
 	const tsLs = ts.createLanguageService(proxyHost);
-	let globalPropNames: string[] = [];
-	globalPropNames = checkerOptions.globalPropNames ?? getComponentMeta(globalComponentName).props.map(prop => prop.name);
+	let globalPropNames: string[] | undefined;
 
 	return {
 		getExportNames,
@@ -257,8 +256,11 @@ export function baseCreate(
 			}
 
 			// fill global
-			for (const prop of result) {
-				prop.global = globalPropNames.includes(prop.name);
+			if (componentPath !== globalComponentName) {
+				globalPropNames ??= getComponentMeta(globalComponentName).props.map(prop => prop.name);
+				for (const prop of result) {
+					prop.global = globalPropNames.includes(prop.name);
+				}
 			}
 
 			// fill defaults

--- a/packages/vue-component-meta/src/types.ts
+++ b/packages/vue-component-meta/src/types.ts
@@ -58,5 +58,4 @@ export interface MetaCheckerOptions {
 	forceUseTs?: boolean;
 	printer?: ts.PrinterOptions;
 	rawType?: boolean;
-	globalPropNames?: string[];
 }

--- a/packages/vue-component-meta/src/types.ts
+++ b/packages/vue-component-meta/src/types.ts
@@ -58,4 +58,5 @@ export interface MetaCheckerOptions {
 	forceUseTs?: boolean;
 	printer?: ts.PrinterOptions;
 	rawType?: boolean;
+	globalPropNames?: string[];
 }


### PR DESCRIPTION
Setting `globalPropNames` avoid parsing empty component `<script setup lang="ts"></script>` while creating new meta parser. which can save seconds when starting!

In actual vue 3.2, the resolved value is `[ 'key', 'ref', 'ref_for', 'ref_key', 'class', 'style' ]`