### PR TITLE
test: change defineComponent to support JSX

### DIFF
--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -732,6 +732,27 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) => describ
 
 		expect(meta.type).toEqual(TypeMeta.Unknown);
 	});
+
+	test('ts-component.tsx', () => {
+		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/ts-component/component.tsx');
+		const meta = checker.getComponentMeta(componentPath);
+
+		expect(meta.type).toEqual(TypeMeta.Function);
+
+		const a = meta.props.find(prop =>
+			prop.name === 'foo'
+			&& prop.required === true
+			&& prop.type === 'string'
+		);
+		const b = meta.props.find(prop =>
+			prop.name === 'bar'
+			&& prop.required === false
+			&& prop.type === 'number | undefined'
+		);
+
+		expect(a).toBeDefined();
+		expect(b).toBeDefined();
+	});
 });
 
 const checkerOptions: MetaCheckerOptions = {

--- a/packages/vue-test-workspace/vue-component-meta/ts-component/component.ts
+++ b/packages/vue-test-workspace/vue-component-meta/ts-component/component.ts
@@ -2,5 +2,5 @@ import { h, defineComponent } from "vue";
 import { MyProps } from "./PropDefinitions";
 
 export default defineComponent((props: MyProps) => {
-	return h('pre', JSON.stringify(props, null, 2));
+	return () => h('pre', JSON.stringify(props, null, 2));
 });

--- a/packages/vue-test-workspace/vue-component-meta/ts-component/component.tsx
+++ b/packages/vue-test-workspace/vue-component-meta/ts-component/component.tsx
@@ -1,0 +1,8 @@
+import { defineComponent } from "vue";
+import { MyProps } from "./PropDefinitions";
+
+export default defineComponent((props: MyProps) => {
+	return () => <pre>
+		{JSON.stringify(props, null, 2)}
+	</pre>;
+});

--- a/packages/vue-test-workspace/vue-component-meta/ts-named-export/component.ts
+++ b/packages/vue-test-workspace/vue-component-meta/ts-named-export/component.ts
@@ -1,5 +1,5 @@
 import { defineComponent } from "vue";
 
-export const Foo = defineComponent((_: { foo: string; }) => { });
+export const Foo = defineComponent((_: { foo: string; }) => ()=> { });
 
-export const Bar = defineComponent((_: { bar?: number; }) => { });
+export const Bar = defineComponent((_: { bar?: number; }) => ()=> { });


### PR DESCRIPTION
Function Signature [​](https://vuejs.org/api/general.html#function-signature)

defineComponent() also has an alternative signature that is meant to be used with Composition API and [render functions or JSX](https://vuejs.org/guide/extras/render-function.html).

so I changed the test to match the new API and added test for JSX based component

```ts
// options syntax
function defineComponent(
  component: ComponentOptions
): ComponentConstructor

// function syntax (requires 3.3+)
function defineComponent(
  setup: ComponentOptions['setup'],
  extraOptions?: ComponentOptions
): () => any
```