### PR TITLE
feat: Bun-based language server (DEV only)

### DIFF
--- a/packages/vscode-vue/client.js
+++ b/packages/vscode-vue/client.js
@@ -1,3 +1,5 @@
-let modulePath = './dist/client';
-try { modulePath = require.resolve('./out/nodeClientMain'); } catch { }
-module.exports = require(modulePath);
+try {
+	module.exports = require('./out/nodeClientMain');
+} catch { }
+
+module.exports = require('./dist/client');

--- a/packages/vscode-vue/server.js
+++ b/packages/vscode-vue/server.js
@@ -1,3 +1,5 @@
-let modulePath = './dist/server';
-try { modulePath = require.resolve('@volar/vue-language-server/bin/vue-language-server'); } catch { }
-module.exports = require(modulePath);
+try {
+	module.exports = require('@volar/vue-language-server/bin/vue-language-server');
+} catch { }
+
+module.exports = require('./dist/server');

--- a/packages/vscode-vue/src/nodeClientMain.ts
+++ b/packages/vscode-vue/src/nodeClientMain.ts
@@ -49,7 +49,7 @@ export function activate(context: vscode.ExtensionContext) {
 			runOptions.execArgv.push("--max-old-space-size=" + maxOldSpaceSize);
 		}
 		const debugOptions: lsp.ForkOptions = { execArgv: ['--nolazy', '--inspect=' + port] };
-		const serverOptions: lsp.ServerOptions = {
+		let serverOptions: lsp.ServerOptions = {
 			run: {
 				module: serverModule.fsPath,
 				transport: lsp.TransportKind.ipc,
@@ -61,6 +61,29 @@ export function activate(context: vscode.ExtensionContext) {
 				options: debugOptions
 			},
 		};
+		const bunPath: string | undefined = undefined; // path to .bun/bin/bun
+		if (bunPath) {
+			serverOptions = {
+				run: {
+					transport: {
+						kind: lsp.TransportKind.socket,
+						port: port + 10,
+					},
+					options: runOptions,
+					command: bunPath,
+					args: ['run', serverModule.fsPath],
+				},
+				debug: {
+					transport: {
+						kind: lsp.TransportKind.socket,
+						port: port + 10,
+					},
+					options: debugOptions,
+					command: bunPath,
+					args: ['run', serverModule.fsPath],
+				},
+			};
+		}
 		const clientOptions: lsp.LanguageClientOptions = {
 			middleware,
 			documentSelector: langs.map<lsp.DocumentFilter>(lang => ({ language: lang })),


### PR DESCRIPTION
Supported Bun language server.

This PR is not user-oriented, because after testing, the performance of node executing TS LanguageService is 1.65 times faster than that of bun. The possible reason is that the TS team has been optimizing the performance of code running on node based on benchmarks. We're not going to switch to buns for now anyway until buns fix this in the future.

If you want to try it, please clone https://github.com/volarjs/workspace to use the latest commit of volar core, and hardcode to set bunPath: https://github.com/vuejs/language-tools/blob/2c36449d4c1095fd886df0be56a90aef4e1f50d7/packages/vscode-vue/src/nodeClientMain.ts#L64