### PR TITLE
feat: expose custom blocks attrs

### DIFF
--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -51,6 +51,7 @@ export function generate(
 			endTagStart: 0,
 			generic: undefined,
 			genericOffset: 0,
+			attrs: {},
 		};
 		scriptSetupRanges = {
 			bindings: [],

--- a/packages/vue-language-core/src/sourceFile.ts
+++ b/packages/vue-language-core/src/sourceFile.ts
@@ -569,6 +569,7 @@ export class VueFile implements VirtualFile {
 				content: block.content,
 				lang: block.lang ?? 'txt',
 				type: block.type,
+				attrs: block.attrs,
 			};
 
 			if (this.sfc.customBlocks.length > i) {

--- a/packages/vue-language-core/src/sourceFile.ts
+++ b/packages/vue-language-core/src/sourceFile.ts
@@ -584,9 +584,19 @@ export class VueFile implements VirtualFile {
 		}
 	}
 
-	updateBlock<T>(oldBlock: T, newBlock: T) {
-		for (let key in newBlock) {
-			oldBlock[key] = newBlock[key];
+	updateBlock<T extends object>(oldBlock: T, newBlock: T) {
+		for (const key in newBlock) {
+			if (typeof oldBlock[key] === 'object' && typeof newBlock[key] === 'object') {
+				this.updateBlock(oldBlock[key] as object, newBlock[key] as object);
+			}
+			else {
+				oldBlock[key] = newBlock[key];
+			}
+		}
+		for (const key in oldBlock) {
+			if (!(key in newBlock)) {
+				delete oldBlock[key];
+			}
 		}
 	}
 }

--- a/packages/vue-language-core/src/sourceFile.ts
+++ b/packages/vue-language-core/src/sourceFile.ts
@@ -474,6 +474,7 @@ export class VueFile implements VirtualFile {
 			endTagStart: block.loc.end.offset,
 			content: block.content,
 			lang: block.lang ?? 'html',
+			attrs: block.attrs,
 		} : null;
 
 		if (this.sfc.template && newData) {
@@ -496,6 +497,7 @@ export class VueFile implements VirtualFile {
 			lang: block.lang ?? 'js',
 			src: block.src,
 			srcOffset: block.src ? this.snapshot.getText(0, block.loc.start.offset).lastIndexOf(block.src) - block.loc.start.offset : -1,
+			attrs: block.attrs,
 		} : null;
 
 		if (this.sfc.script && newData) {
@@ -518,6 +520,7 @@ export class VueFile implements VirtualFile {
 			lang: block.lang ?? 'js',
 			generic: typeof block.attrs.generic === 'string' ? block.attrs.generic : undefined,
 			genericOffset: typeof block.attrs.generic === 'string' ? this.snapshot.getText(0, block.loc.start.offset).lastIndexOf(block.attrs.generic) - block.loc.start.offset : -1,
+			attrs: block.attrs,
 		} : null;
 
 		if (this.sfc.scriptSetup && newData) {
@@ -542,6 +545,7 @@ export class VueFile implements VirtualFile {
 				lang: block.lang ?? 'css',
 				module: typeof block.module === 'string' ? block.module : block.module ? '$style' : undefined,
 				scoped: !!block.scoped,
+				attrs: block.attrs,
 			};
 
 			if (this.sfc.styles.length > i) {

--- a/packages/vue-language-core/src/types.ts
+++ b/packages/vue-language-core/src/types.ts
@@ -72,6 +72,7 @@ export interface SfcBlock {
 	endTagStart: number;
 	lang: string;
 	content: string;
+	attrs: Record<string, string | true>;
 }
 
 export interface Sfc {
@@ -91,7 +92,6 @@ export interface Sfc {
 	})[];
 	customBlocks: (SfcBlock & {
 		type: string;
-		attrs: Record<string, string | true>;
 	})[];
 
 	// ast

--- a/packages/vue-language-core/src/types.ts
+++ b/packages/vue-language-core/src/types.ts
@@ -91,6 +91,7 @@ export interface Sfc {
 	})[];
 	customBlocks: (SfcBlock & {
 		type: string;
+		attrs: Record<string, string | true>;
 	})[];
 
 	// ast


### PR DESCRIPTION
Adds `attrs` property to `Sfc.customBlocks` to enable accessing custom block attrs through the Plugins API