### PR TITLE
fix: patch tsc to not crash on composite project errors

### DIFF
--- a/packages/vue-tsc/bin/vue-tsc.js
+++ b/packages/vue-tsc/bin/vue-tsc.js
@@ -25,6 +25,8 @@ fs.readFileSync = (...args) => {
 				.filter(file => !file.toLowerCase().includes('__vls_'))
 				.map(file => file.replace(/\.vue\.(j|t)sx?$/i, '.vue'))
 			) {`);
+
+			tryReplace(`relativeToBuildInfo(file.resolvedPath)`, `relativeToBuildInfo(file.resolvedPath || file.fileName)`);
 		}
 
 		return tsc;


### PR DESCRIPTION
Fixes #2622

I don't know the exact detail of the crash, but I find that tsc crashed because the `diagnostic.file` object is somehow missing a `resolvedPath` field. Meanwhile, the `fileName` field is always present. So I just added a fallback to `fileName` in the patch.

Maybe related: https://github.com/microsoft/TypeScript/issues/54057

I only add it to the 5.0 branch because I haven't tested it on 4.x, so let's play it safe.