### PR TITLE
test: move the test for #2726 in strict-template directory

### DIFF
--- a/packages/vue-test-workspace/vue-tsc/strict-template/#2726/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/strict-template/#2726/main.vue
@@ -1,5 +1,3 @@
-<!-- TODO: This problem only happens when strictTemplates is enabled -->
-
 <script lang="ts" setup>
 import { ref } from 'vue';
 


### PR DESCRIPTION
Moved the test for #2726 to `strict-template` directory as there was a TODO comment.