### PR TITLE
Update the link to the Volar's site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vue Language Tools
 
-> ⚡ High-performance Vue language tooling based-on [Volar.js](https://volarjs.github.io/)
+> ⚡ High-performance Vue language tooling based-on [Volar.js](https://volarjs.dev/)
 
 Discord: https://discord.gg/5bnSSSSBbK
 


### PR DESCRIPTION
The link to Volar's site (https://volarjs.github.io/) is no more available, and the repository (https://github.com/volarjs/volarjs.github.io) is read-only