### PR TITLE
refactor: don't generate additional virtual code for `defineSlots`

### DIFF
--- a/packages/vue-language-core/src/generators/template.ts
+++ b/packages/vue-language-core/src/generators/template.ts
@@ -73,6 +73,7 @@ export function generate(
 	sourceLang: string,
 	sfc: Sfc,
 	hasScriptSetupSlots: boolean,
+	slotsAssignName: string | undefined,
 	codegenStack: boolean,
 ) {
 
@@ -1644,7 +1645,7 @@ export function generate(
 			codes.push(
 				'__VLS_normalizeSlot(',
 				['', 'template', node.loc.start.offset, capabilitiesPresets.diagnosticOnly],
-				'__VLS_slots[',
+				`${slotsAssignName ?? '__VLS_slots'}[`,
 				['', 'template', node.loc.start.offset, capabilitiesPresets.diagnosticOnly],
 				slotNameExpNode?.content ?? `('${getSlotName()}' as const)`,
 				['', 'template', node.loc.end.offset, capabilitiesPresets.diagnosticOnly],

--- a/packages/vue-language-core/src/parsers/scriptSetupRanges.ts
+++ b/packages/vue-language-core/src/parsers/scriptSetupRanges.ts
@@ -16,7 +16,8 @@ export function parseScriptSetupRanges(
 	let defineProps: TextRange | undefined;
 	let propsRuntimeArg: TextRange | undefined;
 	let propsTypeArg: TextRange | undefined;
-	let slotsTypeArg: TextRange | undefined;
+	let defineSlots: TextRange | undefined;
+	let slotsAssignName: string | undefined;
 	let emitsAssignName: string | undefined;
 	let emitsRuntimeArg: TextRange | undefined;
 	let emitsTypeArg: TextRange | undefined;
@@ -65,10 +66,11 @@ export function parseScriptSetupRanges(
 		bindings,
 		withDefaultsArg,
 		defineProps,
+		defineSlots,
 		propsAssignName,
 		propsRuntimeArg,
 		propsTypeArg,
-		slotsTypeArg,
+		slotsAssignName,
 		emitsAssignName,
 		emitsRuntimeArg,
 		emitsTypeArg,
@@ -170,6 +172,12 @@ export function parseScriptSetupRanges(
 				if (vueCompilerOptions.macros.defineProps.includes(callText)) {
 					defineProps = _getStartEnd(node);
 				}
+				if (vueCompilerOptions.macros.defineSlots.includes(callText)) {
+					defineSlots = _getStartEnd(node);
+					if (ts.isVariableDeclaration(parent)) {
+						slotsAssignName = parent.name.getText(ast);
+					}
+				}
 				if (node.arguments.length) {
 					const runtimeArg = node.arguments[0];
 					if (vueCompilerOptions.macros.defineProps.includes(callText)) {
@@ -196,10 +204,7 @@ export function parseScriptSetupRanges(
 							propsAssignName = parent.name.getText(ast);
 						}
 					}
-					if (vueCompilerOptions.macros.defineSlots.includes(callText)) {
-						slotsTypeArg = _getStartEnd(typeArg);
-					}
-					else if (vueCompilerOptions.macros.defineEmits.includes(callText)) {
+					if (vueCompilerOptions.macros.defineEmits.includes(callText)) {
 						emitsTypeArg = _getStartEnd(typeArg);
 						if (ts.isTypeLiteralNode(typeArg)) {
 							emitsTypeNums = typeArg.members.length;

--- a/packages/vue-language-core/src/plugins/vue-tsx.ts
+++ b/packages/vue-language-core/src/plugins/vue-tsx.ts
@@ -151,12 +151,19 @@ function createTsx(fileName: string, _sfc: Sfc, { vueCompilerOptions, compilerOp
 			_sfc.template?.lang ?? 'html',
 			_sfc,
 			hasScriptSetupSlots.value,
+			slotsAssignName.value,
 			codegenStack,
 		);
 	});
-	const hasScriptSetupSlots = ref(false); // remove when https://github.com/vuejs/core/pull/5912 merged
+
+	//#region remove when https://github.com/vuejs/core/pull/5912 merged
+	const hasScriptSetupSlots = ref(false);
+	const slotsAssignName = ref<string>();
+	//#endregion
+
 	const tsxGen = computed(() => {
-		hasScriptSetupSlots.value = !!scriptSetupRanges.value?.slotsTypeArg;
+		hasScriptSetupSlots.value = !!scriptSetupRanges.value?.defineSlots;
+		slotsAssignName.value = scriptSetupRanges.value?.slotsAssignName;
 		return genScript(
 			ts,
 			fileName,

--- a/packages/vue-test-workspace/vue-tsc/non-strict-template/components/main.vue
+++ b/packages/vue-test-workspace/vue-tsc/non-strict-template/components/main.vue
@@ -20,8 +20,8 @@ const ScriptSetupExact = defineComponent({
 // https://vuejs.org/api/sfc-script-setup.html#defineexpose
 const ScriptSetupExposeExact = defineComponent({
 	setup() {
-		const a = 1
-		const b = ref(2)
+		const a = 1;
+		const b = ref(2);
 		return {
 			a,
 			b
@@ -67,13 +67,13 @@ declare const ScriptSetupGenericExact: <T, >(
 	_ctx?: Pick<NonNullable<Awaited<typeof _setup>>, 'attrs' | 'emit' | 'slots'>,
 	_expose?: NonNullable<Awaited<typeof _setup>>['expose'],
 	_setup?: Promise<{
-		props: { foo: T } & { [K in keyof JSX.ElementChildrenAttribute]?: { default?(data: T): any } },
+		props: { foo: T; } & { [K in keyof JSX.ElementChildrenAttribute]?: Readonly<{ default?(data: T): any; }> },
 		attrs: any,
-		slots: { default?(data: T): any },
-		emit: { (e: 'bar', data: T): void },
-		expose(_exposed: { baz: T }): void,
+		slots: Readonly<{ default?(data: T): any; }>,
+		emit: { (e: 'bar', data: T): void; },
+		expose(_exposed: { baz: T; }): void,
 	}>
-) => import('vue').VNode & { __ctx?: Awaited<typeof _setup> };
+) => import('vue').VNode & { __ctx?: Awaited<typeof _setup>; };
 
 exactType(ScriptSetup, ScriptSetupExact);
 exactType(ScriptSetupExpose, ScriptSetupExposeExact);

--- a/packages/vue-tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/vue-tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -64,9 +64,9 @@ exports[`vue-tsc-dts > Input: components/script-setup-generic.vue, Output: compo
         baz: T;
     }): void;
     attrs: any;
-    slots: {
+    slots: Readonly<{
         default?(data: T): any;
-    };
+    }>;
     emit: (e: 'bar', data: T) => void;
 }, \\"slots\\" | \\"attrs\\" | \\"emit\\">, __VLS_expose?: (exposed: {
     baz: T;
@@ -78,9 +78,9 @@ exports[`vue-tsc-dts > Input: components/script-setup-generic.vue, Output: compo
         baz: T;
     }): void;
     attrs: any;
-    slots: {
+    slots: Readonly<{
         default?(data: T): any;
-    };
+    }>;
     emit: (e: 'bar', data: T) => void;
 }>) => import(\\"vue\\").VNode<import(\\"vue\\").RendererNode, import(\\"vue\\").RendererElement, {
     [key: string]: any;
@@ -93,9 +93,9 @@ exports[`vue-tsc-dts > Input: components/script-setup-generic.vue, Output: compo
             baz: T;
         }): void;
         attrs: any;
-        slots: {
+        slots: Readonly<{
             default?(data: T): any;
-        };
+        }>;
         emit: (e: 'bar', data: T) => void;
     };
 };


### PR DESCRIPTION
For `defineSlots`, we can reuse its return type instead of generating duplicate virtual code for template.

For the following vue code.

```html
<script setup lang="ts">
defineSlots<{
  activator?(props: { isActive: boolean }): void
}>();
</script>

<template>
	<!-- ... -->
</template>
```

### Old virtual code

```ts
/* script setup part */
// ...
defineSlots<{
  activator?(props: { isActive: boolean }): void
}>();
// ...

/* template part */
var __VLS_slots!: {
  activator?(props: { isActive: boolean }): void
};
// some template virtual codes reference __VLS_slots
```

### New virtual code

```ts
/* script setup part */
// ...
const __VLS_slots = defineSlots<{
  activator?(props: { isActive: boolean }): void
}>();
// ...

/* template part */
// some template virtual codes reference __VLS_slots
```