### PR TITLE
fix(language-core): add missing peer dependency `typescript`

### DIFF
--- a/packages/vue-component-meta/package.json
+++ b/packages/vue-component-meta/package.json
@@ -20,5 +20,10 @@
 	},
 	"peerDependencies": {
 		"typescript": "*"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
 	}
 }

--- a/packages/vue-language-core/package.json
+++ b/packages/vue-language-core/package.json
@@ -25,5 +25,8 @@
 	"devDependencies": {
 		"@vue/compiler-sfc": "^3.3.0-beta.3",
 		"@types/minimatch": "^5.1.2"
+	},
+	"peerDependencies": {
+		"typescript": "*"
 	}
 }

--- a/packages/vue-language-core/package.json
+++ b/packages/vue-language-core/package.json
@@ -28,5 +28,10 @@
 	},
 	"peerDependencies": {
 		"typescript": "*"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
 	}
 }


### PR DESCRIPTION
`@vue/language-core` tries to require `typescript` but doesn't declare it as a dependency.
This PR fixes that by declaring `typescript` as a peer dependency of `@vue/language-core`.

Ref https://github.com/yarnpkg/berry/actions/runs/4919080804/jobs/8786259067#step:5:63