### PR TITLE
feat: add `vue-type-helpers` package

### DIFF
--- a/packages/vue-language-core/src/utils/localTypes.ts
+++ b/packages/vue-language-core/src/utils/localTypes.ts
@@ -86,7 +86,7 @@ export type EmitEvent<F, E> =
 export declare function asFunctionalComponent<T, K = T extends new (...args: any) => any ? InstanceType<T> : unknown>(t: T, instance?: K):
 	T extends (...args: any) => any ? T
 	: K extends { $props?: infer Props, $slots?: infer Slots, $emit?: infer Emit }
-		? (props: Props, ctx?: { attrs?: any, expose?: any, slots?: Slots, emit?: Emit }) => JSX.Element & { __ctx?: typeof ctx, __props?: typeof props }
+		? (props: Props, ctx?: { attrs?: any, expose?(exposed: K): void, slots?: Slots, emit?: Emit }) => JSX.Element & { __ctx?: typeof ctx, __props?: typeof props }
 		: (_: T, ctx?: any) => { __ctx?: { attrs?: undefined, expose?: undefined, slots?: undefined, emit?: undefined }, __props?: T }; // IntrinsicElement
 export declare function pickEvent<Emit, K, E>(emit: Emit, emitKey: K, event: E): FillingEventArg<
 	PickNotAny<

--- a/packages/vue-test-workspace/package.json
+++ b/packages/vue-test-workspace/package.json
@@ -4,6 +4,7 @@
 	"version": "1.3.12",
 	"license": "MIT",
 	"devDependencies": {
-		"vue": "3.3.0-alpha.6"
+		"vue": "3.3.0-alpha.6",
+		"vue-type-helpers": "1.3.12"
 	}
 }

--- a/packages/vue-test-workspace/vue-tsc/type-helpers/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/type-helpers/main.vue
@@ -1,0 +1,10 @@
+<script lang="ts">
+import type { ComponentProps, ComponentSlots, ComponentEmit, ComponentExposed } from 'vue-type-helpers';
+import { exactType } from '../shared';
+import ScriptSetup from '../components/script-setup.vue';
+
+exactType((new ScriptSetup()).$props, {} as ComponentProps<typeof ScriptSetup>);
+exactType((new ScriptSetup()).$emit, {} as ComponentEmit<typeof ScriptSetup>);
+exactType((new ScriptSetup()).$slots, {} as ComponentSlots<typeof ScriptSetup>);
+exactType((new ScriptSetup()), {} as ComponentExposed<typeof ScriptSetup>);
+</script>

--- a/packages/vue-type-helpers/LICENSE
+++ b/packages/vue-type-helpers/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vue-type-helpers/index.d.ts
+++ b/packages/vue-type-helpers/index.d.ts
@@ -1,0 +1,21 @@
+export type ComponentProps<T> = FunctionalComponentProps<FunctionalComponent<T>>;
+
+export type ComponentSlots<T> = FunctionalComponentSlots<FunctionalComponent<T>>;
+
+export type ComponentEmit<T> = FunctionalComponentEmit<FunctionalComponent<T>>;
+
+export type ComponentExposed<T> = FunctionalComponentExposed<FunctionalComponent<T>>;
+
+export type FunctionalComponentProps<T> = T extends (props: infer Props, ...args: any) => any ? Props : never;
+
+export type FunctionalComponentSlots<T> = T extends (props: any, ctx: { slots: infer Slots; }, ...args: any) => any ? NonNullable<Slots> : never;
+
+export type FunctionalComponentEmit<T> = T extends (props: any, ctx: { emit: infer Emit; }, ...args: any) => any ? NonNullable<Emit> : never;
+
+export type FunctionalComponentExposed<T> = T extends (props: any, ctx: { expose(exposed: infer Exposed): void; }, ...args: any) => any ? Exposed : never;
+
+export type FunctionalComponent<T, K = T extends new (...args: any) => any ? InstanceType<T> : unknown> =
+	T extends (...args: any) => any ? T
+	: K extends { $props: infer Props, $slots: infer Slots, $emit: infer Emit; }
+	? (props: Props, ctx?: { attrs?: any, expose?(exposed: K): void, slots?: Slots, emit?: Emit; }) => { __ctx?: typeof ctx, __props?: typeof props; }
+	: never;

--- a/packages/vue-type-helpers/package.json
+++ b/packages/vue-type-helpers/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "vue-type-helpers",
+	"version": "1.3.12",
+	"license": "MIT",
+	"files": [
+		"*.d.ts"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/vuejs/language-tools.git",
+		"directory": "packages/vue-type-helpers"
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       vue:
         specifier: 3.3.0-alpha.6
         version: 3.3.0-alpha.6
+      vue-type-helpers:
+        specifier: 1.3.12
+        version: link:../vue-type-helpers
 
   packages/vue-tsc:
     dependencies:
@@ -270,6 +273,8 @@ importers:
       vue-tsc:
         specifier: 1.3.12
         version: link:../vue-tsc
+
+  packages/vue-type-helpers: {}
 
   packages/vue-typescript:
     dependencies:


### PR DESCRIPTION
Added `vue-type-helpers` to expose type helpers that can use for component dts built by vue-tsc.

- ComponentProps
- ComponentEmit
- ComponentSlots
- ComponentExposed