### PR TITLE
Do not hide output channel on server restart :rocket:

### DIFF
--- a/packages/vscode-vue/src/nodeClientMain.ts
+++ b/packages/vscode-vue/src/nodeClientMain.ts
@@ -35,6 +35,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		documentSelector,
 		initOptions,
 		port,
+		outputChannel
 	) => {
 
 		initOptions.cancellationPipeName = cancellationPipeName;
@@ -92,6 +93,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			middleware,
 			documentSelector: documentSelector,
 			initializationOptions: initOptions,
+			outputChannel
 		};
 		const client = new _LanguageClient(
 			id,


### PR DESCRIPTION
Since output channels are created automatically right now, when you restart server, opened output channel disappears and you have to find it again... Right there is no api in vscode to focus specific output channel :(
