### PR TITLE
feat: redo `nativeTags`

### DIFF
--- a/packages/vue-component-meta/src/index.ts
+++ b/packages/vue-component-meta/src/index.ts
@@ -85,7 +85,7 @@ function createComponentMetaCheckerWorker(
 	};
 
 	return {
-		...baseCreate(_host, parsedCommandLine.vueOptions, checkerOptions, globalComponentName, ts),
+		...baseCreate(_host, vue.resolveVueCompilerOptions(parsedCommandLine.vueOptions), checkerOptions, globalComponentName, ts),
 		updateFile(fileName: string, text: string) {
 			fileName = (fileName as path.OsPath).replace(/\\/g, '/') as path.PosixPath;
 			scriptSnapshots.set(fileName, ts.ScriptSnapshot.fromString(text));
@@ -110,12 +110,11 @@ function createComponentMetaCheckerWorker(
 
 export function baseCreate(
 	_host: vue.TypeScriptLanguageHost,
-	_vueCompilerOptions: Partial<vue.VueCompilerOptions>,
+	vueCompilerOptions: vue.VueCompilerOptions,
 	checkerOptions: MetaCheckerOptions,
 	globalComponentName: string,
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 ) {
-	const vueCompilerOptions = vue.resolveVueCompilerOptions(_vueCompilerOptions);
 	const globalComponentSnapshot = ts.ScriptSnapshot.fromString('<script setup lang="ts"></script>');
 	const metaSnapshots: Record<string, ts.IScriptSnapshot> = {};
 	const host = new Proxy<Partial<vue.TypeScriptLanguageHost>>({

--- a/packages/vue-language-core/schemas/vue-tsconfig.deprecated.schema.json
+++ b/packages/vue-language-core/schemas/vue-tsconfig.deprecated.schema.json
@@ -63,10 +63,6 @@
 				"jsxTemplates": {
 					"deprecated": true,
 					"description": "Deprecated since v1.5.0."
-				},
-				"nativeTags": {
-					"deprecated": true,
-					"description": "Deprecated since v1.5.1."
 				}
 			}
 		}

--- a/packages/vue-language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/vue-language-core/schemas/vue-tsconfig.schema.json
@@ -37,6 +37,15 @@
 					"type": "boolean",
 					"markdownDescription": "https://github.com/vuejs/language-tools/issues/577"
 				},
+				"nativeTags": {
+					"type": "array",
+					"default": [
+						"div",
+						"img",
+						"..."
+					],
+					"markdownDescription": "List of valid intrinsic elements."
+				},
 				"dataAttributes": {
 					"type": "array",
 					"default": [ ],

--- a/packages/vue-language-core/src/types.ts
+++ b/packages/vue-language-core/src/types.ts
@@ -18,6 +18,7 @@ export interface VueCompilerOptions {
 	jsxSlots: boolean;
 	strictTemplates: boolean;
 	skipTemplateCodegen: boolean;
+	nativeTags: string[];
 	dataAttributes: string[];
 	htmlAttributes: string[];
 	optionsWrapper: [string, string] | [];

--- a/packages/vue-language-core/src/utils/ts.ts
+++ b/packages/vue-language-core/src/utils/ts.ts
@@ -201,6 +201,31 @@ function getPartialVueCompilerOptions(
 	}
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+const HTML_TAGS =
+	'html,body,base,head,link,meta,style,title,address,article,aside,footer,' +
+	'header,hgroup,h1,h2,h3,h4,h5,h6,nav,section,div,dd,dl,dt,figcaption,' +
+	'figure,picture,hr,img,li,main,ol,p,pre,ul,a,b,abbr,bdi,bdo,br,cite,code,' +
+	'data,dfn,em,i,kbd,mark,q,rp,rt,ruby,s,samp,small,span,strong,sub,sup,' +
+	'time,u,var,wbr,area,audio,map,track,video,embed,object,param,source,' +
+	'canvas,script,noscript,del,ins,caption,col,colgroup,table,thead,tbody,td,' +
+	'th,tr,button,datalist,fieldset,form,input,label,legend,meter,optgroup,' +
+	'option,output,progress,select,textarea,details,dialog,menu,' +
+	'summary,template,blockquote,iframe,tfoot';
+
+// https://developer.mozilla.org/en-US/docs/Web/SVG/Element
+const SVG_TAGS =
+	'svg,animate,animateMotion,animateTransform,circle,clipPath,color-profile,' +
+	'defs,desc,discard,ellipse,feBlend,feColorMatrix,feComponentTransfer,' +
+	'feComposite,feConvolveMatrix,feDiffuseLighting,feDisplacementMap,' +
+	'feDistanceLight,feDropShadow,feFlood,feFuncA,feFuncB,feFuncG,feFuncR,' +
+	'feGaussianBlur,feImage,feMerge,feMergeNode,feMorphology,feOffset,' +
+	'fePointLight,feSpecularLighting,feSpotLight,feTile,feTurbulence,filter,' +
+	'foreignObject,g,hatch,hatchpath,image,line,linearGradient,marker,mask,' +
+	'mesh,meshgradient,meshpatch,meshrow,metadata,mpath,path,pattern,' +
+	'polygon,polyline,radialGradient,rect,set,solidcolor,stop,switch,symbol,' +
+	'text,textPath,title,tspan,unknown,use,view';
+
 export function resolveVueCompilerOptions(vueOptions: Partial<VueCompilerOptions>): VueCompilerOptions {
 	const target = vueOptions.target ?? 3.3;
 	const lib = vueOptions.lib || (target < 2.7 ? '@vue/runtime-dom' : 'vue');
@@ -212,6 +237,14 @@ export function resolveVueCompilerOptions(vueOptions: Partial<VueCompilerOptions
 		jsxSlots: vueOptions.jsxSlots ?? false,
 		strictTemplates: vueOptions.strictTemplates ?? false,
 		skipTemplateCodegen: vueOptions.skipTemplateCodegen ?? false,
+		nativeTags: vueOptions.nativeTags ?? [...new Set([
+			...HTML_TAGS.split(','),
+			...SVG_TAGS.split(','),
+			// fix https://github.com/johnsoncodehk/volar/issues/1340
+			'hgroup',
+			'slot',
+			'component',
+		])],
 		dataAttributes: vueOptions.dataAttributes ?? [],
 		htmlAttributes: vueOptions.htmlAttributes ?? ['aria-*'],
 		optionsWrapper: vueOptions.optionsWrapper ?? (

--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -97,7 +97,7 @@ function resolvePlugins(
 
 								// fix #2458
 								if (source) {
-									casing ??= await getNameCasing(ts, _context, _context.env.fileNameToUri(source.fileName));
+									casing ??= await getNameCasing(ts, _context, _context.env.fileNameToUri(source.fileName), vueCompilerOptions);
 									if (casing.tag === TagNameCasing.Kebab) {
 										for (const item of result.items) {
 											item.filterText = hyphenate(item.filterText ?? item.label);
@@ -149,7 +149,7 @@ function resolvePlugins(
 						item.textEdit.newText = newName;
 						const source = _context.documents.getVirtualFileByUri(itemData.uri)[1];
 						if (source) {
-							const casing = await getNameCasing(ts, _context, _context.env.fileNameToUri(source.fileName));
+							const casing = await getNameCasing(ts, _context, _context.env.fileNameToUri(source.fileName), vueCompilerOptions);
 							if (casing.tag === TagNameCasing.Kebab) {
 								item.textEdit.newText = hyphenate(item.textEdit.newText);
 							}


### PR DESCRIPTION
close #3148

This PR is a rollback of #2685.

After confirmation, #3259 does not solve #3148. It seems that it is necessary to generate more efficient virtual code through the nativeTags of hard code, instead of entrusting the work of judging IntrinsicElements to TS.

This also fixed the regression introduced by #3259.

cc @ModyQyW