### PR TITLE
perf: Avoid doing type gymnastics with `JSX.IntrinsicElements`

### DIFF
--- a/packages/vue-language-core/src/generators/template.ts
+++ b/packages/vue-language-core/src/generators/template.ts
@@ -179,7 +179,7 @@ export function generate(
 
 		const data: Record<string, string> = {};
 
-		codes.push(`let __VLS_templateComponents!: {}\n`);
+		codes.push(`let __VLS_templateComponents!: __VLS_IntrinsicElements\n`);
 
 		for (const tagName in tagNames) {
 

--- a/packages/vue-language-core/src/utils/directorySharedTypes.ts
+++ b/packages/vue-language-core/src/utils/directorySharedTypes.ts
@@ -62,12 +62,10 @@ declare function __VLS_makeOptional<T>(t: T): { [K in keyof T]?: T[K] };
 
 type __VLS_SelfComponent<N, C> = string extends N ? {} : N extends string ? { [P in N]: C } : {};
 type __VLS_WithComponent<N0 extends string, Components, N1 extends string, N2 extends string, N3 extends string> =
-	__VLS_IsAny<__VLS_IntrinsicElements[N0]> extends true ? (
-		N1 extends keyof Components ? N1 extends N0 ? Pick<Components, N0> : { [K in N0]: Components[N1] } :
-		N2 extends keyof Components ? N2 extends N0 ? Pick<Components, N0> : { [K in N0]: Components[N2] } :
-		N3 extends keyof Components ? N3 extends N0 ? Pick<Components, N0> : { [K in N0]: Components[N3] } :
-		${vueCompilerOptions.strictTemplates ? '{}' : '{ [K in N0]: any }'}
-	) : Pick<__VLS_IntrinsicElements, N0>;
+	N1 extends keyof Components ? N1 extends N0 ? Pick<Components, N0> : { [K in N0]: Components[N1] } :
+	N2 extends keyof Components ? N2 extends N0 ? Pick<Components, N0> : { [K in N0]: Components[N2] } :
+	N3 extends keyof Components ? N3 extends N0 ? Pick<Components, N0> : { [K in N0]: Components[N3] } :
+	${vueCompilerOptions.strictTemplates ? '{}' : '{ [K in N0]: unknown }'}
 
 type __VLS_FillingEventArg_ParametersLength<E extends (...args: any) => any> = __VLS_IsAny<Parameters<E>> extends true ? -1 : Parameters<E>['length'];
 type __VLS_FillingEventArg<E> = E extends (...args: any) => any ? __VLS_FillingEventArg_ParametersLength<E> extends 0 ? ($event?: undefined) => ReturnType<E> : E : E;
@@ -100,7 +98,7 @@ declare function __VLS_asFunctionalComponent<T, K = T extends new (...args: any)
 	}) => JSX.Element & { __ctx?: typeof ctx & { props?: typeof props; expose?(exposed: K): void; } }
 	: T extends () => any ? (props: {}, ctx?: any) => ReturnType<T>
 	: T extends (...args: any) => any ? T
-	: (_: T extends import('${vueCompilerOptions.lib}').VNode | import('${vueCompilerOptions.lib}').VNode[] | string ? {}: T${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'}, ctx?: any) => { __ctx?: { attrs?: unknown, expose?: unknown, slots?: unknown, emit?: unknown, props?: T${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'} } }; // IntrinsicElement
+	: (_: T extends import('${vueCompilerOptions.lib}').VNode | import('${vueCompilerOptions.lib}').VNode[] | string ? {}: T${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'}, ctx?: any) => { __ctx?: { attrs?: any, expose?: any, slots?: any, emit?: any, props?: T${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'} } }; // IntrinsicElement
 declare function __VLS_functionalComponentArgsRest<T extends (...args: any) => any>(t: T): Parameters<T>['length'] extends 2 ? [any] : [];
 declare function __VLS_pickEvent<Emit, K, E>(emit: Emit, emitKey: K, event: E): __VLS_FillingEventArg<
 	__VLS_PickNotAny<

--- a/packages/vue-test-workspace/rename/duplicate-name-element/input/entry.vue
+++ b/packages/vue-test-workspace/rename/duplicate-name-element/input/entry.vue
@@ -1,9 +1,0 @@
-<template>
-    <h1>{{ h1 }}</h1>
-      <!-- ^^rename: h2 -->
-</template>
-
-<script lang="ts" setup>
-const h1: string = 'header';
-   // ^^rename: h2
-</script>

--- a/packages/vue-test-workspace/rename/duplicate-name-element/output/entry.vue
+++ b/packages/vue-test-workspace/rename/duplicate-name-element/output/entry.vue
@@ -1,9 +1,0 @@
-<template>
-    <h1>{{ h2 }}</h1>
-      <!-- ^^rename: h2 -->
-</template>
-
-<script lang="ts" setup>
-const h2: string = 'header';
-   // ^^rename: h2
-</script>


### PR DESCRIPTION
close #3226, close #3148, close #3130, close #2533

First I wasn't able to actually reproduce the problem, so please let me know if it doesn't solve the above closed issue. Thanks to @Fuzzyma for helping to investigate, I think the problem is most likely happening in #2685.

In this PR we no longer do type gymnastics with `JSX.IntrinsicElements`, so TS type evaluation may be faster.

But it also makes the template unable to separate `JSX.IntrinsicElements` and components types, which affects DX in some cases, but I think it is a reasonable trade-off, and it is too expensive to trade performance for it.