### PR TITLE
fix(vue-tsc): prevent rebuild in incremental mode throwing error

### DIFF
--- a/packages/vue-tsc/bin/vue-tsc.js
+++ b/packages/vue-tsc/bin/vue-tsc.js
@@ -28,6 +28,10 @@ fs.readFileSync = (...args) => {
 					.map(file => file.replace(/\.vue\.(j|t)sx?$/i, '.vue'))
 				) {`
 			);
+			tryReplace(
+				`return [toFileId(key), toFileIdListId(state.exportedModulesMap.getValues(key))];`, 
+				`return [toFileId(key), toFileIdListId(new Set(arrayFrom(state.exportedModulesMap.getValues(key)).filter(file => file !== void 0)))];`
+			);
 		}
 		if (semver.gte(tsPkg.version, '5.0.4')) {
 			tryReplace(


### PR DESCRIPTION
Fix rebuilding in incremental mode with tsbuildinfo file causing error.

Secondary rebuilds cause the following error:

```
Error: Debug Failure. False expression: Paths must either both be absolute or both be relative
```

This is caused because the mapping of the exportedModules looks for `__vls__` file id, but this has been removed in the other patches. This new patch filters this file which is virtual and removes it before mapping. This prevents the error occurring on rebuilds and composite mode. 

resolves: #3345
resolves: #2622