### PR TITLE
refactor: deprecate `jsxTemplates`

### DIFF
--- a/packages/vue-language-core/schemas/vue-tsconfig.deprecated.schema.json
+++ b/packages/vue-language-core/schemas/vue-tsconfig.deprecated.schema.json
@@ -59,6 +59,9 @@
 				},
 				"narrowingTypesInInlineHandlers": {
 					"deprecated": true
+				},
+				"jsxTemplates": {
+					"deprecated": true
 				}
 			}
 		}

--- a/packages/vue-language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/vue-language-core/schemas/vue-tsconfig.schema.json
@@ -19,11 +19,6 @@
 					"default": [ ".vue" ],
 					"markdownDescription": "Valid file extensions that should be considered as regular Vue SFC, please note that you should not use this option separately for additional file extensions IDE support, see https://github.com/johnsoncodehk/volar/tree/master/packages/vscode-vue/README.md#custom-file-extensions."
 				},
-				"jsxTemplates": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "Whether to compile template to JSX. (Generics component type checking only working with JSX)"
-				},
 				"strictTemplates": {
 					"type": "boolean",
 					"default": false,

--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -80,12 +80,7 @@ export function generate(
 		PropsChildren: false,
 	};
 
-	if (vueCompilerOptions.jsxTemplates && vueCompilerOptions.target >= 3.3) {
-		codes.push(`/** @jsxImportSource vue */\n`);
-	}
-	else {
-		codes.push('/** __vue_virtual_code_placeholder */\n');
-	}
+	codes.push('/** __vue_virtual_code_placeholder */\n');
 
 	let generatedTemplate = false;
 

--- a/packages/vue-language-core/src/plugins/vue-tsx.ts
+++ b/packages/vue-language-core/src/plugins/vue-tsx.ts
@@ -105,19 +105,10 @@ const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOption
 	function createTsx(fileName: string, _sfc: Sfc) {
 
 		const lang = computed(() => {
-			let lang = !_sfc.script && !_sfc.scriptSetup ? 'ts'
+			return !_sfc.script && !_sfc.scriptSetup ? 'ts'
 				: _sfc.scriptSetup && _sfc.scriptSetup.lang !== 'js' ? _sfc.scriptSetup.lang
 					: _sfc.script && _sfc.script.lang !== 'js' ? _sfc.script.lang
 						: 'js';
-			if (vueCompilerOptions.jsxTemplates) {
-				if (lang === 'js') {
-					lang = 'jsx';
-				}
-				else if (lang === 'ts') {
-					lang = 'tsx';
-				}
-			}
-			return lang;
 		});
 		const cssVars = computed(() => collectCssVars(_sfc));
 		const scriptRanges = computed(() =>

--- a/packages/vue-language-core/src/types.ts
+++ b/packages/vue-language-core/src/types.ts
@@ -19,7 +19,6 @@ export type RawVueCompilerOptions = Partial<Omit<VueCompilerOptions, 'target' | 
 export interface VueCompilerOptions {
 	target: number;
 	extensions: string[];
-	jsxTemplates: boolean;
 	strictTemplates: boolean;
 	skipTemplateCodegen: boolean;
 	nativeTags: string[];

--- a/packages/vue-language-core/src/utils/ts.ts
+++ b/packages/vue-language-core/src/utils/ts.ts
@@ -201,7 +201,6 @@ export function resolveVueCompilerOptions(vueOptions: Partial<VueCompilerOptions
 		...vueOptions,
 		target,
 		extensions: vueOptions.extensions ?? ['.vue'],
-		jsxTemplates: vueOptions.jsxTemplates ?? false,
 		strictTemplates: vueOptions.strictTemplates ?? false,
 		skipTemplateCodegen: vueOptions.skipTemplateCodegen ?? false,
 		nativeTags: vueOptions.nativeTags ?? [...new Set([


### PR DESCRIPTION
In the past, we generated jsx format virtual code for templates based on the jsxTemplates option to obtain complete generic support, but with 1.4 substantially refactoring virtual code generation, we found a way to support generics for class components and functional components at the same time without relying on jsx , if you are interested in the principle, here is the playground link.

https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEYD2A7AzgF3gMQK4rAwEtUoIBhJAWwAdUQUMAueAHgBUA+AChpiRpoWAb3gA3MrhAt2AGnGSQQ+OwDaAXXgBfAJTwAvJ3hQUATwDcAKEuhIsBMnRZy0NGkq16jFihAB3Ni5efkERBQgpGXkJCKUZDW09Q3hRABI+AWUMUxoQJAAzeAzBbSsbcGg4eHz8QhIUYzQ8AmJSCmo6X0YOeQBpHmYVeQBrFl6dJksASHZ4EAAPDAZgNHhfAO4AOm3YAHNlE1Mko0P4AH5pqd65xeXVtOK0M5YiFHyQGHgABRC0LUupmd4MFMiwfpljsYzACfCAxB9pjIbksUCtgdtNnsDmZIacgexEWs4QjLAB6ABU5Ms8HJbGadTaHk6DCwMSk+gARJgYBz4Ew2UpOQBGXmkzjU8mk6yOTCIDpCgyNemtFBkJleDDcZX1NUdDXydY4Woq3WeLqa0QClgAcm51uiimUCt0OjKyFoQu4lsUNrtDtiTsS8FJpPguDQCGyuTAAAtwMN4HA0LgIFgMDGiKsIK8QNYKVSaWwXFA3OrzeF2VyMDy+QK0MLReKaVLLDKsO6aAAmRUl7WMvXm7jF0sDlkG-zwYfuUeML0V6TwW3V+3zwMut0dTtzq2Lv2rljOvQhsMR+BR8BxsAJpMptMZrM5yxAA

---

Why is this important?

- Currently template codegen is too complicated, it makes sense to simplify it in any way to improve maintainability, and removing jsxTemplates can reduce a lot of codegen code.
- This makes #592 problem become history, we don't have this mess anymore
- This eliminates inconsistencies such as #2671

Note that this is not a breaking change, users should not be aware of this change, but just remove the jsxTemplates option from tsconfig as it is no longer needed.

Target version: >= v1.5.0 pre-release