### PR TITLE
fix(language-service): remove js extension from vue imports

### DIFF
--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -82,7 +82,6 @@ function resolvePlugins(
 							&& (!item.labelDetails?.description || item.labelDetails.description.indexOf('__VLS_') === -1)
 						) {
 							if (item.labelDetails?.description?.endsWith('.vue.js')) {
-								console.log(item);
 								// remove .js from .vue files
 								item.labelDetails.description = item.labelDetails.description.slice(0, -3);
 							}


### PR DESCRIPTION
My best attempt to fix #3150.

Mainly it seems to be fixing it after the fact, possible something is adding .vue.js extension in the first place.
Not sure where to look to find that though.

Also I was looking at trying to add tests, but doesn't seem to be a straight forward way to add another completion test, but with different vscode settings?