### PR TITLE
refactor: rename workspace configs

### DIFF
--- a/packages/vscode-vue/package.json
+++ b/packages/vscode-vue/package.json
@@ -389,11 +389,6 @@
 					"default": false,
 					"description": "Reverse priority for tsconfig pickup."
 				},
-				"volar.vueserver.disableFileWatcher": {
-					"type": "boolean",
-					"default": false,
-					"description": "Disable file watcher in language server for better performance."
-				},
 				"volar.vueserver.additionalExtensions": {
 					"type": "array",
 					"items": {
@@ -407,20 +402,10 @@
 					"default": false,
 					"description": "Enable this option if you want to get complete CompletionList in language client. (Disable for better performance)"
 				},
-				"volar.codeLens.references": {
+				"volar.vueserver.fileWatchers": {
 					"type": "boolean",
 					"default": true,
-					"description": "[references] code lens."
-				},
-				"volar.inlayHints.missingRequiredProps": {
-					"type": "boolean",
-					"default": false,
-					"description": "Show inlay hints for missing required props."
-				},
-				"volar.inlayHints.eventArgumentInInlineHandlers": {
-					"type": "boolean",
-					"default": false,
-					"description": "Show inlay hints for event argument in inline handlers."
+					"description": "Enable file watcher in language server."
 				},
 				"volar.icon.splitEditors": {
 					"type": "boolean",
@@ -431,21 +416,6 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Show known problems in status bar."
-				},
-				"volar.autoWrapParentheses": {
-					"type": "boolean",
-					"default": true,
-					"description": "Auto-wrap `()` to As Expression in interpolations for fix issue #520."
-				},
-				"volar.autoCompleteRefs": {
-					"type": "boolean",
-					"default": false,
-					"description": "Auto-complete Ref value with `.value`."
-				},
-				"volar.addSpaceBetweenDoubleCurlyBrackets": {
-					"type": "boolean",
-					"default": true,
-					"description": "Auto add space between double curly brackets: {{|}} -> {{ | }}"
 				},
 				"volar.format.initialIndent": {
 					"type": "object",
@@ -513,45 +483,6 @@
 					"default": "Vue.volar",
 					"description": "The extension that take over language support for *.ts."
 				},
-				"volar.completion.preferredTagNameCase": {
-					"type": "string",
-					"enum": [
-						"auto-kebab",
-						"auto-pascal",
-						"kebab",
-						"pascal"
-					],
-					"enumDescriptions": [
-						"Auto Detect from Content (Preferred <kebab-case>)",
-						"Auto Detect from Content (Preferred <PascalCase>)",
-						"<kebab-case>",
-						"<PascalCase>"
-					],
-					"default": "auto-pascal",
-					"description": "Preferred tag name case."
-				},
-				"volar.completion.preferredAttrNameCase": {
-					"type": "string",
-					"enum": [
-						"auto-kebab",
-						"auto-camel",
-						"kebab",
-						"camel"
-					],
-					"enumDescriptions": [
-						"Auto Detect from Content (Preferred :kebab-case=\"...\")",
-						"Auto Detect from Content (Preferred :camelCase=\"...\")",
-						":kebab-case=\"...\"",
-						":camelCase=\"...\""
-					],
-					"default": "auto-kebab",
-					"description": "Preferred attr name case."
-				},
-				"volar.completion.normalizeComponentImportName": {
-					"type": "boolean",
-					"default": true,
-					"description": "Normalize import name for auto import. (\"myCompVue\" -> \"MyComp\")"
-				},
 				"volar.splitEditors.layout.left": {
 					"type": "array",
 					"default": [
@@ -567,15 +498,84 @@
 						"customBlocks"
 					]
 				},
-				"volar.updateImportsOnFileMove.enabled": {
+				"volar.features.updateImportsOnFileMove.enable": {
 					"type": "boolean",
-					"default": true,
+					"default": false,
 					"description": "Enabled update imports on file move."
 				},
-				"volar.diagnostics.delay": {
-					"type": "number",
-					"default": 200,
-					"description": "Delay time for diagnostics."
+				"volar.features.codeActions.enable": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enabled code actions."
+				},
+				"volar.features.codeLens": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enabled code lens."
+				},
+				"volar.features.complete.tagNameCasing": {
+					"type": "string",
+					"enum": [
+						"autoKebab",
+						"autoPascal",
+						"kebab",
+						"pascal"
+					],
+					"enumDescriptions": [
+						"Auto Detect from Content (Fallback to <kebab-case> if detect failed)",
+						"Auto Detect from Content  (Fallback to <PascalCase> if detect failed)",
+						"<kebab-case>",
+						"<PascalCase>"
+					],
+					"default": "autoPascal",
+					"description": "Preferred tag name case."
+				},
+				"volar.features.complete.propNameCasing": {
+					"type": "string",
+					"enum": [
+						"autoKebab",
+						"autoCamel",
+						"kebab",
+						"camel"
+					],
+					"enumDescriptions": [
+						"Auto Detect from Content (Fallback to :kebab-case=\"...\" if detect failed)",
+						"Auto Detect from Content (Fallback to :camelCase=\"...\" if detect failed)",
+						":kebab-case=\"...\"",
+						":camelCase=\"...\""
+					],
+					"default": "autoKebab",
+					"description": "Preferred attr name case."
+				},
+				"volar.features.complete.normalizeComponentImportName": {
+					"type": "boolean",
+					"default": true,
+					"description": "Normalize import name for auto import. (\"myCompVue\" -> \"MyComp\")"
+				},
+				"volar.features.autoInsert.parentheses": {
+					"type": "boolean",
+					"default": true,
+					"description": "Auto-wrap `()` to As Expression in interpolations for fix issue #520."
+				},
+				"volar.features.autoInsert.dotValue": {
+					"type": "boolean",
+					"default": false,
+					"description": "Auto-complete Ref value with `.value`."
+				},
+				"volar.features.autoInsert.bracketSpacing": {
+					"type": "boolean",
+					"default": true,
+					"description": "Auto add space between double curly brackets: {{|}} -> {{ | }}"
+				},
+				"volar.features.inlayHints.missingProps": {
+					"type": "boolean",
+					"default": false,
+					"description": "Show inlay hints for missing required props."
+				},
+				"volar.features.inlayHints.inlineHandlerLeading": {
+					"type": "boolean",
+					"default": false,
+					"description": "Show inlay hints for event argument in inline handlers."
 				}
 			}
 		},

--- a/packages/vscode-vue/src/config.ts
+++ b/packages/vscode-vue/src/config.ts
@@ -1,0 +1,82 @@
+import * as vscode from 'vscode';
+
+const _configs = vscode.workspace.getConfiguration('volar');
+
+export const config = {
+	splitEditors: {
+		get layout() {
+			return _configs.get<{ left: string[], right: string[]; }>('splitEditors.layout') ?? { left: [], right: [] };
+		}
+	},
+	features: {
+		updateImportsOnFileMove: {
+			get enable() {
+				return _configs.get<boolean>('features.updateImportsOnFileMove.enable');
+			},
+		},
+		codeActions: {
+			get enable() {
+				return _configs.get<boolean>('features.codeActions.enable');
+			},
+		},
+		codeLens: {
+			get enable() {
+				return _configs.get<boolean>('features.codeLens.enable');
+			},
+		},
+		complete: {
+			get attrNameCasing() {
+				return _configs.get<'autoKebab' | 'autoCamel' | 'kebab' | 'camel'>('features.complete.propNameCasing');
+			},
+			get tagNameCasing() {
+				return _configs.get<'autoKebab' | 'autoPascal' | 'kebab' | 'pascal'>('features.complete.tagNameCasing');
+			},
+		},
+	},
+	json: {
+		get customBlockSchemaUrls() {
+			return _configs.get<Record<string, string>>('json.customBlockSchemaUrls');
+		}
+	},
+	vueserver: {
+		get maxOldSpaceSize() {
+			return _configs.get<number>('vueserver.maxOldSpaceSize');
+		},
+		get maxFileSize() {
+			return _configs.get<number>('vueserver.maxFileSize');
+		},
+		get reverseConfigFilePriority() {
+			return _configs.get<boolean>('vueserver.reverseConfigFilePriority');
+		},
+		get diagnosticModel() {
+			return _configs.get<'push' | 'pull'>('vueserver.diagnosticModel');
+		},
+		get additionalExtensions() {
+			return _configs.get<string[]>('vueserver.additionalExtensions') ?? [];
+		},
+		get fullCompletionList() {
+			return _configs.get<boolean>('vueserver.fullCompletionList');
+		},
+		get configFilePath() {
+			return _configs.get<string>('vueserver.configFilePath');
+		},
+		get fileWatches() {
+			return _configs.get<boolean>('volar.vueserver.fileWatchers');
+		},
+		petiteVue: {
+			get processHtmlFile() {
+				return _configs.get<boolean>('vueserver.petiteVue.processHtmlFile');
+			},
+		},
+		vitePress: {
+			get processMdFile() {
+				return _configs.get<boolean>('vueserver.vitePress.processMdFile');
+			},
+		},
+	},
+	doctor: {
+		get status() {
+			return _configs.get<boolean>('doctor.status');
+		}
+	}
+};

--- a/packages/vscode-vue/src/features/doctor.ts
+++ b/packages/vscode-vue/src/features/doctor.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as semver from 'semver';
 import { BaseLanguageClient } from 'vscode-languageclient';
 import { ParseSFCRequest } from '@volar/vue-language-server';
+import { config } from '../config';
 
 const scheme = 'vue-doctor';
 const knownValidSyntaxHighlightExtensions = {
@@ -64,7 +65,7 @@ export async function register(context: vscode.ExtensionContext, client: BaseLan
 
 	async function updateStatusBar(editor: vscode.TextEditor | undefined) {
 		if (
-			vscode.workspace.getConfiguration('volar').get<boolean>('doctor.status')
+			config.doctor.status
 			&& editor
 			&& (editor.document.languageId === 'vue' || editor.document.uri.toString().endsWith('.vue'))
 			&& editor.document.uri.scheme === 'file'

--- a/packages/vscode-vue/src/features/nameCasing.ts
+++ b/packages/vscode-vue/src/features/nameCasing.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { quickPick } from '@volar/vscode/out/common';
 import { BaseLanguageClient, State } from 'vscode-languageclient';
 import { AttrNameCasing, TagNameCasing, DetectNameCasingRequest, GetConvertAttrCasingEditsRequest, GetConvertTagCasingEditsRequest } from '@volar/vue-language-server';
-import { processHtml, processMd } from '../common';
+import { config } from '../config';
 
 export const attrNameCasings = new Map<string, AttrNameCasing>();
 export const tagNameCasings = new Map<string, TagNameCasing>();
@@ -135,15 +135,15 @@ export async function activate(_context: vscode.ExtensionContext, client: BaseLa
 	async function update(document: vscode.TextDocument | undefined) {
 		if (
 			document?.languageId === 'vue'
-			|| (processMd() && document?.languageId === 'markdown')
-			|| (processHtml() && document?.languageId === 'html')
+			|| (config.vueserver.vitePress.processMdFile && document?.languageId === 'markdown')
+			|| (config.vueserver.petiteVue.processHtmlFile && document?.languageId === 'html')
 		) {
 			let detected: Awaited<ReturnType<typeof detect>> | undefined;
 			let attrNameCasing = attrNameCasings.get(document.uri.toString());
 			let tagNameCasing = tagNameCasings.get(document.uri.toString());
 
 			if (!attrNameCasing) {
-				const attrNameCasingSetting = vscode.workspace.getConfiguration('volar').get<'auto-kebab' | 'auto-camel' | 'kebab' | 'camel'>('completion.preferredAttrNameCase');
+				const attrNameCasingSetting = config.features.complete.attrNameCasing;
 				if (attrNameCasingSetting === 'kebab') {
 					attrNameCasing = AttrNameCasing.Kebab;
 				}
@@ -166,7 +166,7 @@ export async function activate(_context: vscode.ExtensionContext, client: BaseLa
 			}
 
 			if (!tagNameCasing) {
-				const tagMode = vscode.workspace.getConfiguration('volar').get<'auto-kebab' | 'auto-pascal' | 'kebab' | 'pascal'>('completion.preferredTagNameCase');
+				const tagMode = config.features.complete.tagNameCasing;
 				if (tagMode === 'kebab') {
 					tagNameCasing = TagNameCasing.Kebab;
 				}

--- a/packages/vscode-vue/src/features/splitEditors.ts
+++ b/packages/vscode-vue/src/features/splitEditors.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { BaseLanguageClient } from 'vscode-languageclient';
 import { ParseSFCRequest } from '@volar/vue-language-server';
+import { config } from '../config';
 
 type SFCBlock = ParseSFCRequest.ResponseType['descriptor']['customBlocks'][number];
 
@@ -15,8 +16,7 @@ export function register(context: vscode.ExtensionContext, client: BaseLanguageC
 		const editor = vscode.window.activeTextEditor;
 		if (!editor) return;
 
-		const layout = await vscode.workspace.getConfiguration('volar').get<{ left: string[], right: string[]; }>('splitEditors.layout') ?? { left: [], right: [] };
-
+		const layout = config.splitEditors.layout;
 		const doc = editor.document;
 		const { descriptor } = await getDocDescriptor(doc.getText());
 		let leftBlocks: SFCBlock[] = [];

--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -124,7 +124,7 @@ function resolvePlugins(
 						&& _context.typescript
 						&& item.textEdit?.newText.endsWith(suffix)
 						&& item.additionalTextEdits?.length === 1 && item.additionalTextEdits[0].newText.indexOf('import ' + item.textEdit.newText + ' from ') >= 0
-						&& (await _context.configurationHost?.getConfiguration<boolean>('volar.completion.normalizeComponentImportName') ?? true)
+						&& (await _context.configurationHost?.getConfiguration<boolean>('volar.features.complete.normalizeComponentImportName') ?? true)
 					) {
 						let newName = item.textEdit.newText.slice(0, -suffix.length);
 						newName = newName[0].toUpperCase() + newName.substring(1);

--- a/packages/vue-language-service/src/plugins/vue-autoinsert-dotvalue.ts
+++ b/packages/vue-language-service/src/plugins/vue-autoinsert-dotvalue.ts
@@ -21,7 +21,7 @@ const plugin: LanguageServicePlugin = (context) => {
 			if (!isCharacterTyping(document, insertContext))
 				return;
 
-			const enabled = await context.configurationHost?.getConfiguration<boolean>('volar.autoCompleteRefs') ?? true;
+			const enabled = await context.configurationHost?.getConfiguration<boolean>('volar.features.autoInsert.dotValue') ?? true;
 			if (!enabled)
 				return;
 

--- a/packages/vue-language-service/src/plugins/vue-autoinsert-parentheses.ts
+++ b/packages/vue-language-service/src/plugins/vue-autoinsert-parentheses.ts
@@ -17,7 +17,7 @@ const plugin: LanguageServicePlugin = (context) => {
 
 		async provideAutoInsertionEdit(document, position, options_2) {
 
-			const enabled = await context.configurationHost?.getConfiguration<boolean>('volar.autoWrapParentheses') ?? false;
+			const enabled = await context.configurationHost?.getConfiguration<boolean>('volar.features.autoInsert.parentheses') ?? false;
 			if (!enabled)
 				return;
 

--- a/packages/vue-language-service/src/plugins/vue-autoinsert-space.ts
+++ b/packages/vue-language-service/src/plugins/vue-autoinsert-space.ts
@@ -11,7 +11,7 @@ const plugin: LanguageServicePlugin = (context): LanguageServicePluginInstance =
 
 			if (document.languageId === 'html' || document.languageId === 'jade') {
 
-				const enabled = await context.configurationHost?.getConfiguration<boolean>('volar.addSpaceBetweenDoubleCurlyBrackets') ?? true;
+				const enabled = await context.configurationHost?.getConfiguration<boolean>('volar.features.autoInsert.bracketSpacing') ?? true;
 				if (!enabled)
 					return;
 

--- a/packages/vue-language-service/src/plugins/vue-template.ts
+++ b/packages/vue-language-service/src/plugins/vue-template.ts
@@ -106,7 +106,7 @@ export default function useVueTemplateLanguagePlugin<T extends ReturnType<typeof
 				if (!options.isSupportedDocument(document))
 					return;
 
-				const enabled = await _context.configurationHost?.getConfiguration<boolean>('volar.inlayHints.missingRequiredProps') ?? true;
+				const enabled = await _context.configurationHost?.getConfiguration<boolean>('volar.features.inlayHints.missingProps') ?? false;
 				if (!enabled)
 					return;
 

--- a/packages/vue-language-service/src/plugins/vue-visualize-hidden-callback-param.ts
+++ b/packages/vue-language-service/src/plugins/vue-visualize-hidden-callback-param.ts
@@ -10,7 +10,7 @@ const plugin: LanguageServicePlugin = (context) => {
 
 		async provideInlayHints(document, range) {
 
-			const enabled = await context.configurationHost?.getConfiguration<boolean>('volar.inlayHints.eventArgumentInInlineHandlers') ?? true;
+			const enabled = await context.configurationHost?.getConfiguration<boolean>('volar.features.inlayHints.inlineHandlerLeading') ?? false;
 			if (!enabled)
 				return;
 


### PR DESCRIPTION
Rename and change the default values of some configs.

For the principle of not disturbing users as much as possible, missing props hint and event argument hint are now disabled by default.

`updateImportsOnFileMove` is now disabled by default, taking into account that based on past experience, it is not useful in vue projects for all users and sometimes degrades UX instead.

Added `codeActions.enable` setting and disabled by default as we've been getting many complaints from the past on github/marketplace/twitter/discord...that Volar is slow to save when used with ESLint, even though it's not an issue with Volar itself . Some versions of VSCode will have problems, some versions will not, this problem seems to be periodic, even if VSCode fixes the problem again in recent versions, it is difficult to guarantee that it will not happen again in future versions. We don't have the energy to explain to every user that the problem is not from Volar, disabling it by default and giving users the option to enable it at their own risk is a decision of frustration.

close #2598, close #2615

| old name                                       | new name                                           | old default | new default |   |
|------------------------------------------------|----------------------------------------------------|-------------|-------------|---|
| volar.vueserver.disableFileWatcher             | volar.vueserver.fileWatchers                       | false       | true        |   |
| volar.codeLens.references                      | vue.features.codeLens.enable                       | --          | --          |   |
| volar.inlayHints.missingRequiredProps          | vue.features.inlayHints.missingProps               | true        | false       |   |
| volar.inlayHints.eventArgumentInInlineHandlers | vue.features.inlayHints.inlineHandlerLeading       | true        | false       |   |
| volar.autoWrapParentheses                      | vue.features.autoInsert.parentheses                | --          | --          |   |
| volar.autoCompleteRefs                         | vue.features.autoInsert.dotValue                   | --          | --          |   |
| volar.addSpaceBetweenDoubleCurlyBrackets       | vue.features.autoInsert.bracketSpacing             |             |             |   |
| volar.completion.preferredTagNameCase          | vue.features.complete.tagNameCasing                | auto-pascal | autoPascal  |   |
| volar.completion.preferredAttrNameCase         | vue.features.complete.propNameCasing               | auto-kebab  | autoKebab   |   |
| volar.completion.normalizeComponentImportName  | vue.features.complete.normalizeComponentImportName | --          | --          |   |
| volar.diagnostics.delay                        | --                                                 | 200         | 250         |   |
| volar.updateImportsOnFileMove.enabled          | vue.features.updateImportsOnFileMove.enable        | true        | false       |   |
| --                                             | vue.features.codeActions.enable                    | true        | false       |   |