### PR TITLE
feat: RFC 436 Leaves Experimental

### DIFF
--- a/packages/vue-language-core/schemas/vue-tsconfig.deprecated.schema.json
+++ b/packages/vue-language-core/schemas/vue-tsconfig.deprecated.schema.json
@@ -53,6 +53,12 @@
 				},
 				"bypassDefineComponentToExposePropsAndEmitsForJsScriptSetupComponents": {
 					"deprecated": true
+				},
+				"experimentalRfc436": {
+					"deprecated": true,
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "This flag is no longer needed after v1.4.0.\n\n[RFC](https://github.com/vuejs/rfcs/discussions/436)"
 				}
 			}
 		}

--- a/packages/vue-language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/vue-language-core/schemas/vue-tsconfig.schema.json
@@ -93,11 +93,6 @@
 					],
 					"markdownDescription": "https://github.com/johnsoncodehk/volar/issues/1038, https://github.com/johnsoncodehk/volar/issues/1121"
 				},
-				"experimentalRfc436": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "https://github.com/vuejs/rfcs/discussions/436"
-				},
 				"experimentalUseElementAccessInTemplate": {
 					"type": "boolean",
 					"default": false,

--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -309,6 +309,9 @@ export function generate(
 					sfc.scriptSetup.genericOffset,
 					FileRangeCapabilities.full,
 				]);
+				if (!sfc.scriptSetup.generic.endsWith(',')) {
+					codeGen.push(`,`);
+				}
 				codeGen.push(`>`);
 			}
 			codeGen.push('(');

--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -76,7 +76,7 @@ export function generate(
 		ConstructorOverloads: false,
 		WithTemplateSlots: false,
 	};
-	const generateFunctionType = !!vueCompilerOptions.experimentalRfc436 && !!sfc.scriptSetup?.generic;
+	const generateFunctionType = !!sfc.scriptSetup?.generic;
 
 	writeScriptSrc();
 	writeScriptSetupImportsSegment();

--- a/packages/vue-language-core/src/types.ts
+++ b/packages/vue-language-core/src/types.ts
@@ -33,7 +33,6 @@ export interface VueCompilerOptions {
 
 	// experimental
 	experimentalResolveStyleCssClasses: 'scoped' | 'always' | 'never';
-	experimentalRfc436: boolean;
 	experimentalModelPropName: Record<string, Record<string, boolean | Record<string, string> | Record<string, string>[]>>;
 	experimentalUseElementAccessInTemplate: boolean;
 	experimentalAdditionalLanguageModules: string[];

--- a/packages/vue-language-core/src/utils/ts.ts
+++ b/packages/vue-language-core/src/utils/ts.ts
@@ -211,7 +211,6 @@ export function resolveVueCompilerOptions(vueOptions: Partial<VueCompilerOptions
 		// experimental
 		experimentalAdditionalLanguageModules: vueOptions.experimentalAdditionalLanguageModules ?? [],
 		experimentalResolveStyleCssClasses: vueOptions.experimentalResolveStyleCssClasses ?? 'scoped',
-		experimentalRfc436: vueOptions.experimentalRfc436 ?? false,
 		// https://github.com/vuejs/vue-next/blob/master/packages/compiler-dom/src/transforms/vModel.ts#L49-L51
 		// https://vuejs.org/guide/essentials/forms.html#form-input-bindings
 		experimentalModelPropName: vueOptions.experimentalModelPropName ?? {


### PR DESCRIPTION
Follow-up to #1964

- [x] No needed `generic="T extends any"` and more, just `generic="T"`
- [x] Deprecated `experimentalRfc436` flag, judging only based on whether there is a `generic` attr
- [x] Workaround for #592 when enabled `jsxTemplates`: `"jsxImportSource": "@vue/jsx"`

## Requirement

- Volar / vue-tsc: v1.4.0
- Vue: v3.3

## Usage

Note: Explicitly specify `@vue/jsx` to solve #592, if your node_modules does not include `@types/react` then `@vue/jsx` is not needed.

- `package.json`

```json
{
  "devDependencies": {
    "@vue/jsx": ">=3.3.0"
  }
}
```

- `tsconfg.json`

```json
{
  "compilerOptions": {
    "jsxImportSource": "@vue/jsx"
  },
  "vueCompilerOptions": {
    "jsxTemplates": true
  }
}
```

- Component

```html
<script setup lang="ts" generic="T">
defineProps<{ msg: T }>()
</script>
```

If in doubt about codegen behavior, you can inspect the virtual code with the `Volar (Debug): Show Virtual Files` command.