### PR TITLE
fix(vue-tsc): fix typescript 5 support

### DIFF
--- a/packages/vue-tsc/src/index.ts
+++ b/packages/vue-tsc/src/index.ts
@@ -54,7 +54,10 @@ export function createProgram(options: ts.CreateProgramOptions) {
 			version: string,
 		}>();
 		const vueLsHost = new Proxy(<vue.VueLanguageServiceHost>{
-			resolveModuleNames: undefined, // avoid failed with tsc built-in fileExists
+			// avoid failed with tsc built-in fileExists
+			resolveModuleNames: undefined,
+			resolveModuleNameLiterals: undefined,
+
 			writeFile: (fileName, content) => {
 				if (fileName.indexOf('__VLS_') === -1) {
 					ctx.options.host!.writeFile(fileName, content, false);


### PR DESCRIPTION
Typescript 5 will attempt to use the host `resolveModuleNameLiterals` if present, which prevents vue-tsc looking up Vue files.

Set this as undefined so it defaults back to existing logic.

---

I'm unsure on the api of `resolveModuleNameLiterals` so didn't try to implement a solution for this currently; thought it best to fallback to existing behavior and then discover if we get any benefits from using this API. 