### PR TITLE
refactor: Renaming packages from `@volar/vue-*` to `@vue/*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ flowchart LR
 	%% Volar - Packages
 	VOLAR_VUE_SERVER["@vue/language-server"]
 	VOLAR_VUE_TS["@volar/vue-typescript"]
-	VOLAR_VUE_CORE["@volar/vue-language-core"]
+	VOLAR_VUE_CORE["@vue/language-core"]
 	VOLAR_VUE_SERVICE["@vue/language-service"]
 	VOLAR_PUG_SERVICE["@volar/pug-language-service"]
 	VOLAR_TS_SERVICE["@volar/typescript-language-service"]

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ flowchart LR
 	VOLAR_VUE_SERVER["@vue/language-server"]
 	VOLAR_VUE_TS["@volar/vue-typescript"]
 	VOLAR_VUE_CORE["@volar/vue-language-core"]
-	VOLAR_VUE_SERVICE["@volar/vue-language-service"]
+	VOLAR_VUE_SERVICE["@vue/language-service"]
 	VOLAR_PUG_SERVICE["@volar/pug-language-service"]
 	VOLAR_TS_SERVICE["@volar/typescript-language-service"]
 	VUE_TSC[vue-tsc]

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ flowchart LR
 
 	%% Volar - Packages
 	VOLAR_VUE_SERVER["@vue/language-server"]
-	VOLAR_VUE_TS["@volar/vue-typescript"]
+	VOLAR_VUE_TS["@vue/typescript"]
 	VOLAR_VUE_CORE["@vue/language-core"]
 	VOLAR_VUE_SERVICE["@vue/language-service"]
 	VOLAR_PUG_SERVICE["@volar/pug-language-service"]

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ flowchart LR
 	click VSC_TSVP "https://github.com/vuejs/language-tools/tree/master/packages/vscode-typescript-vue-plugin"
 
 	%% Volar - Packages
-	VOLAR_VUE_SERVER["@volar/vue-language-server"]
+	VOLAR_VUE_SERVER["@vue/language-server"]
 	VOLAR_VUE_TS["@volar/vue-typescript"]
 	VOLAR_VUE_CORE["@volar/vue-language-core"]
 	VOLAR_VUE_SERVICE["@volar/vue-language-service"]

--- a/packages/typescript-vue-plugin/package.json
+++ b/packages/typescript-vue-plugin/package.json
@@ -14,6 +14,6 @@
 	},
 	"dependencies": {
 		"@vue/language-core": "1.6.4",
-		"@volar/vue-typescript": "1.6.4"
+		"@vue/typescript": "1.6.4"
 	}
 }

--- a/packages/typescript-vue-plugin/package.json
+++ b/packages/typescript-vue-plugin/package.json
@@ -13,7 +13,7 @@
 		"directory": "packages/typescript-vue-plugin"
 	},
 	"dependencies": {
-		"@volar/vue-language-core": "1.6.4",
+		"@vue/language-core": "1.6.4",
 		"@volar/vue-typescript": "1.6.4"
 	}
 }

--- a/packages/typescript-vue-plugin/src/index.ts
+++ b/packages/typescript-vue-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import * as vue from '@vue/language-core';
-import * as vueTs from '@volar/vue-typescript';
+import * as vueTs from '@vue/typescript';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 
 const init: ts.server.PluginModuleFactory = (modules) => {

--- a/packages/typescript-vue-plugin/src/index.ts
+++ b/packages/typescript-vue-plugin/src/index.ts
@@ -1,4 +1,4 @@
-import * as vue from '@volar/vue-language-core';
+import * as vue from '@vue/language-core';
 import * as vueTs from '@volar/vue-typescript';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 

--- a/packages/vscode-vue/package.json
+++ b/packages/vscode-vue/package.json
@@ -744,7 +744,7 @@
 		"@volar/source-map": "1.5.3",
 		"@volar/vscode": "1.5.3",
 		"@volar/vue-language-core": "1.6.4",
-		"@volar/vue-language-server": "1.6.4",
+		"@vue/language-server": "1.6.4",
 		"esbuild": "0.15.18",
 		"esbuild-plugin-copy": "latest",
 		"esbuild-visualizer": "latest",

--- a/packages/vscode-vue/package.json
+++ b/packages/vscode-vue/package.json
@@ -743,7 +743,7 @@
 		"@types/vscode": "1.67.0",
 		"@volar/source-map": "1.5.3",
 		"@volar/vscode": "1.5.3",
-		"@volar/vue-language-core": "1.6.4",
+		"@vue/language-core": "1.6.4",
 		"@vue/language-server": "1.6.4",
 		"esbuild": "0.15.18",
 		"esbuild-plugin-copy": "latest",

--- a/packages/vscode-vue/scripts/build.js
+++ b/packages/vscode-vue/scripts/build.js
@@ -34,7 +34,7 @@ require('esbuild').build({
 		require('esbuild-plugin-copy').copy({
 			resolveFrom: 'cwd',
 			assets: {
-				from: ['./node_modules/@volar/vue-language-core/schemas/**/*'],
+				from: ['./node_modules/@vue/language-core/schemas/**/*'],
 				to: ['./dist/schemas'],
 			},
 			keepStructure: true,

--- a/packages/vscode-vue/scripts/build.js
+++ b/packages/vscode-vue/scripts/build.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 require('esbuild').build({
 	entryPoints: {
 		client: './out/nodeClientMain.js',
-		server: './node_modules/@volar/vue-language-server/out/nodeServer.js',
+		server: './node_modules/@vue/language-server/out/nodeServer.js',
 	},
 	bundle: true,
 	metafile: process.argv.includes('--metafile'),

--- a/packages/vscode-vue/server.js
+++ b/packages/vscode-vue/server.js
@@ -1,5 +1,5 @@
 try {
-	module.exports = require('@volar/vue-language-server/bin/vue-language-server');
+	module.exports = require('@vue/language-server/bin/vue-language-server');
 } catch {
 	module.exports = require('./dist/server');
 }

--- a/packages/vscode-vue/src/common.ts
+++ b/packages/vscode-vue/src/common.ts
@@ -11,7 +11,7 @@ import {
 	getTsdk,
 	takeOverModeActive,
 } from '@volar/vscode';
-import { DiagnosticModel, ServerMode, VueServerInitializationOptions } from '@volar/vue-language-server';
+import { DiagnosticModel, ServerMode, VueServerInitializationOptions } from '@vue/language-server';
 import * as vscode from 'vscode';
 import * as lsp from 'vscode-languageclient';
 import * as componentMeta from './features/componentMeta';

--- a/packages/vscode-vue/src/features/componentMeta.ts
+++ b/packages/vscode-vue/src/features/componentMeta.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import type { BaseLanguageClient } from 'vscode-languageclient';
-import { GetComponentMeta } from '@volar/vue-language-server';
+import { GetComponentMeta } from '@vue/language-server';
 
 const scheme = 'vue-component-meta';
 

--- a/packages/vscode-vue/src/features/doctor.ts
+++ b/packages/vscode-vue/src/features/doctor.ts
@@ -144,24 +144,24 @@ export async function register(context: vscode.ExtensionContext, client: BaseLan
 			});
 		}
 
-		// check using pug but don't install @volar/vue-language-plugin-pug
+		// check using pug but don't install @vue/language-plugin-pug
 		if (
 			sfc?.descriptor.template?.lang === 'pug'
-			&& !await getPackageJsonOfWorkspacePackage(fileUri.fsPath, '@volar/vue-language-plugin-pug')
+			&& !await getPackageJsonOfWorkspacePackage(fileUri.fsPath, '@vue/language-plugin-pug')
 		) {
 			problems.push({
-				title: '`@volar/vue-language-plugin-pug` missing',
+				title: '`@vue/language-plugin-pug` missing',
 				message: [
-					'For `<template lang="pug">`, the `@volar/vue-language-plugin-pug` plugin is required. Install it using `$ npm install -D @volar/vue-language-plugin-pug` and add it to `vueCompilerOptions.plugins` to support TypeScript intellisense in Pug templates.',
+					'For `<template lang="pug">`, the `@vue/language-plugin-pug` plugin is required. Install it using `$ npm install -D @vue/language-plugin-pug` and add it to `vueCompilerOptions.plugins` to support TypeScript intellisense in Pug templates.',
 					'',
 					'- package.json',
 					'```json',
-					JSON.stringify({ devDependencies: { "@volar/vue-language-plugin-pug": "latest" } }, undefined, 2),
+					JSON.stringify({ devDependencies: { "@vue/language-plugin-pug": "latest" } }, undefined, 2),
 					'```',
 					'',
 					'- tsconfig.json / jsconfig.json',
 					'```jsonc',
-					JSON.stringify({ vueCompilerOptions: { plugins: ["@volar/vue-language-plugin-pug"] } }, undefined, 2),
+					JSON.stringify({ vueCompilerOptions: { plugins: ["@vue/language-plugin-pug"] } }, undefined, 2),
 					'```',
 				].join('\n'),
 			});

--- a/packages/vscode-vue/src/features/doctor.ts
+++ b/packages/vscode-vue/src/features/doctor.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as semver from 'semver';
 import { BaseLanguageClient } from 'vscode-languageclient';
-import { ParseSFCRequest } from '@volar/vue-language-server';
+import { ParseSFCRequest } from '@vue/language-server';
 import { getTsdk } from '@volar/vscode';
 import { config } from '../config';
 

--- a/packages/vscode-vue/src/features/nameCasing.ts
+++ b/packages/vscode-vue/src/features/nameCasing.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { quickPick } from '@volar/vscode/out/common';
 import { BaseLanguageClient, State } from 'vscode-languageclient';
-import { AttrNameCasing, TagNameCasing, DetectNameCasingRequest, GetConvertAttrCasingEditsRequest, GetConvertTagCasingEditsRequest } from '@volar/vue-language-server';
+import { AttrNameCasing, TagNameCasing, DetectNameCasingRequest, GetConvertAttrCasingEditsRequest, GetConvertTagCasingEditsRequest } from '@vue/language-server';
 import { config } from '../config';
 
 export const attrNameCasings = new Map<string, AttrNameCasing>();

--- a/packages/vscode-vue/src/features/splitEditors.ts
+++ b/packages/vscode-vue/src/features/splitEditors.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { BaseLanguageClient } from 'vscode-languageclient';
-import { ParseSFCRequest } from '@volar/vue-language-server';
+import { ParseSFCRequest } from '@vue/language-server';
 import { config } from '../config';
 
 type SFCBlock = ParseSFCRequest.ResponseType['descriptor']['customBlocks'][number];

--- a/packages/vscode-vue/src/middleware.ts
+++ b/packages/vscode-vue/src/middleware.ts
@@ -1,4 +1,4 @@
-import { AttrNameCasing, TagNameCasing } from '@volar/vue-language-server';
+import { AttrNameCasing, TagNameCasing } from '@vue/language-server';
 import { middleware as baseMiddleware } from '@volar/vscode';
 import * as vscode from 'vscode';
 import * as lsp from 'vscode-languageclient';

--- a/packages/vscode-vue/src/nodeClientMain.ts
+++ b/packages/vscode-vue/src/nodeClientMain.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as lsp from 'vscode-languageclient/node';
 import { activate as commonActivate, deactivate as commonDeactivate, getDocumentSelector } from './common';
 import { middleware } from './middleware';
-import { ServerMode } from '@volar/vue-language-server';
+import { ServerMode } from '@vue/language-server';
 import { config } from './config';
 
 export function activate(context: vscode.ExtensionContext) {

--- a/packages/vue-component-meta/package.json
+++ b/packages/vue-component-meta/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@volar/language-core": "1.5.3",
-		"@volar/vue-language-core": "1.6.4",
+		"@vue/language-core": "1.6.4",
 		"typesafe-path": "^0.2.2",
 		"vue-component-type-helpers": "1.6.4"
 	},

--- a/packages/vue-component-meta/src/index.ts
+++ b/packages/vue-component-meta/src/index.ts
@@ -1,4 +1,4 @@
-import * as vue from '@volar/vue-language-core';
+import * as vue from '@vue/language-core';
 import { createLanguageContext } from '@volar/language-core';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as path from 'typesafe-path/posix';

--- a/packages/vue-language-core/package.json
+++ b/packages/vue-language-core/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@volar/vue-language-core",
+	"name": "@vue/language-core",
 	"version": "1.6.4",
 	"main": "out/index.js",
 	"license": "MIT",

--- a/packages/vue-language-plugin-pug/README.md
+++ b/packages/vue-language-plugin-pug/README.md
@@ -1,4 +1,4 @@
-A `VueLanguagePlugin` to support `<template lang="pug">` for `@volar/vue-language-server`.
+A `VueLanguagePlugin` to support `<template lang="pug">` for `@vue/language-server`.
 
 ## Usage
 

--- a/packages/vue-language-plugin-pug/README.md
+++ b/packages/vue-language-plugin-pug/README.md
@@ -4,14 +4,14 @@ A `VueLanguagePlugin` to support `<template lang="pug">` for `@vue/language-serv
 
 1. Install
 
-   `$ npm i -D @volar/vue-language-plugin-pug`
+   `$ npm i -D @vue/language-plugin-pug`
 
 2. Add to `tsconfig.json`
 
    ```jsonc
 	{
 		"vueCompilerOptions": {
-			"plugins": ["@volar/vue-language-plugin-pug"]
+			"plugins": ["@vue/language-plugin-pug"]
 		}
 	}
    ```

--- a/packages/vue-language-plugin-pug/package.json
+++ b/packages/vue-language-plugin-pug/package.json
@@ -13,7 +13,7 @@
 		"directory": "packages/vue-language-plugin-pug"
 	},
 	"devDependencies": {
-		"@volar/vue-language-core": "1.6.4"
+		"@vue/language-core": "1.6.4"
 	},
 	"dependencies": {
 		"@volar/language-service": "1.5.3",

--- a/packages/vue-language-plugin-pug/package.json
+++ b/packages/vue-language-plugin-pug/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@volar/vue-language-plugin-pug",
+	"name": "@vue/language-plugin-pug",
 	"version": "1.6.4",
 	"main": "out/index.js",
 	"license": "MIT",

--- a/packages/vue-language-plugin-pug/src/index.ts
+++ b/packages/vue-language-plugin-pug/src/index.ts
@@ -1,4 +1,4 @@
-import type { VueLanguagePlugin } from '@volar/vue-language-core';
+import type { VueLanguagePlugin } from '@vue/language-core';
 import * as pug from 'volar-service-pug/out/languageService';
 import { SourceMap } from '@volar/source-map';
 

--- a/packages/vue-language-server/package.json
+++ b/packages/vue-language-server/package.json
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"@volar/language-core": "1.5.3",
 		"@volar/language-server": "1.5.3",
-		"@volar/vue-language-core": "1.6.4",
+		"@vue/language-core": "1.6.4",
 		"@vue/language-service": "1.6.4",
 		"vscode-languageserver-protocol": "^3.17.3",
 		"vue-component-meta": "1.6.4"

--- a/packages/vue-language-server/package.json
+++ b/packages/vue-language-server/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@volar/vue-language-server",
+	"name": "@vue/language-server",
 	"version": "1.6.4",
 	"main": "out/index.js",
 	"license": "MIT",

--- a/packages/vue-language-server/package.json
+++ b/packages/vue-language-server/package.json
@@ -19,7 +19,7 @@
 		"@volar/language-core": "1.5.3",
 		"@volar/language-server": "1.5.3",
 		"@volar/vue-language-core": "1.6.4",
-		"@volar/vue-language-service": "1.6.4",
+		"@vue/language-service": "1.6.4",
 		"vscode-languageserver-protocol": "^3.17.3",
 		"vue-component-meta": "1.6.4"
 	}

--- a/packages/vue-language-server/src/index.ts
+++ b/packages/vue-language-server/src/index.ts
@@ -6,4 +6,4 @@ export * from '@volar/language-server/out/protocol';
 export * from '@volar/language-server/out/types';
 
 // only export types of depend packages
-export * from '@volar/vue-language-service/out/types';
+export * from '@vue/language-service/out/types';

--- a/packages/vue-language-server/src/languageServerPlugin.ts
+++ b/packages/vue-language-server/src/languageServerPlugin.ts
@@ -1,13 +1,13 @@
 import * as embedded from '@volar/language-core';
 import { LanguageServerPlugin, Connection } from '@volar/language-server';
 import * as vue from '@vue/language-service';
-import * as vue2 from '@volar/vue-language-core';
+import * as vue2 from '@vue/language-core';
 import * as nameCasing from '@vue/language-service';
 import { DetectNameCasingRequest, GetConvertAttrCasingEditsRequest, GetConvertTagCasingEditsRequest, ParseSFCRequest, GetComponentMeta } from './protocol';
 import { VueServerInitializationOptions } from './types';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as componentMeta from 'vue-component-meta';
-import { VueCompilerOptions } from '@volar/vue-language-core';
+import { VueCompilerOptions } from '@vue/language-core';
 
 export function createServerPlugin(connection: Connection) {
 

--- a/packages/vue-language-server/src/languageServerPlugin.ts
+++ b/packages/vue-language-server/src/languageServerPlugin.ts
@@ -1,8 +1,8 @@
 import * as embedded from '@volar/language-core';
 import { LanguageServerPlugin, Connection } from '@volar/language-server';
-import * as vue from '@volar/vue-language-service';
+import * as vue from '@vue/language-service';
 import * as vue2 from '@volar/vue-language-core';
-import * as nameCasing from '@volar/vue-language-service';
+import * as nameCasing from '@vue/language-service';
 import { DetectNameCasingRequest, GetConvertAttrCasingEditsRequest, GetConvertTagCasingEditsRequest, ParseSFCRequest, GetComponentMeta } from './protocol';
 import { VueServerInitializationOptions } from './types';
 import type * as ts from 'typescript/lib/tsserverlibrary';

--- a/packages/vue-language-server/src/protocol.ts
+++ b/packages/vue-language-server/src/protocol.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode-languageserver-protocol';
-import { TagNameCasing, AttrNameCasing, SFCParseResult } from '@volar/vue-language-service';
+import { TagNameCasing, AttrNameCasing, SFCParseResult } from '@vue/language-service';
 import { ComponentMeta } from 'vue-component-meta';
 
 export namespace GetComponentMeta {

--- a/packages/vue-language-service/package.json
+++ b/packages/vue-language-service/package.json
@@ -20,7 +20,7 @@
 		"@volar/language-core": "1.5.3",
 		"@volar/language-service": "1.5.3",
 		"@volar/source-map": "1.5.3",
-		"@volar/vue-language-core": "1.6.4",
+		"@vue/language-core": "1.6.4",
 		"@vue/compiler-dom": "^3.3.0-beta.3",
 		"@vue/reactivity": "^3.3.0-beta.3",
 		"@vue/shared": "^3.3.0-beta.3",

--- a/packages/vue-language-service/package.json
+++ b/packages/vue-language-service/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@volar/vue-language-service",
+	"name": "@vue/language-service",
 	"version": "1.6.4",
 	"main": "out/index.js",
 	"license": "MIT",

--- a/packages/vue-language-service/rules.d.ts
+++ b/packages/vue-language-service/rules.d.ts
@@ -1,7 +1,7 @@
-import type * as vue from '@volar/vue-language-core';
+import type * as vue from '@vue/language-core';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type * as ts from 'typescript/lib/tsserverlibrary';
-import type { VueLanguagePlugin } from '@volar/vue-language-core';
+import type { VueLanguagePlugin } from '@vue/language-core';
 
 declare module '@volar/language-service' {
 	interface RuleContext {

--- a/packages/vue-language-service/src/helpers.ts
+++ b/packages/vue-language-service/src/helpers.ts
@@ -1,8 +1,8 @@
-import * as vue from '@volar/vue-language-core';
+import * as vue from '@vue/language-core';
 import * as embedded from '@volar/language-core';
 import * as CompilerDOM from '@vue/compiler-dom';
 import { computed, ComputedRef } from '@vue/reactivity';
-import { sharedTypes } from '@volar/vue-language-core';
+import { sharedTypes } from '@vue/language-core';
 import { camelize, capitalize } from '@vue/shared';
 
 import type * as ts from 'typescript/lib/tsserverlibrary';

--- a/packages/vue-language-service/src/ideFeatures/nameCasing.ts
+++ b/packages/vue-language-service/src/ideFeatures/nameCasing.ts
@@ -1,7 +1,7 @@
 import { hyphenate } from '@vue/shared';
 import { ServiceContext, VirtualFile } from '@volar/language-service';
 import { checkComponentNames, getTemplateTagsAndAttrs, checkPropsOfTag, checkNativeTags } from '../helpers';
-import * as vue from '@volar/vue-language-core';
+import * as vue from '@vue/language-core';
 import * as vscode from 'vscode-languageserver-protocol';
 import { AttrNameCasing, TagNameCasing } from '../types';
 

--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -5,7 +5,7 @@ import createJsonPlugin from 'volar-service-json';
 import createPugPlugin from 'volar-service-pug';
 import createTsPlugin from 'volar-service-typescript';
 import createTsTqPlugin from 'volar-service-typescript-twoslash-queries';
-import * as vue from '@volar/vue-language-core';
+import * as vue from '@vue/language-core';
 import type * as html from 'vscode-html-languageservice';
 import * as vscode from 'vscode-languageserver-protocol';
 import createVuePlugin from './plugins/vue';

--- a/packages/vue-language-service/src/plugins/vue-autoinsert-parentheses.ts
+++ b/packages/vue-language-service/src/plugins/vue-autoinsert-parentheses.ts
@@ -1,7 +1,7 @@
 import * as embedded from '@volar/language-core';
 import { VirtualFile } from '@volar/language-core';
 import { Service } from '@volar/language-service';
-import { VueFile } from '@volar/vue-language-core';
+import { VueFile } from '@vue/language-core';
 import * as vscode from 'vscode-languageserver-protocol';
 import { isCharacterTyping } from './vue-autoinsert-dotvalue';
 

--- a/packages/vue-language-service/src/plugins/vue-codelens-references.ts
+++ b/packages/vue-language-service/src/plugins/vue-codelens-references.ts
@@ -1,5 +1,5 @@
 import { Service } from '@volar/language-service';
-import { VueFile } from '@volar/vue-language-core';
+import { VueFile } from '@vue/language-core';
 import * as vscode from 'vscode-languageserver-protocol';
 
 export default function (): Service {

--- a/packages/vue-language-service/src/plugins/vue-template.ts
+++ b/packages/vue-language-service/src/plugins/vue-template.ts
@@ -1,6 +1,6 @@
 import createHtmlPlugin from 'volar-service-html';
 import { FileRangeCapabilities, Service, SourceMapWithDocuments } from '@volar/language-service';
-import * as vue from '@volar/vue-language-core';
+import * as vue from '@vue/language-core';
 import { hyphenate, capitalize, camelize } from '@vue/shared';
 import * as html from 'vscode-html-languageservice';
 import * as vscode from 'vscode-languageserver-protocol';

--- a/packages/vue-language-service/src/plugins/vue-twoslash-queries.ts
+++ b/packages/vue-language-service/src/plugins/vue-twoslash-queries.ts
@@ -1,5 +1,5 @@
 import { FileKind, forEachEmbeddedFile, Service } from '@volar/language-service';
-import * as vue from '@volar/vue-language-core';
+import * as vue from '@vue/language-core';
 import * as vscode from 'vscode-languageserver-protocol';
 
 const plugin: Service = (context, modules) => {

--- a/packages/vue-language-service/src/plugins/vue.ts
+++ b/packages/vue-language-service/src/plugins/vue.ts
@@ -3,7 +3,7 @@ import * as html from 'vscode-html-languageservice';
 import * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import createHtmlPlugin from 'volar-service-html';
-import * as vue from '@volar/vue-language-core';
+import * as vue from '@vue/language-core';
 import { loadLanguageBlocks } from './data';
 
 let sfcDataProvider: html.IHTMLDataProvider | undefined;

--- a/packages/vue-language-service/src/types.ts
+++ b/packages/vue-language-service/src/types.ts
@@ -10,4 +10,4 @@ export enum AttrNameCasing {
 
 // only export types of depend packages
 export * from '@volar/language-service/out/types';
-export * from '@volar/vue-language-core/out/types';
+export * from '@vue/language-core/out/types';

--- a/packages/vue-tsc/package.json
+++ b/packages/vue-tsc/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"@vue/language-core": "1.6.4",
-		"@volar/vue-typescript": "1.6.4",
+		"@vue/typescript": "1.6.4",
 		"semver": "^7.3.8"
 	},
 	"peerDependencies": {

--- a/packages/vue-tsc/package.json
+++ b/packages/vue-tsc/package.json
@@ -17,7 +17,7 @@
 		"vue-tsc": "./bin/vue-tsc.js"
 	},
 	"dependencies": {
-		"@volar/vue-language-core": "1.6.4",
+		"@vue/language-core": "1.6.4",
 		"@volar/vue-typescript": "1.6.4",
 		"semver": "^7.3.8"
 	},

--- a/packages/vue-tsc/src/index.ts
+++ b/packages/vue-tsc/src/index.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import * as vue from '@vue/language-core';
-import * as vueTs from '@volar/vue-typescript';
+import * as vueTs from '@vue/typescript';
 import { state } from './shared';
 
 export type Hook = (program: _Program) => void;

--- a/packages/vue-tsc/src/index.ts
+++ b/packages/vue-tsc/src/index.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import * as vue from '@volar/vue-language-core';
+import * as vue from '@vue/language-core';
 import * as vueTs from '@volar/vue-typescript';
 import { state } from './shared';
 

--- a/packages/vue-typescript/package.json
+++ b/packages/vue-typescript/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@volar/vue-typescript",
+	"name": "@vue/typescript",
 	"version": "1.6.4",
 	"main": "out/index.js",
 	"license": "MIT",

--- a/packages/vue-typescript/package.json
+++ b/packages/vue-typescript/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@volar/typescript": "1.5.3",
-		"@volar/vue-language-core": "1.6.4"
+		"@vue/language-core": "1.6.4"
 	},
 	"peerDependencies": {
 		"typescript": "*"

--- a/packages/vue-typescript/src/index.ts
+++ b/packages/vue-typescript/src/index.ts
@@ -1,5 +1,5 @@
 import * as base from '@volar/typescript';
-import * as vue from '@volar/vue-language-core';
+import * as vue from '@vue/language-core';
 
 export function createLanguageService(
 	host: vue.VueLanguageServiceHost,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
       '@vue/language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
-      '@volar/vue-typescript':
+      '@vue/typescript':
         specifier: 1.6.4
         version: link:../vue-typescript
 
@@ -269,7 +269,7 @@ importers:
       '@vue/language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
-      '@volar/vue-typescript':
+      '@vue/typescript':
         specifier: 1.6.4
         version: link:../vue-typescript
       semver:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,7 +178,7 @@ importers:
       '@volar/vue-language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
-      '@volar/vue-language-service':
+      '@vue/language-service':
         specifier: 1.6.4
         version: link:../vue-language-service
       vscode-languageserver-protocol:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
 
   packages/typescript-vue-plugin:
     dependencies:
-      '@volar/vue-language-core':
+      '@vue/language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
       '@volar/vue-typescript':
@@ -69,7 +69,7 @@ importers:
       '@volar/vscode':
         specifier: 1.5.3
         version: 1.5.3(@types/vscode@1.67.0)(vscode-languageclient@8.1.0)
-      '@volar/vue-language-core':
+      '@vue/language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
       '@vue/language-server':
@@ -105,7 +105,7 @@ importers:
       '@volar/language-core':
         specifier: 1.5.3
         version: 1.5.3
-      '@volar/vue-language-core':
+      '@vue/language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
       typesafe-path:
@@ -163,7 +163,7 @@ importers:
         specifier: 0.0.1
         version: 0.0.1(@volar/language-service@1.5.3)(@volar/source-map@1.5.3)
     devDependencies:
-      '@volar/vue-language-core':
+      '@vue/language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
 
@@ -175,7 +175,7 @@ importers:
       '@volar/language-server':
         specifier: 1.5.3
         version: 1.5.3
-      '@volar/vue-language-core':
+      '@vue/language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
       '@vue/language-service':
@@ -199,7 +199,7 @@ importers:
       '@volar/source-map':
         specifier: 1.5.3
         version: 1.5.3
-      '@volar/vue-language-core':
+      '@vue/language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
       '@vue/compiler-dom':
@@ -266,7 +266,7 @@ importers:
 
   packages/vue-tsc:
     dependencies:
-      '@volar/vue-language-core':
+      '@vue/language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
       '@volar/vue-typescript':
@@ -294,7 +294,7 @@ importers:
       '@volar/typescript':
         specifier: 1.5.3
         version: 1.5.3(typescript@5.0.4)
-      '@volar/vue-language-core':
+      '@vue/language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
       '@volar/vue-language-core':
         specifier: 1.6.4
         version: link:../vue-language-core
-      '@volar/vue-language-server':
+      '@vue/language-server':
         specifier: 1.6.4
         version: link:../vue-language-server
       esbuild:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
 			"@volar/vue-language-core": [
 				"packages/vue-language-core/src"
 			],
-			"@volar/vue-language-plugin-pug": [
+			"@vue/language-plugin-pug": [
 				"packages/vue-language-plugin-pug/src"
 			],
 			"@vue/language-server": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 			"vue-component-type-helpers": [
 				"packages/vue-component-type-helpers/src"
 			],
-			"@volar/vue-language-core": [
+			"@vue/language-core": [
 				"packages/vue-language-core/src"
 			],
 			"@vue/language-plugin-pug": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
 			"@volar/vue-language-plugin-pug": [
 				"packages/vue-language-plugin-pug/src"
 			],
-			"@volar/vue-language-server": [
+			"@vue/language-server": [
 				"packages/vue-language-server/src"
 			],
 			"@volar/vue-language-service": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
 			"@vue/language-server": [
 				"packages/vue-language-server/src"
 			],
-			"@volar/vue-language-service": [
+			"@vue/language-service": [
 				"packages/vue-language-service/src"
 			],
 			"vue-tsc": [


### PR DESCRIPTION
close #2437 

Changes:

- [x] `@volar/vue-language-server` -> `@vue/language-server`
- [x] `@volar/vue-language-service` -> `@vue/language-service`
- [x] `@volar/vue-language-plugin-pug` -> `@vue/language-plugin-pug`
- [x] `@volar/vue-language-core` -> `@vue/language-core`
- [x] `@volar/vue-typescript` -> `@vue/typescript`