### PR TITLE
fix(vue-typescript): add missing peer dependency `typescript`

### DIFF
--- a/packages/vue-typescript/package.json
+++ b/packages/vue-typescript/package.json
@@ -15,5 +15,8 @@
 	"dependencies": {
 		"@volar/typescript": "1.4.0",
 		"@volar/vue-language-core": "1.4.2"
+	},
+	"peerDependencies": {
+		"typescript": "*"
 	}
 }


### PR DESCRIPTION
`@volar/vue-typescript` depends on `@volar/typescript` which has a peer dependency on `typescript` that it isn't providing.
This PR fixes that by declaring `typescript` as a peer dependency of `@volar/vue-typescript`