### PR TITLE
fix(vue-component-type-helpers): correctly handle generic components when using `ComponentExposed`

### DIFF
--- a/packages/vue-component-type-helpers/index.d.ts
+++ b/packages/vue-component-type-helpers/index.d.ts
@@ -24,7 +24,7 @@ export type ComponentEmit<T> =
 
 export type ComponentExposed<T> =
 	T extends new () => infer E ? E :
-	T extends (props: any, ctx: { expose(exposed: infer E): any; }, ...args: any) => any ? NonNullable<E> :
+	T extends (props: any, ctx: any, expose: (exposed: infer E) => any, ...args: any) => any ? NonNullable<E> :
 	{};
 
 /**

--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -319,6 +319,7 @@ export function generate(
 				`& import('${vueCompilerOptions.lib}').ComponentCustomProps,\n`,
 			);
 			codes.push(`__VLS_ctx?: Pick<Awaited<typeof __VLS_setup>, 'attrs' | 'emit' | 'slots'>,\n`);
+			codes.push(`__VLS_expose?: NonNullable<Awaited<typeof __VLS_setup>>['expose'],\n`);
 			codes.push('__VLS_setup = (async () => {\n');
 			scriptSetupGeneratedOffset = generateSetupFunction(true, 'none', definePropMirrors);
 

--- a/packages/vue-test-workspace/vue-tsc/non-strict-template/components/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/non-strict-template/components/main.vue
@@ -65,6 +65,7 @@ const ScriptSetupDefaultPropsExact = defineComponent({
 declare const ScriptSetupGenericExact: <T, >(
 	_props: NonNullable<Awaited<typeof _setup>>['props'] & import('vue').VNodeProps & import('vue').AllowedComponentProps & import('vue').ComponentCustomProps,
 	_ctx?: Pick<NonNullable<Awaited<typeof _setup>>, 'attrs' | 'emit' | 'slots'>,
+	_expose?: NonNullable<Awaited<typeof _setup>>['expose'],
 	_setup?: Promise<{
 		props: { foo: T } & { [K in keyof JSX.ElementChildrenAttribute]?: { default?(data: T): any } },
 		attrs: any,

--- a/packages/vue-test-workspace/vue-tsc/non-strict-template/defineProp_B/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/non-strict-template/defineProp_B/main.vue
@@ -21,6 +21,7 @@ const ScriptSetupExact = defineComponent({
 declare const ScriptSetupGenericExact: <T, >(
 	_props: NonNullable<Awaited<typeof _setup>>['props'] & import('vue').VNodeProps & import('vue').AllowedComponentProps & import('vue').ComponentCustomProps,
 	_ctx?: Pick<NonNullable<Awaited<typeof _setup>>, 'attrs' | 'emit' | 'slots'>,
+	_expose?: NonNullable<Awaited<typeof _setup>>['expose'],
 	_setup?: Promise<{
 		props: {
 			a?: T | undefined;


### PR DESCRIPTION
close #3206, close vuejs/core#8373