### PR TITLE
fix: compatible with TS 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@types/node": "latest",
 		"@volar/language-service": "1.7.4",
-		"typescript": "~5.0.4",
+		"typescript": "latest",
 		"vite": "latest",
 		"vitest": "latest"
 	},

--- a/packages/vue-language-core/src/utils/directorySharedTypes.ts
+++ b/packages/vue-language-core/src/utils/directorySharedTypes.ts
@@ -7,20 +7,20 @@ export function getTypesCode(vueCompilerOptions: VueCompilerOptions) {
 	return `
 // @ts-nocheck
 
-type __VLS_IntrinsicElements = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.IntrinsicElements & {}, __VLS_PickNotAny<JSX.IntrinsicElements, Record<string, any>>>;
-type __VLS_Element = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.Element & {}, JSX.Element>;
+type __VLS_IntrinsicElements = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.IntrinsicElements, __VLS_PickNotAny<JSX.IntrinsicElements, Record<string, any>>>;
+type __VLS_Element = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.Element, JSX.Element>;
 
 type __VLS_IsAny<T> = boolean extends (T extends never ? true : false) ? true : false;
-type __VLS_PickNotAny<A, B> = __VLS_IsAny<A> extends true ? B : A;
+type __VLS_PickNotAny<A, B> = __VLS_IsAny<A & {}> extends true ? B : A;
 
 type __VLS_Prettify<T> = {
 	[K in keyof T]: T[K];
 } & {};
 
 type __VLS_GlobalComponents =
-	__VLS_PickNotAny<import('vue').GlobalComponents & {}, {}>
-	& __VLS_PickNotAny<import('@vue/runtime-core').GlobalComponents & {}, {}>
-	& __VLS_PickNotAny<import('@vue/runtime-dom').GlobalComponents & {}, {}>
+	__VLS_PickNotAny<import('vue').GlobalComponents, {}>
+	& __VLS_PickNotAny<import('@vue/runtime-core').GlobalComponents, {}>
+	& __VLS_PickNotAny<import('@vue/runtime-dom').GlobalComponents, {}>
 	& Pick<typeof import('${vueCompilerOptions.lib}'),
 		'Transition'
 		| 'TransitionGroup'

--- a/packages/vue-language-core/src/utils/directorySharedTypes.ts
+++ b/packages/vue-language-core/src/utils/directorySharedTypes.ts
@@ -11,7 +11,7 @@ type __VLS_IntrinsicElements = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.In
 type __VLS_Element = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.Element, JSX.Element>;
 
 type __VLS_IsAny<T> = boolean extends (T extends never ? true : false) ? true : false;
-type __VLS_PickNotAny<A, B> = __VLS_IsAny<A & {}> extends true ? B : A;
+type __VLS_PickNotAny<A, B> = __VLS_IsAny<A & {}> extends true ? B : A; // & {} for https://github.com/microsoft/TypeScript/issues/54630
 
 type __VLS_Prettify<T> = {
 	[K in keyof T]: T[K];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,16 +17,16 @@ importers:
     devDependencies:
       '@types/node':
         specifier: latest
-        version: 20.2.5
+        version: 20.3.1
       '@volar/language-service':
         specifier: 1.7.4
         version: 1.7.4
       typescript:
-        specifier: ~5.0.4
-        version: 5.0.4
+        specifier: latest
+        version: 5.1.3
       vite:
         specifier: latest
-        version: 4.3.9(@types/node@20.2.5)
+        version: 4.3.9(@types/node@20.3.1)
       vitest:
         specifier: latest
         version: 0.32.0
@@ -239,7 +239,7 @@ importers:
     devDependencies:
       '@volar/kit':
         specifier: 1.7.4
-        version: 1.7.4(typescript@5.0.4)
+        version: 1.7.4(typescript@5.1.3)
       vscode-languageserver-protocol:
         specifier: ^3.17.3
         version: 3.17.3
@@ -279,7 +279,7 @@ importers:
     devDependencies:
       '@types/eslint':
         specifier: latest
-        version: 8.40.0
+        version: 8.40.2
       vue-tsc:
         specifier: 1.7.11
         version: link:../vue-tsc
@@ -1177,8 +1177,8 @@ packages:
     resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}
     dev: true
 
-  /@types/eslint@8.40.0:
-    resolution: {integrity: sha512-nbq2mvc/tBrK9zQQuItvjJl++GTN5j06DaPtp3hZCpngmG6Q3xoyEmd0TwZI0gAy/G1X0zhGBbr2imsGFdFV0g==}
+  /@types/eslint@8.40.2:
+    resolution: {integrity: sha512-PRVjQ4Eh9z9pmmtaq8nTjZjQwKFk7YIHIud3lRoKRBgUQjgjRmoGxxGEPXQkF+lH7QkHJRNr5F4aBgYCW0lqpQ==}
     dependencies:
       '@types/estree': 1.0.1
       '@types/json-schema': 7.0.12
@@ -1201,8 +1201,8 @@ packages:
     dev: false
     optional: true
 
-  /@types/node@20.2.5:
-    resolution: {integrity: sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==}
+  /@types/node@20.3.1:
+    resolution: {integrity: sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -1257,14 +1257,14 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@volar/kit@1.7.4(typescript@5.0.4):
+  /@volar/kit@1.7.4(typescript@5.1.3):
     resolution: {integrity: sha512-LWN08tMYVm181rIztyqp+Qx6efv37w5/kLmAX4R+dr+nn0F/G8Em03TKP81YLOQTzK44EdUaG84Bq95suHcSWw==}
     peerDependencies:
       typescript: '*'
     dependencies:
       '@volar/language-service': 1.7.4
       typesafe-path: 0.2.2
-      typescript: 5.0.4
+      typescript: 5.1.3
       vscode-languageserver-textdocument: 1.0.8
       vscode-uri: 3.0.7
     dev: true
@@ -5587,9 +5587,9 @@ packages:
       semver: 7.5.1
     dev: false
 
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  /typescript@5.1.3:
+    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 
@@ -5683,7 +5683,7 @@ packages:
     dev: false
     optional: true
 
-  /vite-node@0.32.0(@types/node@20.2.5):
+  /vite-node@0.32.0(@types/node@20.3.1):
     resolution: {integrity: sha512-220P/y8YacYAU+daOAqiGEFXx2A8AwjadDzQqos6wSukjvvTWNqleJSwoUn0ckyNdjHIKoxn93Nh1vWBqEKr3Q==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -5693,7 +5693,7 @@ packages:
       mlly: 1.3.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.3.9(@types/node@20.2.5)
+      vite: 4.3.9(@types/node@20.3.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5704,7 +5704,7 @@ packages:
       - terser
     dev: true
 
-  /vite@4.3.9(@types/node@20.2.5):
+  /vite@4.3.9(@types/node@20.3.1):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -5729,7 +5729,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 20.3.1
       esbuild: 0.17.19
       postcss: 8.4.24
       rollup: 3.24.0
@@ -5770,7 +5770,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 20.2.5
+      '@types/node': 20.3.1
       '@vitest/expect': 0.32.0
       '@vitest/runner': 0.32.0
       '@vitest/snapshot': 0.32.0
@@ -5790,8 +5790,8 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.5.0
-      vite: 4.3.9(@types/node@20.2.5)
-      vite-node: 0.32.0(@types/node@20.2.5)
+      vite: 4.3.9(@types/node@20.3.1)
+      vite-node: 0.32.0(@types/node@20.3.1)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Changes:

- https://github.com/microsoft/TypeScript/issues/54630 is not only affected by module types, it is also affected by the `__VLS_componentProps` virtual code that breaks the event type checking, we move `& {}` inside `__VLS_PickNotAny` to fix it.

- Now always respect `vueCompilerOptions.htmlAttributes` (it used to only work when `strictTemplates` was enabled), otherwise valid virtual code for TS 5.1.3 cannot be generated. Since this option reduces virtual code, there may be a little TS performance improvement.