### PR TITLE
chore: support custom configPath for createParsedCommandLineByJson

### DIFF
--- a/packages/vue-language-core/src/utils/ts.ts
+++ b/packages/vue-language-core/src/utils/ts.ts
@@ -11,10 +11,11 @@ export function createParsedCommandLineByJson(
 	parseConfigHost: ts.ParseConfigHost,
 	rootDir: string,
 	json: any,
+	configPath = rootDir + '/jsconfig.json'
 ): ParsedCommandLine {
 
 	const proxyHost = proxyParseConfigHostForExtendConfigPaths(parseConfigHost);
-	ts.parseJsonConfigFileContent(json, proxyHost.host, rootDir, {}, rootDir + '/jsconfig.json');
+	ts.parseJsonConfigFileContent(json, proxyHost.host, rootDir, {}, configPath);
 
 	let vueOptions: Partial<VueCompilerOptions> = {};
 

--- a/packages/vue-language-core/src/utils/ts.ts
+++ b/packages/vue-language-core/src/utils/ts.ts
@@ -11,11 +11,11 @@ export function createParsedCommandLineByJson(
 	parseConfigHost: ts.ParseConfigHost,
 	rootDir: string,
 	json: any,
-	configPath = rootDir + '/jsconfig.json'
+	configFileName = rootDir + '/jsconfig.json'
 ): ParsedCommandLine {
 
 	const proxyHost = proxyParseConfigHostForExtendConfigPaths(parseConfigHost);
-	ts.parseJsonConfigFileContent(json, proxyHost.host, rootDir, {}, configPath);
+	ts.parseJsonConfigFileContent(json, proxyHost.host, rootDir, {}, configFileName);
 
 	let vueOptions: Partial<VueCompilerOptions> = {};
 
@@ -33,7 +33,7 @@ export function createParsedCommandLineByJson(
 		proxyHost.host,
 		rootDir,
 		{},
-		configPath,
+		configFileName,
 		undefined,
 		(vueOptions.extensions ?? ['.vue']).map(extension => ({
 			extension: extension.slice(1),

--- a/packages/vue-language-core/src/utils/ts.ts
+++ b/packages/vue-language-core/src/utils/ts.ts
@@ -33,7 +33,7 @@ export function createParsedCommandLineByJson(
 		proxyHost.host,
 		rootDir,
 		{},
-		rootDir + '/jsconfig.json',
+		configPath,
 		undefined,
 		(vueOptions.extensions ?? ['.vue']).map(extension => ({
 			extension: extension.slice(1),


### PR DESCRIPTION
I want to parse config content after overriding and I found two methods: `createParsedCommandLine` and `createParsedCommandLineByJson`.

`createParsedCommandLine` parse config via path and cannot specify the config content.

`createParsedCommandLineByJson` will always set config path to `rootDir + '/jsconfig.json'`.

So it would be great if `createParsedCommandLineByJson` can support custom config path.