### PR TITLE
chore: remove serverStats command from package.json of VSCode extension

### DIFF
--- a/packages/vscode-vue/package.json
+++ b/packages/vscode-vue/package.json
@@ -611,11 +611,6 @@
 				"category": "Volar (Debug)"
 			},
 			{
-				"command": "volar.action.serverStats",
-				"title": "Server Stats",
-				"category": "Volar (Debug)"
-			},
-			{
 				"command": "volar.action.showComponentMeta",
 				"title": "Show Component Meta",
 				"category": "Volar"


### PR DESCRIPTION
Removed previously deleted feature commands that remained in contributes.commands of the VSCode extension.