### PR TITLE
Deprecate language server `json.customBlockSchemaUrls` option

### DIFF
--- a/packages/vscode-vue/package.json
+++ b/packages/vscode-vue/package.json
@@ -426,9 +426,6 @@
 					"type": "boolean",
 					"default": false
 				},
-				"vue.server.json.customBlockSchemaUrls": {
-					"type": "object"
-				},
 				"vue.server.diagnosticModel": {
 					"type": "string",
 					"default": "push",

--- a/packages/vscode-vue/src/common.ts
+++ b/packages/vscode-vue/src/common.ts
@@ -214,11 +214,7 @@ async function getInitializationOptions(
 			tokenTypes: ['component'],
 			tokenModifiers: [],
 		};
-	options.fullCompletionList = config.server.fullCompletionList,
-		// vue
-		options.json = {
-			customBlockSchemaUrls: config.server.json.customBlockSchemaUrls,
-		};
+	options.fullCompletionList = config.server.fullCompletionList;
 	options.additionalExtensions = [
 		...config.server.additionalExtensions,
 		...!config.server.petiteVue.supportHtmlFile ? [] : ['html'],

--- a/packages/vscode-vue/src/config.ts
+++ b/packages/vscode-vue/src/config.ts
@@ -29,9 +29,6 @@ export const config = {
 		petiteVue: {
 			supportHtmlFile: boolean;
 		};
-		json: {
-			customBlockSchemaUrls: Record<string, string>;
-		};
 	}> {
 		return _config().get('server')!;
 	},

--- a/packages/vue-language-server/src/languageServerPlugin.ts
+++ b/packages/vue-language-server/src/languageServerPlugin.ts
@@ -35,7 +35,6 @@ export function createServerPlugin(connection: Connection) {
 			async resolveConfig(config, ctx) {
 
 				const vueOptions = await getVueCompilerOptions();
-				const vueLanguageServiceSettings = getVueLanguageServiceSettings();
 
 				if (ctx) {
 					hostToVueOptions.set(ctx.host, vue.resolveVueCompilerOptions(vueOptions));
@@ -46,7 +45,6 @@ export function createServerPlugin(connection: Connection) {
 					ctx?.host.getCompilationSettings() ?? {},
 					vueOptions,
 					ts,
-					vueLanguageServiceSettings,
 					initOptions.codegenStack,
 				);
 
@@ -80,24 +78,6 @@ export function createServerPlugin(connection: Connection) {
 					vueOptions.extensions = [...new Set(vueOptions.extensions)];
 
 					return vueOptions;
-				}
-
-				function getVueLanguageServiceSettings() {
-
-					const settings: vue.Settings = {};
-
-					if (initOptions.json && ctx) {
-						settings.json = { schemas: [] };
-						for (const blockType in initOptions.json.customBlockSchemaUrls) {
-							const url = initOptions.json.customBlockSchemaUrls[blockType];
-							settings.json.schemas?.push({
-								fileMatch: [`*.customBlock_${blockType}_*.json*`],
-								uri: new URL(url, ctx.project.rootUri.toString() + '/').toString(),
-							});
-						}
-					}
-
-					return settings;
 				}
 			},
 			onInitialized(getService, env) {

--- a/packages/vue-language-server/src/types.ts
+++ b/packages/vue-language-server/src/types.ts
@@ -1,9 +1,6 @@
 import { InitializationOptions } from "@volar/language-server";
 
 export type VueServerInitializationOptions = InitializationOptions & {
-	json?: {
-		customBlockSchemaUrls?: Record<string, string>;
-	};
 	/**
 	 * @example ['vue1', 'vue2']
 	 */

--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -34,7 +34,6 @@ export function resolveConfig(
 	compilerOptions: ts.CompilerOptions = {},
 	vueCompilerOptions: Partial<vue.VueCompilerOptions> = {},
 	ts: typeof import('typescript/lib/tsserverlibrary') = require('typescript'),
-	settings?: Settings,
 	codegenStack: boolean = false,
 ) {
 
@@ -42,7 +41,7 @@ export function resolveConfig(
 	const vueLanguageModules = vue.createLanguages(compilerOptions, resolvedVueCompilerOptions, ts, codegenStack);
 
 	config.languages = Object.assign({}, vueLanguageModules, config.languages);
-	config.services = resolvePlugins(config.services, resolvedVueCompilerOptions, settings);
+	config.services = resolvePlugins(config.services, resolvedVueCompilerOptions);
 
 	return config;
 }
@@ -52,7 +51,6 @@ const unicodeReg = /\\u/g;
 function resolvePlugins(
 	services: Config['services'],
 	vueCompilerOptions: VueCompilerOptions,
-	settings?: Settings,
 ) {
 
 	const originalTsPlugin: Service = services?.typescript ?? createTsService();
@@ -284,7 +282,7 @@ function resolvePlugins(
 	services.vue ??= createVueService();
 	services.css ??= createCssService();
 	services['pug-beautify'] ??= createPugFormatService();
-	services.json ??= createJsonService(settings?.json);
+	services.json ??= createJsonService();
 	services['typescript/twoslash-queries'] ??= createTsTqService();
 	services['vue/referencesCodeLens'] ??= createReferencesCodeLensService();
 	services['vue/autoInsertDotValue'] ??= createAutoDotValueService();


### PR DESCRIPTION
We added `json.customBlockSchemaUrls` in [1.0.10](https://github.com/vuejs/language-tools/blob/master/CHANGELOG.md#1010-20221129) to solve a specific use case, but after Some time it is considered impractical now, the same problem can be solved through Volar's Services API.