### PR TITLE
doc: fix typo

### DIFF
--- a/packages/vscode-typescript-vue-plugin/README.md
+++ b/packages/vscode-typescript-vue-plugin/README.md
@@ -10,7 +10,7 @@ This plugin proxies TS server requests to provide some extra functionality:
 
 - When finding references in *.ts files, you also get results from *.vue files.
 - When renaming in *.ts files, references on *.vue files also get adjusted.
-- When typing import statements, .vue* files will also appear for autocompletion.
+- When typing import statements, *.vue files will also appear for autocompletion.
 - (And some extra details most people don't need to know...)
 
 ## Sponsors


### PR DESCRIPTION
".vue*" => "*.vue"