### PR TITLE
feat: fewer side effects codegen for `<script setup>`

### DIFF
--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -343,7 +343,7 @@ export function generate(
 			) {
 				if (scriptSetupRanges.propsRuntimeArg && scriptSetupRanges.defineProps) {
 					codes.push(`const __VLS_props = `);
-					addVirtualCode('scriptSetup', scriptSetupRanges.defineProps.start, scriptSetupRanges.defineProps.end);
+					addExtraReferenceVirtualCode('scriptSetup', scriptSetupRanges.defineProps.start, scriptSetupRanges.defineProps.end);
 					codes.push(`;\n`);
 				}
 				else if (scriptSetupRanges.defineProp.length) {
@@ -389,7 +389,7 @@ export function generate(
 				if (scriptSetupRanges.slotsTypeArg) {
 					usedHelperTypes.ToTemplateSlots = true;
 					codes.push(` & { [K in keyof JSX.ElementChildrenAttribute]: __VLS_ToTemplateSlots<`);
-					addVirtualCode('scriptSetup', scriptSetupRanges.slotsTypeArg.start, scriptSetupRanges.slotsTypeArg.end);
+					addExtraReferenceVirtualCode('scriptSetup', scriptSetupRanges.slotsTypeArg.start, scriptSetupRanges.slotsTypeArg.end);
 					codes.push(`>; }`);
 				}
 				codes.push(`;\n`);
@@ -399,12 +399,12 @@ export function generate(
 				if (scriptSetupRanges.slotsTypeArg) {
 					usedHelperTypes.ToTemplateSlots = true;
 					codes.push(` & { [K in keyof JSX.ElementChildrenAttribute]: __VLS_ToTemplateSlots<`);
-					addVirtualCode('scriptSetup', scriptSetupRanges.slotsTypeArg.start, scriptSetupRanges.slotsTypeArg.end);
+					addExtraReferenceVirtualCode('scriptSetup', scriptSetupRanges.slotsTypeArg.start, scriptSetupRanges.slotsTypeArg.end);
 					codes.push(`>; }`);
 				}
 				if (scriptSetupRanges.propsTypeArg) {
 					codes.push(' & ');
-					addVirtualCode('scriptSetup', scriptSetupRanges.propsTypeArg.start, scriptSetupRanges.propsTypeArg.end);
+					addExtraReferenceVirtualCode('scriptSetup', scriptSetupRanges.propsTypeArg.start, scriptSetupRanges.propsTypeArg.end);
 				}
 				codes.push(`;\n`);
 			}
@@ -414,12 +414,12 @@ export function generate(
 			codes.push(`const __VLS_emit = `);
 			if (scriptSetupRanges.emitsTypeArg) {
 				codes.push('{} as ');
-				addVirtualCode('scriptSetup', scriptSetupRanges.emitsTypeArg.start, scriptSetupRanges.emitsTypeArg.end);
+				addExtraReferenceVirtualCode('scriptSetup', scriptSetupRanges.emitsTypeArg.start, scriptSetupRanges.emitsTypeArg.end);
 				codes.push(';\n');
 			}
 			else if (scriptSetupRanges.emitsRuntimeArg) {
 				codes.push(`(await import('vue')).defineEmits(`);
-				addVirtualCode('scriptSetup', scriptSetupRanges.emitsRuntimeArg.start, scriptSetupRanges.emitsRuntimeArg.end);
+				addExtraReferenceVirtualCode('scriptSetup', scriptSetupRanges.emitsRuntimeArg.start, scriptSetupRanges.emitsRuntimeArg.end);
 				codes.push(');\n');
 			}
 			else {

--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -321,8 +321,9 @@ export function generate(
 			}
 			codes.push(`>`);
 			codes.push('(\n');
-			codes.push(`__VLS_props: NonNullable<typeof __VLS_ctx['__props']> & import('vue').VNodeProps,\n`);
-			codes.push('__VLS_ctx = (() => {\n');
+			codes.push(`__VLS_props: typeof __VLS_setup['props'] & import('vue').VNodeProps,\n`);
+			codes.push(`__VLS_ctx: Pick<typeof __VLS_setup, 'expose' | 'attrs' | 'emit' | 'slots'>,\n`);
+			codes.push('__VLS_setup = (() => {\n');
 			scriptSetupGeneratedOffset = generateSetupFunction(true, 'none', definePropMirrors);
 
 			//#region exposed
@@ -428,14 +429,14 @@ export function generate(
 			//#endregion
 
 			codes.push('return {} as {\n');
-			codes.push(`__props?: typeof __VLS_props,\n`);
-			codes.push('expose?(exposed: typeof __VLS_exposed): void,\n');
-			codes.push('attrs?: any,\n');
-			codes.push('slots?: ReturnType<typeof __VLS_template>,\n');
-			codes.push('emit?: typeof __VLS_emit');
+			codes.push(`props: typeof __VLS_props,\n`);
+			codes.push('expose(exposed: typeof __VLS_exposed): void,\n');
+			codes.push('attrs: any,\n');
+			codes.push('slots: ReturnType<typeof __VLS_template>,\n');
+			codes.push('emit: typeof __VLS_emit');
 			codes.push('};\n');
 			codes.push('})(),\n');
-			codes.push(') => ({} as JSX.Element & { __ctx?: typeof __VLS_ctx, __props?: typeof __VLS_props }))');
+			codes.push(') => ({} as any))');
 		}
 		else if (!sfc.script) {
 			// no script block, generate script setup code at root

--- a/packages/vue-language-core/src/parsers/scriptSetupRanges.ts
+++ b/packages/vue-language-core/src/parsers/scriptSetupRanges.ts
@@ -10,7 +10,6 @@ export function parseScriptSetupRanges(
 ) {
 
 	let foundNonImportExportNode = false;
-	let notOnTopTypeExports: TextRange[] = [];
 	let importSectionEndOffset = 0;
 	let withDefaultsArg: TextRange | undefined;
 	let propsAssignName: string | undefined;
@@ -48,15 +47,11 @@ export function parseScriptSetupRanges(
 			importSectionEndOffset = node.getStart(ast, true);
 			foundNonImportExportNode = true;
 		}
-		else if (isTypeExport && foundNonImportExportNode) {
-			notOnTopTypeExports.push(_getStartEnd(node));
-		}
 	});
 	ast.forEachChild(child => visitNode(child, ast));
 
 	return {
 		importSectionEndOffset,
-		notOnTopTypeExports,
 		bindings,
 		withDefaultsArg,
 		defineProps,

--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -266,7 +266,7 @@ function resolvePlugins(
 		isSupportedDocument: (document) => document.languageId === 'jade',
 		vueCompilerOptions,
 	});
-	plugins.vue ??= createVuePlugin(vueCompilerOptions);
+	plugins.vue ??= createVuePlugin();
 	plugins.css ??= createCssPlugin();
 	plugins['pug-beautify'] ??= createPugFormatPlugin();
 	plugins.json ??= createJsonPlugin(settings?.json);

--- a/packages/vue-language-service/src/plugins/vue.ts
+++ b/packages/vue-language-service/src/plugins/vue.ts
@@ -1,16 +1,14 @@
-import { parseScriptSetupRanges } from '@volar/vue-language-core';
 import { LanguageServicePlugin } from '@volar/language-service';
 import * as html from 'vscode-html-languageservice';
 import * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import createHtmlPlugin from '@volar-plugins/html';
 import * as vue from '@volar/vue-language-core';
-import { VueCompilerOptions } from '../types';
 import { loadLanguageBlocks } from './data';
 
 let sfcDataProvider: html.IHTMLDataProvider | undefined;
 
-export default (vueCompilerOptions: VueCompilerOptions): LanguageServicePlugin => (context) => {
+export default (): LanguageServicePlugin => (context) => {
 
 	const htmlPlugin = createHtmlPlugin({ validLang: 'vue', disableCustomData: true })(context);
 
@@ -46,23 +44,6 @@ export default (vueCompilerOptions: VueCompilerOptions): LanguageServicePlugin =
 
 				const result: vscode.Diagnostic[] = [];
 				const sfc = vueSourceFile.sfc;
-
-				if (sfc.scriptSetup && sfc.scriptSetupAst) {
-					const scriptSetupRanges = parseScriptSetupRanges(_ts.module, sfc.scriptSetupAst, vueCompilerOptions);
-					for (const range of scriptSetupRanges.notOnTopTypeExports) {
-						result.push(vscode.Diagnostic.create(
-							{
-								start: document.positionAt(range.start + sfc.scriptSetup.startTagEnd),
-								end: document.positionAt(range.end + sfc.scriptSetup.startTagEnd),
-							},
-							'type and interface export statements must be on the top in <script setup>',
-							vscode.DiagnosticSeverity.Warning,
-							undefined,
-							'volar',
-						));
-					}
-				}
-
 				const program = _ts.languageService.getProgram();
 
 				if (program && !program.getSourceFile(vueSourceFile.mainScriptName)) {

--- a/packages/vue-test-workspace/vue-tsc/components/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/components/main.vue
@@ -64,12 +64,13 @@ const ScriptSetupDefaultPropsExact = defineComponent({
 });
 // vue 3.3 generic
 declare const ScriptSetupGenericExact: <T, >(
-	_props: import('vue').VNodeProps & { [K in keyof JSX.ElementChildrenAttribute]: { default(data: T): any } } & { foo: T },
+	_props: import('vue').VNodeProps & NonNullable<NonNullable<typeof _ctx>['__props']>,
 	_ctx?: {
-		attrs: any,
-		slots: { default(data: T): any },
-		emit: { (e: 'bar', data: T): void },
-		expose(_exposed: { baz: T }): void,
+		__props?: { foo: T } & { [K in keyof JSX.ElementChildrenAttribute]: { default(data: T): any } },
+		attrs?: any,
+		slots?: { default(data: T): any },
+		emit?: { (e: 'bar', data: T): void },
+		expose?(_exposed: { baz: T }): void,
 	}
 ) => JSX.Element & {
 	__props?: typeof _props;

--- a/packages/vue-test-workspace/vue-tsc/components/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/components/main.vue
@@ -64,18 +64,16 @@ const ScriptSetupDefaultPropsExact = defineComponent({
 });
 // vue 3.3 generic
 declare const ScriptSetupGenericExact: <T, >(
-	_props: import('vue').VNodeProps & NonNullable<NonNullable<typeof _ctx>['__props']>,
-	_ctx?: {
-		__props?: { foo: T } & { [K in keyof JSX.ElementChildrenAttribute]: { default(data: T): any } },
-		attrs?: any,
-		slots?: { default(data: T): any },
-		emit?: { (e: 'bar', data: T): void },
-		expose?(_exposed: { baz: T }): void,
+	_props: import('vue').VNodeProps & NonNullable<typeof _setup>['props'],
+	_ctx: Pick<NonNullable<typeof _setup>, 'expose' | 'attrs' | 'emit' | 'slots'>,
+	_setup?: {
+		props: { foo: T } & { [K in keyof JSX.ElementChildrenAttribute]: { default(data: T): any } },
+		attrs: any,
+		slots: { default(data: T): any },
+		emit: { (e: 'bar', data: T): void },
+		expose(_exposed: { baz: T }): void,
 	}
-) => JSX.Element & {
-	__props?: typeof _props;
-	__ctx?: typeof _ctx;
-};
+) => any;
 
 exactType(ScriptSetup, ScriptSetupExact);
 exactType(ScriptSetupExpose, ScriptSetupExposeExact);

--- a/packages/vue-test-workspace/vue-tsc/components/script-setup-generic.vue
+++ b/packages/vue-test-workspace/vue-tsc/components/script-setup-generic.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts" generic="T">
-const props: { foo: T } = defineProps<{ foo: T }>();
+defineProps<{ foo: T }>();
 defineEmits<{ (e: 'bar', data: T): void }>();
-defineExpose({ baz: props.foo });
+defineExpose({ baz: {} as T });
 defineSlots<{ default(data: T): any }>();
 </script>
 

--- a/packages/vue-test-workspace/vue-tsc/defineProp_B/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/defineProp_B/main.vue
@@ -19,23 +19,21 @@ const ScriptSetupExact = defineComponent({
 	},
 });
 declare const ScriptSetupGenericExact: <T, >(
-	_props: import('vue').VNodeProps & NonNullable<NonNullable<typeof _ctx>['__props']>,
-	_ctx?: {
-		__props?: {
+	_props: import('vue').VNodeProps & NonNullable<typeof _setup>['props'],
+	_ctx: Pick<NonNullable<typeof _setup>, 'expose' | 'attrs' | 'emit' | 'slots'>,
+	_setup?: {
+		props: {
 			a?: T | undefined;
 			b?: T | undefined;
 			c?: T | undefined;
 			d: T;
 		},
-		attrs?: any,
-		slots?: {},
-		emit?: any,
-		expose?(_exposed: {}): void,
+		attrs: any,
+		slots: {},
+		emit: any,
+		expose(_exposed: {}): void,
 	}
-) => JSX.Element & {
-	__props?: typeof _props;
-	__ctx?: typeof _ctx;
-};
+) => any;
 
 exactType(ScriptSetup, ScriptSetupExact);
 exactType(ScriptSetupGeneric, ScriptSetupGenericExact);

--- a/packages/vue-test-workspace/vue-tsc/defineProp_B/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/defineProp_B/main.vue
@@ -19,17 +19,18 @@ const ScriptSetupExact = defineComponent({
 	},
 });
 declare const ScriptSetupGenericExact: <T, >(
-	_props?: {
-		a?: T | undefined;
-		b?: T | undefined;
-		c?: T | undefined;
-		d: T;
-	} & import('vue').VNodeProps,
+	_props: import('vue').VNodeProps & NonNullable<NonNullable<typeof _ctx>['__props']>,
 	_ctx?: {
-		attrs: any,
-		slots: {},
-		emit: any,
-		expose(_exposed: {}): void,
+		__props?: {
+			a?: T | undefined;
+			b?: T | undefined;
+			c?: T | undefined;
+			d: T;
+		},
+		attrs?: any,
+		slots?: {},
+		emit?: any,
+		expose?(_exposed: {}): void,
 	}
 ) => JSX.Element & {
 	__props?: typeof _props;

--- a/packages/vue-test-workspace/vue-tsc/generic-interface/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/generic-interface/main.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts" generic="T">
+interface Props {
+    foo: T;
+}
+defineProps<Props>();
+</script>

--- a/packages/vue-test-workspace/vue-tsc/script-setup-scope/export-order.vue
+++ b/packages/vue-test-workspace/vue-tsc/script-setup-scope/export-order.vue
@@ -10,5 +10,6 @@ export const useTwo = async () => ({ two: 'two' })
 
 <script lang="ts" setup>
 useOne()
+// @ts-expect-error
 useTwo()
 </script>


### PR DESCRIPTION
- [x] If `<script>` block does not exist, directly generate script setup code to root scope instead of wrapping it into function scope.
- [x] Support props interface for generic component.

Fixes #2421