### PR TITLE
fix: resolving of paths in vueCompilerOptions

### DIFF
--- a/packages/vue-language-core/src/utils/ts.ts
+++ b/packages/vue-language-core/src/utils/ts.ts
@@ -135,7 +135,7 @@ function getVueCompilerOptions(
 	function resolvePath(scriptPath: string): string | undefined {
 		try {
 			if (require?.resolve) {
-				scriptPath = require.resolve(scriptPath, { paths: [folder] });
+				return require.resolve(scriptPath, { paths: [folder] });
 			}
 			else {
 				console.log('failed to resolve path:', scriptPath, 'require.resolve is not supported in web');


### PR DESCRIPTION
Have just tried https://github.com/vuejs/language-tools/pull/2267 and it totally didn't work because the path resolving always returned undefined.