### PR TITLE
refactor: Removing `__VLS_types.d.ts`

### DIFF
--- a/packages/vue-language-core/src/plugins/vue-tsx.ts
+++ b/packages/vue-language-core/src/plugins/vue-tsx.ts
@@ -23,9 +23,9 @@ const plugin: VueLanguagePlugin = (ctx) => {
 			'exactOptionalPropertyTypes',
 		],
 
-		getEmbeddedFileNames(fileName, sfc) {
+		getEmbeddedFileNames(fileName, sfc, vueFile) {
 
-			const tsx = useTsx(fileName, sfc);
+			const tsx = useTsx(fileName, sfc, vueFile.withGlobalTypes);
 			const fileNames: string[] = [];
 
 			if (['js', 'ts', 'jsx', 'tsx'].includes(tsx.lang.value)) {
@@ -40,9 +40,9 @@ const plugin: VueLanguagePlugin = (ctx) => {
 			return fileNames;
 		},
 
-		resolveEmbeddedFile(fileName, sfc, embeddedFile) {
+		resolveEmbeddedFile(fileName, sfc, embeddedFile, vueFile) {
 
-			const _tsx = useTsx(fileName, sfc);
+			const _tsx = useTsx(fileName, sfc, vueFile.withGlobalTypes);
 			const suffix = embeddedFile.fileName.replace(fileName, '');
 
 			if (suffix === '.' + _tsx.lang.value) {
@@ -109,9 +109,9 @@ const plugin: VueLanguagePlugin = (ctx) => {
 		},
 	};
 
-	function useTsx(fileName: string, sfc: Sfc) {
+	function useTsx(fileName: string, sfc: Sfc, withGlobalTypes: boolean) {
 		if (!tsCodegen.has(sfc)) {
-			tsCodegen.set(sfc, createTsx(fileName, sfc, ctx));
+			tsCodegen.set(sfc, createTsx(fileName, sfc, ctx, withGlobalTypes));
 		}
 		return tsCodegen.get(sfc)!;
 	}
@@ -119,7 +119,12 @@ const plugin: VueLanguagePlugin = (ctx) => {
 
 export default plugin;
 
-function createTsx(fileName: string, _sfc: Sfc, { vueCompilerOptions, compilerOptions, codegenStack, modules }: Parameters<VueLanguagePlugin>[0]) {
+function createTsx(
+	fileName: string,
+	_sfc: Sfc,
+	{ vueCompilerOptions, compilerOptions, codegenStack, modules }: Parameters<VueLanguagePlugin>[0],
+	withGlobalTypes: boolean
+) {
 
 	const ts = modules.typescript;
 	const lang = computed(() => {
@@ -168,6 +173,7 @@ function createTsx(fileName: string, _sfc: Sfc, { vueCompilerOptions, compilerOp
 			compilerOptions,
 			vueCompilerOptions,
 			codegenStack,
+			withGlobalTypes,
 		);
 	});
 

--- a/packages/vue-language-core/src/sourceFile.ts
+++ b/packages/vue-language-core/src/sourceFile.ts
@@ -201,7 +201,7 @@ export class VueFile implements VirtualFile {
 		const files = computed(() => {
 			try {
 				if (plugin.getEmbeddedFileNames) {
-					const embeddedFileNames = plugin.getEmbeddedFileNames(this.fileName, this.sfc);
+					const embeddedFileNames = plugin.getEmbeddedFileNames(this.fileName, this.sfc, this);
 					for (const oldFileName of Object.keys(embeddedFiles)) {
 						if (!embeddedFileNames.includes(oldFileName)) {
 							delete embeddedFiles[oldFileName];
@@ -215,7 +215,7 @@ export class VueFile implements VirtualFile {
 								for (const plugin of this.plugins) {
 									if (plugin.resolveEmbeddedFile) {
 										try {
-											plugin.resolveEmbeddedFile(this.fileName, this.sfc, file);
+											plugin.resolveEmbeddedFile(this.fileName, this.sfc, file, this);
 										}
 										catch (e) {
 											console.error(e);
@@ -394,6 +394,7 @@ export class VueFile implements VirtualFile {
 		public plugins: ReturnType<VueLanguagePlugin>[],
 		public ts: typeof import('typescript/lib/tsserverlibrary'),
 		public codegenStack: boolean,
+		public withGlobalTypes: boolean,
 	) {
 		this.onUpdate();
 	}

--- a/packages/vue-language-core/src/types.ts
+++ b/packages/vue-language-core/src/types.ts
@@ -2,7 +2,7 @@ import type { SFCParseResult } from '@vue/compiler-sfc';
 
 import type * as CompilerDOM from '@vue/compiler-dom';
 import type * as ts from 'typescript/lib/tsserverlibrary';
-import { VueEmbeddedFile } from './sourceFile';
+import { VueEmbeddedFile, VueFile } from './sourceFile';
 
 export type { SFCParseResult } from '@vue/compiler-sfc';
 
@@ -58,8 +58,8 @@ export type VueLanguagePlugin = (ctx: {
 	resolveTemplateCompilerOptions?(options: CompilerDOM.CompilerOptions): CompilerDOM.CompilerOptions;
 	compileSFCTemplate?(lang: string, template: string, options: CompilerDOM.CompilerOptions): CompilerDOM.CodegenResult | undefined;
 	updateSFCTemplate?(oldResult: CompilerDOM.CodegenResult, textChange: { start: number, end: number, newText: string; }): CompilerDOM.CodegenResult | undefined;
-	getEmbeddedFileNames?(fileName: string, sfc: Sfc): string[];
-	resolveEmbeddedFile?(fileName: string, sfc: Sfc, embeddedFile: VueEmbeddedFile): void;
+	getEmbeddedFileNames?(fileName: string, sfc: Sfc, vueFile: VueFile): string[];
+	resolveEmbeddedFile?(fileName: string, sfc: Sfc, embeddedFile: VueEmbeddedFile, vueFile: VueFile): void;
 };
 
 export interface SfcBlock {

--- a/packages/vue-language-core/src/utils/globalTypes.ts
+++ b/packages/vue-language-core/src/utils/globalTypes.ts
@@ -1,127 +1,125 @@
 import { VueCompilerOptions } from '../types';
 import { getSlotsPropertyName } from './shared';
 
-export const baseName = '__VLS_types.d.ts';
-
-export function getTypesCode(vueCompilerOptions: VueCompilerOptions) {
+export function geneateGlobalTypes(vueCompilerOptions: VueCompilerOptions) {
 	return `
-// @ts-nocheck
+declare global {
+	type __VLS_IntrinsicElements = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.IntrinsicElements, __VLS_PickNotAny<JSX.IntrinsicElements, Record<string, any>>>;
+	type __VLS_Element = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.Element, JSX.Element>;
 
-type __VLS_IntrinsicElements = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.IntrinsicElements, __VLS_PickNotAny<JSX.IntrinsicElements, Record<string, any>>>;
-type __VLS_Element = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.Element, JSX.Element>;
+	type __VLS_IsAny<T> = 0 extends 1 & T ? true : false;
+	type __VLS_PickNotAny<A, B> = __VLS_IsAny<A> extends true ? B : A;
 
-type __VLS_IsAny<T> = 0 extends 1 & T ? true : false;
-type __VLS_PickNotAny<A, B> = __VLS_IsAny<A> extends true ? B : A;
+	type __VLS_Prettify<T> = {
+		[K in keyof T]: T[K];
+	} & {};
 
-type __VLS_Prettify<T> = {
-	[K in keyof T]: T[K];
-} & {};
+	type __VLS_GlobalComponents =
+		__VLS_PickNotAny<import('vue').GlobalComponents, {}>
+		& __VLS_PickNotAny<import('@vue/runtime-core').GlobalComponents, {}>
+		& __VLS_PickNotAny<import('@vue/runtime-dom').GlobalComponents, {}>
+		& Pick<typeof import('${vueCompilerOptions.lib}'),
+			'Transition'
+			| 'TransitionGroup'
+			| 'KeepAlive'
+			| 'Suspense'
+			| 'Teleport'
+		>;
 
-type __VLS_GlobalComponents =
-	__VLS_PickNotAny<import('vue').GlobalComponents, {}>
-	& __VLS_PickNotAny<import('@vue/runtime-core').GlobalComponents, {}>
-	& __VLS_PickNotAny<import('@vue/runtime-dom').GlobalComponents, {}>
-	& Pick<typeof import('${vueCompilerOptions.lib}'),
-		'Transition'
-		| 'TransitionGroup'
-		| 'KeepAlive'
-		| 'Suspense'
-		| 'Teleport'
+	// v-for
+	function __VLS_getVForSourceType(source: number): [number, number, number][];
+	function __VLS_getVForSourceType(source: string): [string, number, number][];
+	function __VLS_getVForSourceType<T extends any[]>(source: T): [
+		T[number], // item
+		number, // key
+		number, // index
+	][];
+	function __VLS_getVForSourceType<T extends { [Symbol.iterator](): Iterator<any> }>(source: T): [
+		T extends { [Symbol.iterator](): Iterator<infer T1> } ? T1 : never, // item 
+		number, // key
+		undefined, // index
+	][];
+	function __VLS_getVForSourceType<T>(source: T): [
+		T[keyof T], // item
+		keyof T, // key
+		number, // index
+	][];
+
+	function __VLS_getSlotParams<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>;
+	function __VLS_getSlotParam<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>[0];
+	function __VLS_directiveFunction<T>(dir: T):
+		T extends import('${vueCompilerOptions.lib}').ObjectDirective<infer E, infer V> | import('${vueCompilerOptions.lib}').FunctionDirective<infer E, infer V> ? (value: V) => void
+		: T;
+	function __VLS_withScope<T, K>(ctx: T, scope: K): ctx is T & K;
+	function __VLS_makeOptional<T>(t: T): { [K in keyof T]?: T[K] };
+
+	type __VLS_SelfComponent<N, C> = string extends N ? {} : N extends string ? { [P in N]: C } : {};
+	type __VLS_WithComponent<N0 extends string, LocalComponents, N1 extends string, N2 extends string, N3 extends string> =
+		N1 extends keyof LocalComponents ? N1 extends N0 ? Pick<LocalComponents, N0> : { [K in N0]: LocalComponents[N1] } :
+		N2 extends keyof LocalComponents ? N2 extends N0 ? Pick<LocalComponents, N0> : { [K in N0]: LocalComponents[N2] } :
+		N3 extends keyof LocalComponents ? N3 extends N0 ? Pick<LocalComponents, N0> : { [K in N0]: LocalComponents[N3] } :
+		N1 extends keyof __VLS_GlobalComponents ? N1 extends N0 ? Pick<__VLS_GlobalComponents, N0> : { [K in N0]: __VLS_GlobalComponents[N1] } :
+		N2 extends keyof __VLS_GlobalComponents ? N2 extends N0 ? Pick<__VLS_GlobalComponents, N0> : { [K in N0]: __VLS_GlobalComponents[N2] } :
+		N3 extends keyof __VLS_GlobalComponents ? N3 extends N0 ? Pick<__VLS_GlobalComponents, N0> : { [K in N0]: __VLS_GlobalComponents[N3] } :
+		${vueCompilerOptions.strictTemplates ? '{}' : '{ [K in N0]: unknown }'}
+
+	type __VLS_FillingEventArg_ParametersLength<E extends (...args: any) => any> = __VLS_IsAny<Parameters<E>> extends true ? -1 : Parameters<E>['length'];
+	type __VLS_FillingEventArg<E> = E extends (...args: any) => any ? __VLS_FillingEventArg_ParametersLength<E> extends 0 ? ($event?: undefined) => ReturnType<E> : E : E;
+	type __VLS_EmitEvent<F, E> =
+		F extends {
+			(event: E, ...payload: infer P): any
+		} ? (...payload: P) => void
+		: F extends {
+			(event: E, ...payload: infer P): any
+			(...args: any): any
+		} ? (...payload: P) => void
+		: F extends {
+			(event: E, ...payload: infer P): any
+			(...args: any): any
+			(...args: any): any
+		} ? (...payload: P) => void
+		: F extends {
+			(event: E, ...payload: infer P): any
+			(...args: any): any
+			(...args: any): any
+			(...args: any): any
+		} ? (...payload: P) => void
+		: unknown | '[Type Warning] Volar could not infer $emit event more than 4 overloads without DefineComponent. see https://github.com/vuejs/language-tools/issues/60';
+	function __VLS_asFunctionalComponent<T, K = T extends new (...args: any) => any ? InstanceType<T> : unknown>(t: T, instance?: K):
+		T extends new (...args: any) => any
+		? (props: (K extends { $props: infer Props } ? Props : any)${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'}, ctx?: {
+			attrs?: any,
+			slots?: K extends { ${getSlotsPropertyName(vueCompilerOptions.target)}: infer Slots } ? Slots : any,
+			emit?: K extends { $emit: infer Emit } ? Emit : any
+		}) => JSX.Element & { __ctx?: typeof ctx & { props?: typeof props; expose?(exposed: K): void; } }
+		: T extends () => any ? (props: {}, ctx?: any) => ReturnType<T>
+		: T extends (...args: any) => any ? T
+		: (_: T extends import('${vueCompilerOptions.lib}').VNode | import('${vueCompilerOptions.lib}').VNode[] | string ? {}: T${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'}, ctx?: any) => { __ctx?: { attrs?: any, expose?: any, slots?: any, emit?: any, props?: T${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'} } }; // IntrinsicElement
+	function __VLS_functionalComponentArgsRest<T extends (...args: any) => any>(t: T): Parameters<T>['length'] extends 2 ? [any] : [];
+	function __VLS_pickEvent<Emit, K, E>(emit: Emit, emitKey: K, event: E): __VLS_FillingEventArg<
+		__VLS_PickNotAny<
+			__VLS_AsFunctionOrAny<E>,
+			__VLS_AsFunctionOrAny<__VLS_EmitEvent<Emit, K>>
+		>
+	> | undefined;
+	function __VLS_pickFunctionalComponentCtx<T, K>(comp: T, compInstance: K): __VLS_PickNotAny<
+		K extends { __ctx?: infer Ctx } ? Ctx : any,
+		T extends (props: any, ctx: infer Ctx) => any ? Ctx : any
 	>;
+	type __VLS_AsFunctionOrAny<F> = unknown extends F ? any : ((...args: any) => any) extends F ? F : any;
 
-// v-for
-declare function __VLS_getVForSourceType(source: number): [number, number, number][];
-declare function __VLS_getVForSourceType(source: string): [string, number, number][];
-declare function __VLS_getVForSourceType<T extends any[]>(source: T): [
-	T[number], // item
-	number, // key
-	number, // index
-][];
-declare function __VLS_getVForSourceType<T extends { [Symbol.iterator](): Iterator<any> }>(source: T): [
-	T extends { [Symbol.iterator](): Iterator<infer T1> } ? T1 : never, // item 
-	number, // key
-	undefined, // index
-][];
-declare function __VLS_getVForSourceType<T>(source: T): [
-	T[keyof T], // item
-	keyof T, // key
-	number, // index
-][];
-
-declare function __VLS_getSlotParams<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>;
-declare function __VLS_getSlotParam<T>(slot: T): Parameters<__VLS_PickNotAny<NonNullable<T>, (...args: any[]) => any>>[0];
-declare function __VLS_directiveFunction<T>(dir: T):
-	T extends import('${vueCompilerOptions.lib}').ObjectDirective<infer E, infer V> | import('${vueCompilerOptions.lib}').FunctionDirective<infer E, infer V> ? (value: V) => void
-	: T;
-declare function __VLS_withScope<T, K>(ctx: T, scope: K): ctx is T & K;
-declare function __VLS_makeOptional<T>(t: T): { [K in keyof T]?: T[K] };
-
-type __VLS_SelfComponent<N, C> = string extends N ? {} : N extends string ? { [P in N]: C } : {};
-type __VLS_WithComponent<N0 extends string, LocalComponents, N1 extends string, N2 extends string, N3 extends string> =
-	N1 extends keyof LocalComponents ? N1 extends N0 ? Pick<LocalComponents, N0> : { [K in N0]: LocalComponents[N1] } :
-	N2 extends keyof LocalComponents ? N2 extends N0 ? Pick<LocalComponents, N0> : { [K in N0]: LocalComponents[N2] } :
-	N3 extends keyof LocalComponents ? N3 extends N0 ? Pick<LocalComponents, N0> : { [K in N0]: LocalComponents[N3] } :
-	N1 extends keyof __VLS_GlobalComponents ? N1 extends N0 ? Pick<__VLS_GlobalComponents, N0> : { [K in N0]: __VLS_GlobalComponents[N1] } :
-	N2 extends keyof __VLS_GlobalComponents ? N2 extends N0 ? Pick<__VLS_GlobalComponents, N0> : { [K in N0]: __VLS_GlobalComponents[N2] } :
-	N3 extends keyof __VLS_GlobalComponents ? N3 extends N0 ? Pick<__VLS_GlobalComponents, N0> : { [K in N0]: __VLS_GlobalComponents[N3] } :
-	${vueCompilerOptions.strictTemplates ? '{}' : '{ [K in N0]: unknown }'}
-
-type __VLS_FillingEventArg_ParametersLength<E extends (...args: any) => any> = __VLS_IsAny<Parameters<E>> extends true ? -1 : Parameters<E>['length'];
-type __VLS_FillingEventArg<E> = E extends (...args: any) => any ? __VLS_FillingEventArg_ParametersLength<E> extends 0 ? ($event?: undefined) => ReturnType<E> : E : E;
-type __VLS_EmitEvent<F, E> =
-	F extends {
-		(event: E, ...payload: infer P): any
-	} ? (...payload: P) => void
-	: F extends {
-		(event: E, ...payload: infer P): any
-		(...args: any): any
-	} ? (...payload: P) => void
-	: F extends {
-		(event: E, ...payload: infer P): any
-		(...args: any): any
-		(...args: any): any
-	} ? (...payload: P) => void
-	: F extends {
-		(event: E, ...payload: infer P): any
-		(...args: any): any
-		(...args: any): any
-		(...args: any): any
-	} ? (...payload: P) => void
-	: unknown | '[Type Warning] Volar could not infer $emit event more than 4 overloads without DefineComponent. see https://github.com/vuejs/language-tools/issues/60';
-declare function __VLS_asFunctionalComponent<T, K = T extends new (...args: any) => any ? InstanceType<T> : unknown>(t: T, instance?: K):
-	T extends new (...args: any) => any
-	? (props: (K extends { $props: infer Props } ? Props : any)${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'}, ctx?: {
-		attrs?: any,
-		slots?: K extends { ${getSlotsPropertyName(vueCompilerOptions.target)}: infer Slots } ? Slots : any,
-		emit?: K extends { $emit: infer Emit } ? Emit : any
-	}) => JSX.Element & { __ctx?: typeof ctx & { props?: typeof props; expose?(exposed: K): void; } }
-	: T extends () => any ? (props: {}, ctx?: any) => ReturnType<T>
-	: T extends (...args: any) => any ? T
-	: (_: T extends import('${vueCompilerOptions.lib}').VNode | import('${vueCompilerOptions.lib}').VNode[] | string ? {}: T${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'}, ctx?: any) => { __ctx?: { attrs?: any, expose?: any, slots?: any, emit?: any, props?: T${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'} } }; // IntrinsicElement
-declare function __VLS_functionalComponentArgsRest<T extends (...args: any) => any>(t: T): Parameters<T>['length'] extends 2 ? [any] : [];
-declare function __VLS_pickEvent<Emit, K, E>(emit: Emit, emitKey: K, event: E): __VLS_FillingEventArg<
-	__VLS_PickNotAny<
-		__VLS_AsFunctionOrAny<E>,
-		__VLS_AsFunctionOrAny<__VLS_EmitEvent<Emit, K>>
-	>
-> | undefined;
-declare function __VLS_pickFunctionalComponentCtx<T, K>(comp: T, compInstance: K): __VLS_PickNotAny<
-	K extends { __ctx?: infer Ctx } ? Ctx : any,
-	T extends (props: any, ctx: infer Ctx) => any ? Ctx : any
->;
-type __VLS_AsFunctionOrAny<F> = unknown extends F ? any : ((...args: any) => any) extends F ? F : any;
-
-declare function __VLS_normalizeSlot<S>(s: S): S extends () => infer R ? (props: {}) => R : S;
-declare function __VLS_componentProps<T, K>(comp: T, fnReturn: K):
-	__VLS_PickNotAny<K, {}> extends { __ctx: { props: infer P } } ? NonNullable<P>
-	: T extends (props: infer P, ...args: any) => any ? NonNullable<P> :
-	{};
+	function __VLS_normalizeSlot<S>(s: S): S extends () => infer R ? (props: {}) => R : S;
+	function __VLS_componentProps<T, K>(comp: T, fnReturn: K):
+		__VLS_PickNotAny<K, {}> extends { __ctx: { props: infer P } } ? NonNullable<P>
+		: T extends (props: infer P, ...args: any) => any ? NonNullable<P> :
+		{};
+}
 `.trim();
 }
 
 // TODO: not working for overloads > n (n = 8)
 // see: https://github.com/vuejs/language-tools/issues/60
-export function genConstructorOverloads(name = 'ConstructorOverloads', nums?: number) {
+export function generateConstructorOverloads(name = 'ConstructorOverloads', nums?: number) {
 	let code = '';
 	code += `type ${name}<T> =\n`;
 	if (nums === undefined) {

--- a/packages/vue-language-service/src/helpers.ts
+++ b/packages/vue-language-service/src/helpers.ts
@@ -2,7 +2,6 @@ import * as vue from '@vue/language-core';
 import type { CompilerDOM } from '@vue/language-core';
 import * as embedded from '@volar/language-core';
 import { computed, ComputedRef } from '@vue/reactivity';
-import { sharedTypes } from '@vue/language-core';
 import { camelize, capitalize } from '@vue/shared';
 
 import type * as ts from 'typescript/lib/tsserverlibrary';
@@ -175,15 +174,18 @@ export function getComponentNames(
 export function getElementAttrs(
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 	tsLs: ts.LanguageService,
-	tsLsHost: ts.LanguageServiceHost,
+	vueLanguage: vue.VueLanguage,
 	tagName: string,
 ) {
 
-	const sharedTypesFileName = tsLsHost.getCurrentDirectory() + '/' + sharedTypes.baseName;
+	const globalTypesFile = vueLanguage.getGlobalTypesFile();
+	if (!globalTypesFile) {
+		return [];
+	}
 
 	let tsSourceFile: ts.SourceFile | undefined;
 
-	if (tsSourceFile = tsLs.getProgram()?.getSourceFile(sharedTypesFileName)) {
+	if (tsSourceFile = tsLs.getProgram()?.getSourceFile(globalTypesFile.mainScriptName)) {
 
 		const typeNode = tsSourceFile.statements.find((node): node is ts.TypeAliasDeclaration => ts.isTypeAliasDeclaration(node) && node.name.getText() === '__VLS_IntrinsicElements');
 		const checker = tsLs.getProgram()?.getTypeChecker();

--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -1,5 +1,5 @@
 import { Config, Service, ServiceContext } from '@volar/language-service';
-import { VueFile, createLanguages, hyphenateTag, resolveVueCompilerOptions, scriptRanges } from '@vue/language-core';
+import { VueFile, VueLanguage, createLanguages, hyphenateTag, resolveVueCompilerOptions, scriptRanges } from '@vue/language-core';
 import { capitalize } from '@vue/shared';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import type { Data } from 'volar-service-typescript/out/features/completions/basic';
@@ -47,7 +47,7 @@ export function resolveConfig(
 	const vueLanguageModules = createLanguages(compilerOptions, resolvedVueCompilerOptions, ts, codegenStack);
 
 	config.languages = Object.assign({}, vueLanguageModules, config.languages);
-	config.services = resolvePlugins(config.services, resolvedVueCompilerOptions, vueLanguageModules[0] as vue.VueLanguage);
+	config.services = resolvePlugins(config.services, resolvedVueCompilerOptions, vueLanguageModules[0] as VueLanguage);
 
 	return config;
 }
@@ -55,7 +55,7 @@ export function resolveConfig(
 function resolvePlugins(
 	services: Config['services'],
 	vueCompilerOptions: VueCompilerOptions,
-	vueLanguage: vue.VueLanguage,
+	vueLanguage: VueLanguage,
 ) {
 
 	const originalTsPlugin: Service = services?.typescript ?? TsService.create();

--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -47,7 +47,7 @@ export function resolveConfig(
 	const vueLanguageModules = vue.createLanguages(compilerOptions, resolvedVueCompilerOptions, ts, codegenStack);
 
 	config.languages = Object.assign({}, vueLanguageModules, config.languages);
-	config.services = resolvePlugins(config.services, resolvedVueCompilerOptions);
+	config.services = resolvePlugins(config.services, resolvedVueCompilerOptions, vueLanguageModules[0] as vue.VueLanguage);
 
 	return config;
 }
@@ -55,6 +55,7 @@ export function resolveConfig(
 function resolvePlugins(
 	services: Config['services'],
 	vueCompilerOptions: VueCompilerOptions,
+	vueLanguage: vue.VueLanguage,
 ) {
 
 	const originalTsPlugin: Service = services?.typescript ?? TsService.create();
@@ -223,6 +224,7 @@ function resolvePlugins(
 		},
 		isSupportedDocument: (document) => document.languageId === 'html',
 		vueCompilerOptions,
+		vueLanguage,
 	});
 	services.pug ??= VueTemplateLanguageService.create({
 		baseService: PugService.create(),
@@ -237,6 +239,7 @@ function resolvePlugins(
 		},
 		isSupportedDocument: (document) => document.languageId === 'jade',
 		vueCompilerOptions,
+		vueLanguage,
 	});
 	services.vue ??= VueService.create();
 	services.css ??= CssService.create();

--- a/packages/vue-language-service/src/plugins/vue-template.ts
+++ b/packages/vue-language-service/src/plugins/vue-template.ts
@@ -18,6 +18,7 @@ export const create = <S extends Service>(options: {
 	baseService: S,
 	isSupportedDocument: (document: TextDocument) => boolean,
 	vueCompilerOptions: VueCompilerOptions,
+	vueLanguage: vue.VueLanguage,
 }): Service => (_context: ServiceContext<import('volar-service-typescript').Provide> | undefined, modules): ReturnType<Service> => {
 
 	const htmlOrPugService = options.baseService(_context, modules) as ReturnType<S>;
@@ -340,7 +341,6 @@ export const create = <S extends Service>(options: {
 	async function provideHtmlData(map: SourceMapWithDocuments<FileRangeCapabilities>, vueSourceFile: vue.VueFile) {
 
 		const languageService = _context!.inject('typescript/languageService');
-		const languageServiceHost = _context!.inject('typescript/languageServiceHost');
 		const casing = await getNameCasing(ts, _context!, map.sourceFileDocument.uri, options.vueCompilerOptions);
 
 		if (builtInData.tags) {
@@ -409,7 +409,7 @@ export const create = <S extends Service>(options: {
 				},
 				provideAttributes: (tag) => {
 
-					const attrs = getElementAttrs(ts, languageService, languageServiceHost, tag);
+					const attrs = getElementAttrs(ts, languageService, options.vueLanguage, tag);
 					const props = new Set(getPropsByTag(ts, languageService, vueSourceFile, tag, options.vueCompilerOptions));
 					const events = getEventsOfTag(ts, languageService, vueSourceFile, tag, options.vueCompilerOptions);
 					const attributes: html.IAttributeData[] = [];

--- a/packages/vue-language-service/src/plugins/vue-template.ts
+++ b/packages/vue-language-service/src/plugins/vue-template.ts
@@ -1,5 +1,5 @@
 import { FileRangeCapabilities, Service, ServiceContext, SourceMapWithDocuments } from '@volar/language-service';
-import { VueFile, hyphenateAttr, hyphenateTag, parseScriptSetupRanges, tsCodegen } from '@vue/language-core';
+import { VueFile, VueLanguage, hyphenateAttr, hyphenateTag, parseScriptSetupRanges, tsCodegen } from '@vue/language-core';
 import { camelize, capitalize } from '@vue/shared';
 import * as html from 'vscode-html-languageservice';
 import type * as vscode from 'vscode-languageserver-protocol';
@@ -18,7 +18,7 @@ export const create = <S extends Service>(options: {
 	baseService: S,
 	isSupportedDocument: (document: TextDocument) => boolean,
 	vueCompilerOptions: VueCompilerOptions,
-	vueLanguage: vue.VueLanguage,
+	vueLanguage: VueLanguage,
 }): Service => (_context: ServiceContext<import('volar-service-typescript').Provide> | undefined, modules): ReturnType<Service> => {
 
 	const htmlOrPugService = options.baseService(_context, modules) as ReturnType<S>;

--- a/packages/vue-tsc/bin/vue-tsc.js
+++ b/packages/vue-tsc/bin/vue-tsc.js
@@ -24,7 +24,6 @@ fs.readFileSync = (...args) => {
 			tryReplace(
 				`for (const existingRoot of buildInfoVersionMap.roots) {`,
 				`for (const existingRoot of buildInfoVersionMap.roots
-					.filter(file => !file.toLowerCase().includes('__vls_'))
 					.map(file => file.replace(/\.vue\.(j|t)sx?$/i, '.vue'))
 				) {`
 			);
@@ -33,7 +32,6 @@ fs.readFileSync = (...args) => {
 			tryReplace(
 				`return createBuilderProgramUsingProgramBuildInfo(buildInfo, buildInfoPath, host);`,
 				s => `buildInfo.program.fileNames = buildInfo.program.fileNames
-					.filter(file => !file.toLowerCase().includes('__vls_'))
 					.map(file => file.replace(/\.vue\.(j|t)sx?$/i, '.vue'));\n` + s
 			);
 		}


### PR DESCRIPTION
As part of the preparatory work for migrating to ts plugin in 2.0, we cannot use global virtual files because tsserver will crash if the files do not actually exist, and there is no way to bypass this problem.

The solution here is to attach the global types code to one of the virtual vue ts file instead of creating a `__VLS_types.d.ts` file.

- [ ] When the attached file is deleted, it should be attached to another file instead.
- [ ] Simplify implementation
- [ ] Ensure global types are not emitted with `vue-tsc --emit`
- [ ] Considering that VueFile is actually reused across multiple tsconfig projects, it is necessary to ensure that in this case a project does not have multiple VueFiles with global types attached.