### PR TITLE
chore: rollback `vscode-languageclient` to 8.1.0

### DIFF
--- a/packages/vscode-vue/package.json
+++ b/packages/vscode-vue/package.json
@@ -741,7 +741,7 @@
 	},
 	"devDependencies": {
 		"@types/semver": "^7.5.3",
-		"@types/vscode": "1.67.0",
+		"@types/vscode": "^1.67.0",
 		"@volar/vscode": "~1.10.3",
 		"@vue/language-core": "1.8.16",
 		"@vue/language-server": "1.8.16",
@@ -750,6 +750,6 @@
 		"esbuild-visualizer": "latest",
 		"semver": "^7.5.4",
 		"vsce": "latest",
-		"vscode-languageclient": "^9.0.1"
+		"vscode-languageclient": "^8.1.0"
 	}
 }

--- a/packages/vscode-vue/tests/index.spec.ts
+++ b/packages/vscode-vue/tests/index.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+
+describe('vscode', () => {
+	test('vscode versions should be consistent ', () => {
+
+		const languageClientVersion = require('vscode-languageclient/package.json').engines.vscode;
+		const typesVersion = require('../package.json').devDependencies['@types/vscode'];
+		const enginesVersion = require('../package.json').engines.vscode;
+
+		expect(typesVersion).toBe(languageClientVersion);
+		expect(enginesVersion).toBe(languageClientVersion);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: latest
-        version: 20.8.2
+        version: 20.8.3
       '@volar/language-service':
         specifier: ~1.10.3
         version: 1.10.3
@@ -26,7 +26,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: latest
-        version: 4.4.11(@types/node@20.8.2)
+        version: 4.4.11(@types/node@20.8.3)
       vitest:
         specifier: latest
         version: 0.34.6
@@ -61,7 +61,7 @@ importers:
         specifier: ^7.5.3
         version: 7.5.3
       '@types/vscode':
-        specifier: 1.67.0
+        specifier: ^1.67.0
         version: 1.67.0
       '@volar/vscode':
         specifier: ~1.10.3
@@ -88,8 +88,8 @@ importers:
         specifier: latest
         version: 2.15.0
       vscode-languageclient:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^8.1.0
+        version: 8.1.0
 
   packages/vue-component-meta:
     dependencies:
@@ -1280,8 +1280,8 @@ packages:
     dev: false
     optional: true
 
-  /@types/node@20.8.2:
-    resolution: {integrity: sha512-Vvycsc9FQdwhxE3y3DzeIxuEJbWGDsnrxvMADzTDF/lcdR9/K+AQIeAghTQsHtotg/q0j3WEOYS/jQgSdWue3w==}
+  /@types/node@20.8.3:
+    resolution: {integrity: sha512-jxiZQFpb+NlH5kjW49vXxvxTjeeqlbsnTAdBTKpzEdPs9itay7MscYXz3Fo9VYFEsfQ6LJFitHad3faerLAjCw==}
     dev: true
 
   /@types/normalize-package-data@2.4.2:
@@ -6102,7 +6102,7 @@ packages:
     dev: false
     optional: true
 
-  /vite-node@0.34.6(@types/node@20.8.2):
+  /vite-node@0.34.6(@types/node@20.8.3):
     resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -6112,7 +6112,7 @@ packages:
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.11(@types/node@20.8.2)
+      vite: 4.4.11(@types/node@20.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6124,7 +6124,7 @@ packages:
       - terser
     dev: true
 
-  /vite@4.4.11(@types/node@20.8.2):
+  /vite@4.4.11(@types/node@20.8.3):
     resolution: {integrity: sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -6152,7 +6152,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.8.2
+      '@types/node': 20.8.3
       esbuild: 0.18.20
       postcss: 8.4.31
       rollup: 3.29.4
@@ -6193,7 +6193,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.6
       '@types/chai-subset': 1.3.3
-      '@types/node': 20.8.2
+      '@types/node': 20.8.3
       '@vitest/expect': 0.34.6
       '@vitest/runner': 0.34.6
       '@vitest/snapshot': 0.34.6
@@ -6212,8 +6212,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.7.0
-      vite: 4.4.11(@types/node@20.8.2)
-      vite-node: 0.34.6(@types/node@20.8.2)
+      vite: 4.4.11(@types/node@20.8.3)
+      vite-node: 0.34.6(@types/node@20.8.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -6387,17 +6387,29 @@ packages:
       vscode-uri: 3.0.8
     dev: false
 
+  /vscode-jsonrpc@8.1.0:
+    resolution: {integrity: sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
 
-  /vscode-languageclient@9.0.1:
-    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
-    engines: {vscode: ^1.82.0}
+  /vscode-languageclient@8.1.0:
+    resolution: {integrity: sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==}
+    engines: {vscode: ^1.67.0}
     dependencies:
       minimatch: 5.1.6
       semver: 7.5.4
-      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-protocol: 3.17.3
+    dev: true
+
+  /vscode-languageserver-protocol@3.17.3:
+    resolution: {integrity: sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==}
+    dependencies:
+      vscode-jsonrpc: 8.1.0
+      vscode-languageserver-types: 3.17.3
     dev: true
 
   /vscode-languageserver-protocol@3.17.5:
@@ -6411,7 +6423,6 @@ packages:
 
   /vscode-languageserver-types@3.17.3:
     resolution: {integrity: sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==}
-    dev: false
 
   /vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}


### PR DESCRIPTION
close #3635, close #3631