### PR TITLE
chore: Lerna-Lite 2.0 publish & version are becoming optional commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	},
 	"optionalDependencies": {
 		"@lerna-lite/cli": "latest",
+		"@lerna-lite/publish": "latest",
 		"opencc": "latest"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ importers:
       '@lerna-lite/cli':
         specifier: latest
         version: 1.17.0
+      '@lerna-lite/publish':
+        specifier: latest
+        version: 1.17.0
       opencc:
         specifier: latest
         version: 1.1.3
@@ -150,7 +153,7 @@ importers:
     dependencies:
       '@volar-plugins/pug':
         specifier: 2.0.0-alpha.21
-        version: 2.0.0-alpha.21(@volar/language-service@1.4.0-alpha.7)(@volar/source-map@1.4.0-alpha.7)
+        version: 2.0.0-alpha.21(@volar/source-map@1.4.0-alpha.7)
       '@volar/source-map':
         specifier: 1.4.0-alpha.7
         version: 1.4.0-alpha.7
@@ -1169,6 +1172,19 @@ packages:
       '@vscode/emmet-helper': 2.8.6
     dev: false
 
+  /@volar-plugins/html@2.0.0-alpha.21:
+    resolution: {integrity: sha512-EDfgJ9l0P2lUMzWx86+GSwZs0KRZBl/BfMtUY5QRHzUes+wHJnv9iW6PgXwtNyWNj4T5zWvwQDIYDnNBdJU5cw==}
+    peerDependencies:
+      '@volar/language-service': '*'
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+    dependencies:
+      vscode-html-languageservice: 5.0.4
+      vscode-languageserver-protocol: 3.17.3
+      vscode-languageserver-textdocument: 1.0.8
+    dev: false
+
   /@volar-plugins/html@2.0.0-alpha.21(@volar/language-service@1.4.0-alpha.7):
     resolution: {integrity: sha512-EDfgJ9l0P2lUMzWx86+GSwZs0KRZBl/BfMtUY5QRHzUes+wHJnv9iW6PgXwtNyWNj4T5zWvwQDIYDnNBdJU5cw==}
     peerDependencies:
@@ -1217,6 +1233,22 @@ packages:
     dependencies:
       '@volar-plugins/html': 2.0.0-alpha.21(@volar/language-service@1.4.0-alpha.7)
       '@volar/language-service': 1.4.0-alpha.7
+      '@volar/source-map': 1.4.0-alpha.7
+      muggle-string: 0.2.2
+      pug-lexer: 5.0.1
+      pug-parser: 6.0.0
+      vscode-html-languageservice: 5.0.4
+      vscode-languageserver-textdocument: 1.0.8
+      vscode-languageserver-types: 3.17.3
+    dev: false
+
+  /@volar-plugins/pug@2.0.0-alpha.21(@volar/source-map@1.4.0-alpha.7):
+    resolution: {integrity: sha512-adO4PASOXyXFI06dAf0/IBsyzoTYkds1xajTiN25dLcVQwAzl00Mz+p4RGJO2rTiAN4cO9b4olqx4XaPotgQog==}
+    peerDependencies:
+      '@volar/language-service': '*'
+      '@volar/source-map': '*'
+    dependencies:
+      '@volar-plugins/html': 2.0.0-alpha.21
       '@volar/source-map': 1.4.0-alpha.7
       muggle-string: 0.2.2
       pug-lexer: 5.0.1


### PR DESCRIPTION
- in the next Lerna-Lite v2.0.0, I made `version` and `publish` as optional commands since it was requested by some users. So Lerna-Lite is now entirely modular and the user will need to manually install the command(s) he want to use (plus the CLI)
- I'm submitting this PR since your Lerna-Lite dependencies are set to `latest` and that will break your workflow, also note `version` is a strict dependency of `publish` which is why we can skip `version` install (we could also include it, it won't make a difference)
- see Lerna-Lite [v2.0.0-alpha.2](https://github.com/lerna-lite/lerna-lite/releases/tag/v2.0.0-alpha.2) release, I'm also expecting an official v2.0 release in a week or two