### PR TITLE
fix: should generate code for slots that uses `v-else-if` and `v-else` directives

### DIFF
--- a/packages/vue-test-workspace/vue-tsc/non-strict-template/#3466/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/non-strict-template/#3466/main.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-const foo = true;
+const fooooooooooooooooo = true;
 </script>
 
 <template>
   <Comp>
-    <template v-if="true" #foo />
-    <template v-else-if="foo" #bar />
+    <template v-if="1" #foo />
+    <template v-else-if="fooooooooooooooooo" #bar />
   </Comp>
 </template>

--- a/packages/vue-test-workspace/vue-tsc/non-strict-template/#3466/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/non-strict-template/#3466/main.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+const foo = true;
+</script>
+
+<template>
+  <Comp>
+    <template v-if="true" #foo />
+    <template v-else-if="foo" #bar />
+  </Comp>
+</template>

--- a/packages/vue-test-workspace/vue-tsc/non-strict-template/#3466/tsconfig.json
+++ b/packages/vue-test-workspace/vue-tsc/non-strict-template/#3466/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": true
+	}
+}


### PR DESCRIPTION
close #3466