### PR TITLE
chore: publish ts plugin to open-vsx too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,7 @@ jobs:
         working-directory: packages/vscode-vue
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
+      - run: pnpm ovsx publish
+        working-directory: packages/vscode-typescript-vue-plugin
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
Hi, need this to have proper intellisense in stackblitz.

`ovsx publish` will automatically run `vscode:prepublish`, so no need to specify it again.