### PR TITLE
fix: generate valid syntax when noPropertyAccessFromIndexSignature is not enabled

### DIFF
--- a/packages/vue-language-core/src/generators/template.ts
+++ b/packages/vue-language-core/src/generators/template.ts
@@ -912,7 +912,7 @@ export function generate(
 							'template',
 							slotDir.arg.loc.start.offset,
 							slotDir.arg.isStatic ? capabilitiesPresets.slotName : capabilitiesPresets.all
-						], slotDir.arg.loc)
+						], false, slotDir.arg.loc)
 						: createPropertyAccessCode([
 							'default',
 							'template',
@@ -1022,7 +1022,7 @@ export function generate(
 								},
 							},
 						},
-					]),
+					], true),
 					`) };\n`,
 					`${eventVar} = {\n`,
 				);
@@ -1906,8 +1906,11 @@ export function generate(
 		return astHolder.__volar_ast as ts.SourceFile;
 	}
 
-	function createPropertyAccessCode(a: Code, astHolder?: any): Code[] {
+	function createPropertyAccessCode(a: Code, forceIndexSignature = false, astHolder?: any): Code[] {
 		const aStr = typeof a === 'string' ? a : a[0];
+		if (forceIndexSignature) {
+			return ['[', ...createStringLiteralKeyCode(a), ']'];
+		}
 		if (!compilerOptions.noPropertyAccessFromIndexSignature && validTsVarReg.test(aStr)) {
 			return ['.', a];
 		}

--- a/packages/vue-test-workspace/vue-tsc/non-strict-template/#3574/Comp.vue
+++ b/packages/vue-test-workspace/vue-tsc/non-strict-template/#3574/Comp.vue
@@ -1,0 +1,5 @@
+<script lang="ts" setup>
+defineEmits<{
+  (event: 'change', value: string): void
+}>()
+</script>

--- a/packages/vue-test-workspace/vue-tsc/non-strict-template/#3574/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/non-strict-template/#3574/main.vue
@@ -1,0 +1,8 @@
+<template>
+  <Comp @change="(value) => console.log(value)" />
+  <!--            ^^^^^ is inferred as `any` now, should be `string` -->
+</template>
+
+<script lang="ts" setup>
+import Comp from './Comp.vue'
+</script>

--- a/packages/vue-test-workspace/vue-tsc/non-strict-template/#3574/tsconfig.json
+++ b/packages/vue-test-workspace/vue-tsc/non-strict-template/#3574/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../tsconfig.json",
+	"include": [ "**/*" ],
+	"compilerOptions": {
+		"noPropertyAccessFromIndexSignature": false
+	}
+}


### PR DESCRIPTION
close #3574