### PR TITLE
Upgrade required VSCode version to 1.82.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "latest",
-		"@volar/language-service": "1.10.2",
+		"@volar/language-service": "~1.10.3",
 		"typescript": "latest",
 		"vite": "latest",
 		"vitest": "latest"

--- a/packages/typescript-vue-plugin/package.json
+++ b/packages/typescript-vue-plugin/package.json
@@ -15,6 +15,6 @@
 	"dependencies": {
 		"@vue/language-core": "1.8.17",
 		"@vue/typescript": "1.8.17",
-		"vscode-uri": "^3.0.7"
+		"vscode-uri": "^3.0.8"
 	}
 }

--- a/packages/vscode-vue/package.json
+++ b/packages/vscode-vue/package.json
@@ -742,7 +742,7 @@
 	"devDependencies": {
 		"@types/semver": "^7.5.3",
 		"@types/vscode": "^1.67.0",
-		"@volar/vscode": "1.10.2",
+		"@volar/vscode": "~1.10.3",
 		"@vue/language-core": "1.8.17",
 		"@vue/language-server": "1.8.17",
 		"esbuild": "0.15.18",
@@ -750,6 +750,6 @@
 		"esbuild-visualizer": "latest",
 		"semver": "^7.5.4",
 		"vsce": "latest",
-		"vscode-languageclient": "^8.1.0"
+		"vscode-languageclient": "^9.0.1"
 	}
 }

--- a/packages/vscode-vue/package.json
+++ b/packages/vscode-vue/package.json
@@ -19,7 +19,7 @@
 	"author": "johnsoncodehk",
 	"publisher": "Vue",
 	"engines": {
-		"vscode": "^1.67.0"
+		"vscode": "^1.82.0"
 	},
 	"activationEvents": [
 		"onLanguage:vue",
@@ -741,7 +741,7 @@
 	},
 	"devDependencies": {
 		"@types/semver": "^7.5.3",
-		"@types/vscode": "^1.67.0",
+		"@types/vscode": "^1.82.0",
 		"@volar/vscode": "~1.10.3",
 		"@vue/language-core": "1.8.17",
 		"@vue/language-server": "1.8.17",

--- a/packages/vue-component-meta/package.json
+++ b/packages/vue-component-meta/package.json
@@ -13,7 +13,7 @@
 		"directory": "packages/vue-component-meta"
 	},
 	"dependencies": {
-		"@volar/typescript": "1.10.2",
+		"@volar/typescript": "~1.10.3",
 		"@vue/language-core": "1.8.17",
 		"typesafe-path": "^0.2.2",
 		"vue-component-type-helpers": "1.8.17"

--- a/packages/vue-language-core/package.json
+++ b/packages/vue-language-core/package.json
@@ -13,8 +13,8 @@
 		"directory": "packages/vue-language-core"
 	},
 	"dependencies": {
-		"@volar/language-core": "1.10.2",
-		"@volar/source-map": "1.10.2",
+		"@volar/language-core": "~1.10.3",
+		"@volar/source-map": "~1.10.3",
 		"@vue/compiler-dom": "^3.3.0",
 		"@vue/reactivity": "^3.3.0",
 		"@vue/shared": "^3.3.0",

--- a/packages/vue-language-plugin-pug/package.json
+++ b/packages/vue-language-plugin-pug/package.json
@@ -16,7 +16,7 @@
 		"@vue/language-core": "1.8.17"
 	},
 	"dependencies": {
-		"@volar/source-map": "1.10.2",
-		"volar-service-pug": "0.0.13"
+		"@volar/source-map": "~1.10.3",
+		"volar-service-pug": "0.0.14"
 	}
 }

--- a/packages/vue-language-server/package.json
+++ b/packages/vue-language-server/package.json
@@ -16,12 +16,12 @@
 		"directory": "packages/vue-language-server"
 	},
 	"dependencies": {
-		"@volar/language-core": "1.10.2",
-		"@volar/language-server": "1.10.2",
-		"@volar/typescript": "1.10.2",
+		"@volar/language-core": "~1.10.3",
+		"@volar/language-server": "~1.10.3",
+		"@volar/typescript": "~1.10.3",
 		"@vue/language-core": "1.8.17",
 		"@vue/language-service": "1.8.17",
-		"vscode-languageserver-protocol": "3.17.3",
+		"vscode-languageserver-protocol": "^3.17.5",
 		"vue-component-meta": "1.8.17"
 	}
 }

--- a/packages/vue-language-service/package.json
+++ b/packages/vue-language-service/package.json
@@ -17,27 +17,27 @@
 		"update-html-data": "node ./scripts/update-html-data.js"
 	},
 	"dependencies": {
-		"@volar/language-core": "1.10.2",
-		"@volar/language-service": "1.10.2",
-		"@volar/typescript": "1.10.2",
+		"@volar/language-core": "~1.10.3",
+		"@volar/language-service": "~1.10.3",
+		"@volar/typescript": "~1.10.3",
 		"@vue/compiler-dom": "^3.3.0",
 		"@vue/language-core": "1.8.17",
 		"@vue/reactivity": "^3.3.0",
 		"@vue/shared": "^3.3.0",
-		"volar-service-css": "0.0.13",
-		"volar-service-emmet": "0.0.13",
-		"volar-service-html": "0.0.13",
-		"volar-service-json": "0.0.13",
-		"volar-service-pug": "0.0.13",
-		"volar-service-pug-beautify": "0.0.13",
-		"volar-service-typescript": "0.0.13",
-		"volar-service-typescript-twoslash-queries": "0.0.13",
-		"vscode-html-languageservice": "^5.0.4",
-		"vscode-languageserver-textdocument": "^1.0.8"
+		"volar-service-css": "0.0.14",
+		"volar-service-emmet": "0.0.14",
+		"volar-service-html": "0.0.14",
+		"volar-service-json": "0.0.14",
+		"volar-service-pug": "0.0.14",
+		"volar-service-pug-beautify": "0.0.14",
+		"volar-service-typescript": "0.0.14",
+		"volar-service-typescript-twoslash-queries": "0.0.14",
+		"vscode-html-languageservice": "^5.1.0",
+		"vscode-languageserver-textdocument": "^1.0.11"
 	},
 	"devDependencies": {
-		"@volar/kit": "1.10.2",
-		"vscode-languageserver-protocol": "3.17.3",
-		"vscode-uri": "^3.0.7"
+		"@volar/kit": "~1.10.3",
+		"vscode-languageserver-protocol": "^3.17.5",
+		"vscode-uri": "^3.0.8"
 	}
 }

--- a/packages/vue-language-service/src/plugins/vue.ts
+++ b/packages/vue-language-service/src/plugins/vue.ts
@@ -14,7 +14,7 @@ export interface Provide {
 
 export const create = (): Service<Provide> => (context: ServiceContext<import('volar-service-typescript').Provide> | undefined, modules): ReturnType<Service<Provide>> => {
 
-	const htmlPlugin = createHtmlPlugin({ validLang: 'vue', disableCustomData: true })(context, modules);
+	const htmlPlugin = createHtmlPlugin({ languageId: 'vue', useCustomDataProviders: false })(context, modules);
 
 	if (!context)
 		return htmlPlugin as any;

--- a/packages/vue-tsc-eslint-hook/package.json
+++ b/packages/vue-tsc-eslint-hook/package.json
@@ -21,6 +21,6 @@
 		"eslint": "*"
 	},
 	"dependencies": {
-		"vscode-languageserver-textdocument": "^1.0.8"
+		"vscode-languageserver-textdocument": "^1.0.11"
 	}
 }

--- a/packages/vue-typescript/package.json
+++ b/packages/vue-typescript/package.json
@@ -13,7 +13,7 @@
 		"directory": "packages/vue-typescript"
 	},
 	"dependencies": {
-		"@volar/typescript": "1.10.2",
+		"@volar/typescript": "~1.10.3",
 		"@vue/language-core": "1.8.17"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         specifier: ^7.5.3
         version: 7.5.3
       '@types/vscode':
-        specifier: ^1.67.0
+        specifier: ^1.82.0
         version: 1.83.0
       '@volar/vscode':
         specifier: ~1.10.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: latest
         version: 20.8.3
       '@volar/language-service':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       typescript:
         specifier: latest
         version: 5.2.2
@@ -40,7 +40,7 @@ importers:
         specifier: 1.8.17
         version: link:../vue-typescript
       vscode-uri:
-        specifier: ^3.0.7
+        specifier: ^3.0.8
         version: 3.0.8
 
   packages/vscode-typescript-vue-plugin:
@@ -62,10 +62,10 @@ importers:
         version: 7.5.3
       '@types/vscode':
         specifier: ^1.67.0
-        version: 1.67.0
+        version: 1.83.0
       '@volar/vscode':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@vue/language-core':
         specifier: 1.8.17
         version: link:../vue-language-core
@@ -88,14 +88,14 @@ importers:
         specifier: latest
         version: 2.15.0
       vscode-languageclient:
-        specifier: ^8.1.0
-        version: 8.1.0
+        specifier: ^9.0.1
+        version: 9.0.1
 
   packages/vue-component-meta:
     dependencies:
       '@volar/typescript':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@vue/language-core':
         specifier: 1.8.17
         version: link:../vue-language-core
@@ -111,11 +111,11 @@ importers:
   packages/vue-language-core:
     dependencies:
       '@volar/language-core':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@volar/source-map':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@vue/compiler-dom':
         specifier: ^3.3.0
         version: 3.3.4
@@ -145,11 +145,11 @@ importers:
   packages/vue-language-plugin-pug:
     dependencies:
       '@volar/source-map':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       volar-service-pug:
-        specifier: 0.0.13
-        version: 0.0.13
+        specifier: 0.0.14
+        version: 0.0.14
     devDependencies:
       '@vue/language-core':
         specifier: 1.8.17
@@ -158,14 +158,14 @@ importers:
   packages/vue-language-server:
     dependencies:
       '@volar/language-core':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@volar/language-server':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@volar/typescript':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@vue/language-core':
         specifier: 1.8.17
         version: link:../vue-language-core
@@ -173,8 +173,8 @@ importers:
         specifier: 1.8.17
         version: link:../vue-language-service
       vscode-languageserver-protocol:
-        specifier: 3.17.3
-        version: 3.17.3
+        specifier: ^3.17.5
+        version: 3.17.5
       vue-component-meta:
         specifier: 1.8.17
         version: link:../vue-component-meta
@@ -182,14 +182,14 @@ importers:
   packages/vue-language-service:
     dependencies:
       '@volar/language-core':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@volar/language-service':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@volar/typescript':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@vue/compiler-dom':
         specifier: ^3.3.0
         version: 3.3.4
@@ -203,44 +203,44 @@ importers:
         specifier: ^3.3.0
         version: 3.3.4
       volar-service-css:
-        specifier: 0.0.13
-        version: 0.0.13(@volar/language-service@1.10.2)
+        specifier: 0.0.14
+        version: 0.0.14(@volar/language-service@1.10.3)
       volar-service-emmet:
-        specifier: 0.0.13
-        version: 0.0.13(@volar/language-service@1.10.2)
+        specifier: 0.0.14
+        version: 0.0.14(@volar/language-service@1.10.3)
       volar-service-html:
-        specifier: 0.0.13
-        version: 0.0.13(@volar/language-service@1.10.2)
+        specifier: 0.0.14
+        version: 0.0.14(@volar/language-service@1.10.3)
       volar-service-json:
-        specifier: 0.0.13
-        version: 0.0.13(@volar/language-service@1.10.2)
+        specifier: 0.0.14
+        version: 0.0.14(@volar/language-service@1.10.3)
       volar-service-pug:
-        specifier: 0.0.13
-        version: 0.0.13
+        specifier: 0.0.14
+        version: 0.0.14
       volar-service-pug-beautify:
-        specifier: 0.0.13
-        version: 0.0.13(@volar/language-service@1.10.2)
+        specifier: 0.0.14
+        version: 0.0.14(@volar/language-service@1.10.3)
       volar-service-typescript:
-        specifier: 0.0.13
-        version: 0.0.13(@volar/language-service@1.10.2)(@volar/typescript@1.10.2)
+        specifier: 0.0.14
+        version: 0.0.14(@volar/language-service@1.10.3)(@volar/typescript@1.10.3)
       volar-service-typescript-twoslash-queries:
-        specifier: 0.0.13
-        version: 0.0.13(@volar/language-service@1.10.2)
+        specifier: 0.0.14
+        version: 0.0.14(@volar/language-service@1.10.3)
       vscode-html-languageservice:
-        specifier: ^5.0.4
+        specifier: ^5.1.0
         version: 5.1.0
       vscode-languageserver-textdocument:
-        specifier: ^1.0.8
+        specifier: ^1.0.11
         version: 1.0.11
     devDependencies:
       '@volar/kit':
-        specifier: 1.10.2
-        version: 1.10.2(typescript@5.2.2)
+        specifier: ~1.10.3
+        version: 1.10.3(typescript@5.2.2)
       vscode-languageserver-protocol:
-        specifier: 3.17.3
-        version: 3.17.3
+        specifier: ^3.17.5
+        version: 3.17.5
       vscode-uri:
-        specifier: ^3.0.7
+        specifier: ^3.0.8
         version: 3.0.8
 
   packages/vue-test-workspace:
@@ -267,7 +267,7 @@ importers:
   packages/vue-tsc-eslint-hook:
     dependencies:
       vscode-languageserver-textdocument:
-        specifier: ^1.0.8
+        specifier: ^1.0.11
         version: 1.0.11
     devDependencies:
       '@types/eslint':
@@ -280,8 +280,8 @@ importers:
   packages/vue-typescript:
     dependencies:
       '@volar/typescript':
-        specifier: 1.10.2
-        version: 1.10.2
+        specifier: ~1.10.3
+        version: 1.10.3
       '@vue/language-core':
         specifier: 1.8.17
         version: link:../vue-language-core
@@ -1294,8 +1294,8 @@ packages:
     resolution: {integrity: sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==}
     dev: true
 
-  /@types/vscode@1.67.0:
-    resolution: {integrity: sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==}
+  /@types/vscode@1.83.0:
+    resolution: {integrity: sha512-3mUtHqLAVz9hegut9au4xehuBrzRE3UJiQMpoEHkNl6XHliihO7eATx2BMHs0odsmmrwjJrlixx/Pte6M3ygDQ==}
     dev: true
 
   /@vitest/expect@0.34.6:
@@ -1336,60 +1336,60 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /@volar/kit@1.10.2(typescript@5.2.2):
-    resolution: {integrity: sha512-xsdH0hqoiXp7FqiCXV1JtRx2IdyoW7C3WxY9dPoIoM0EUBpVdL57WJ2SVn4Vok/c7M8QGsDblXy41zF/E0TE2g==}
+  /@volar/kit@1.10.3(typescript@5.2.2):
+    resolution: {integrity: sha512-o3ec9b3LdqG60Uj8fixnzbj4i5/aspIZjjPTtFhSOOdLYOv/3e6m/CpFmhadyJCukgCmuG40oTaeVhaz2zhSeg==}
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@volar/language-service': 1.10.2
+      '@volar/language-service': 1.10.3
       typesafe-path: 0.2.2
       typescript: 5.2.2
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
     dev: true
 
-  /@volar/language-core@1.10.2:
-    resolution: {integrity: sha512-vp9o4/55sBOM9H2OjVqYCERNhzPSNZAFJ4Pd+m59op7/w4WRo0uFQM1edzty0K2tte0S3pShjMbGxt224xv7kA==}
+  /@volar/language-core@1.10.3:
+    resolution: {integrity: sha512-7Qgwu9bWUHN+cLrOkCbIVBkL+RVPREhvY07wY89dGxi4mY9mQCsUVRRp64F61lX7Nc27meMnvy0sWlzY0x6oQQ==}
     dependencies:
-      '@volar/source-map': 1.10.2
+      '@volar/source-map': 1.10.3
 
-  /@volar/language-server@1.10.2:
-    resolution: {integrity: sha512-K1QYF2RBfM+ZE0neBGeY7V0/WSFrskRb/IMeh+Wap0Bsm6nPG1QNsk71MfSX4j+lKkfS0l2TdzBXuIhRt2oy9Q==}
+  /@volar/language-server@1.10.3:
+    resolution: {integrity: sha512-uYrZTMGmMPpXINklWzWp5jDWRij6yN6i8ObDpNwENwhg647jxzuEOxjQFvmHrfAJpqYNnZPWY/G0hwsrv45Xnw==}
     dependencies:
-      '@volar/language-core': 1.10.2
-      '@volar/language-service': 1.10.2
-      '@volar/typescript': 1.10.2
-      '@vscode/l10n': 0.0.11
+      '@volar/language-core': 1.10.3
+      '@volar/language-service': 1.10.3
+      '@volar/typescript': 1.10.3
+      '@vscode/l10n': 0.0.16
       request-light: 0.7.0
       typesafe-path: 0.2.2
-      vscode-languageserver: 8.1.0
-      vscode-languageserver-protocol: 3.17.3
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
 
-  /@volar/language-service@1.10.2:
-    resolution: {integrity: sha512-+csV3RJMfwHWuiDiS2OWc60kTYhq+PC/wxKhn6epYkOovL9H00wJLjd8kAxFyYKfWXbDGSdh86JA83FAZMNtTA==}
+  /@volar/language-service@1.10.3:
+    resolution: {integrity: sha512-nz7Gh8bm+aLFuVxJ0wn18d7ihr2XEtJ9Ed8bD74m3IQlmdqNwSILh5jEMNXOI7DW0R5loxtBHN1HYiNJPXDcvA==}
     dependencies:
-      '@volar/language-core': 1.10.2
-      '@volar/source-map': 1.10.2
-      vscode-languageserver-protocol: 3.17.3
+      '@volar/language-core': 1.10.3
+      '@volar/source-map': 1.10.3
+      vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
 
-  /@volar/source-map@1.10.2:
-    resolution: {integrity: sha512-SgbtGWrdxCF/RO+HiDUBKh1INre3SVOW239HqE1fTi6UBwdosOdM/KE0UahhQI0uLgyL/uPvyLi40Z5ScmI6nQ==}
+  /@volar/source-map@1.10.3:
+    resolution: {integrity: sha512-QE9nwK3xsdBQGongHnC9SCR0itx7xUKQFsUDn5HbZY3pHpyXxdY1hSBG0eh9mE+aTKoM4KlqMvrb+19Tv9vS1Q==}
     dependencies:
       muggle-string: 0.3.1
 
-  /@volar/typescript@1.10.2:
-    resolution: {integrity: sha512-3zDAg3dnpJzFCAZnmpahyVGlm1mVKRSJOSPCUHLene0SSd/SHHVOe37C1+ueSNSxDVX31YXgMJXnXGm6a8oRhg==}
+  /@volar/typescript@1.10.3:
+    resolution: {integrity: sha512-n0ar6xGYpRoSvgGMetm/JXP0QAXx+NOUvxCaWCfCjiFivQRSLJeydYDijhoGBUl5KSKosqq9In5L3e/m2TqTcQ==}
     dependencies:
-      '@volar/language-core': 1.10.2
+      '@volar/language-core': 1.10.3
 
-  /@volar/vscode@1.10.2:
-    resolution: {integrity: sha512-Qxaw5Xrc5IVXKOXRJBxpIU27SFFKJdfz0PzMwRnow70EZH62mk5SR4f83FNyuCcBTKLULc0srTJw+SXebrV11g==}
+  /@volar/vscode@1.10.3:
+    resolution: {integrity: sha512-j5hrMiXCRc/I/E9IB0J9Ph66VbOieYXnnXtDRkoDgPtB4vJacQnn5gYBFYvsdqkKWOmGUT4XhAE9s8oefvrEyw==}
     dependencies:
-      '@volar/language-server': 1.10.2
+      '@volar/language-server': 1.10.3
       typesafe-path: 0.2.2
       vscode-nls: 5.2.0
     dev: true
@@ -1404,12 +1404,8 @@ packages:
       vscode-uri: 2.1.2
     dev: false
 
-  /@vscode/l10n@0.0.11:
-    resolution: {integrity: sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA==}
-
   /@vscode/l10n@0.0.16:
     resolution: {integrity: sha512-JT5CvrIYYCrmB+dCana8sUqJEcGB1ZDXNLMQ2+42bW995WmNoenijWMUdZfwmuQUTQcEVVIa2OecZzTYWUW9Cg==}
-    dev: false
 
   /@vue/compiler-core@3.3.4:
     resolution: {integrity: sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==}
@@ -6229,60 +6225,60 @@ packages:
       - terser
     dev: true
 
-  /volar-service-css@0.0.13(@volar/language-service@1.10.2):
-    resolution: {integrity: sha512-WAuo7oDYgTQ1cr45EqTGoPGtClj0f5PZDQARgQveXKu0CQgyXn8Bs7c4EjDR0fNLhiG3moBEs2uSUGxjSKghxw==}
+  /volar-service-css@0.0.14(@volar/language-service@1.10.3):
+    resolution: {integrity: sha512-xmyKoyWpbgM0u7mGA1ogyj5ol7CfQADm5eXNpeJeX3Rp79rFEtz1DuuaIjcgRvhSYsjJfPBOtOvHBwTRf4HaEQ==}
     peerDependencies:
       '@volar/language-service': ~1.10.0
     peerDependenciesMeta:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 1.10.2
+      '@volar/language-service': 1.10.3
       vscode-css-languageservice: 6.2.9
       vscode-uri: 3.0.8
     dev: false
 
-  /volar-service-emmet@0.0.13(@volar/language-service@1.10.2):
-    resolution: {integrity: sha512-y/U3up9b3YA8DL36h6KUGnBoH/TUmr1Iv9HWuSeWJKoA6LOt57AOIgzl7+/zY8d+0+C0jGqpV4CM8V5+TjptvQ==}
+  /volar-service-emmet@0.0.14(@volar/language-service@1.10.3):
+    resolution: {integrity: sha512-0meSKjQ93j5iSYl6Y+qtARfAYr3J2wNSr6wlKr/V9KULAy+8/me8q9l8wkTQqdRMujZAv2j/LzgQ65Yc9mnA1w==}
     peerDependencies:
       '@volar/language-service': ~1.10.0
     peerDependenciesMeta:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 1.10.2
+      '@volar/language-service': 1.10.3
       '@vscode/emmet-helper': 2.9.2
-      volar-service-html: 0.0.13(@volar/language-service@1.10.2)
+      volar-service-html: 0.0.14(@volar/language-service@1.10.3)
     dev: false
 
-  /volar-service-html@0.0.13(@volar/language-service@1.10.2):
-    resolution: {integrity: sha512-Y4pfmNsIpkDTixJVdobRMDZm5Ax90magUCdYl6HUN0/RstxHb3ogEodTT1GtNmoek/YYTrxbWZYN/Yq49+9zdg==}
+  /volar-service-html@0.0.14(@volar/language-service@1.10.3):
+    resolution: {integrity: sha512-PQb97QICxXhXD7AJFU/S/Vexd1L4IP2Sa5SzxYyKnApcx0GNdxaIbFHlev9wazrTgtCtSnaVXJBxY05pZzTKPw==}
     peerDependencies:
       '@volar/language-service': ~1.10.0
     peerDependenciesMeta:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 1.10.2
+      '@volar/language-service': 1.10.3
       vscode-html-languageservice: 5.1.0
       vscode-uri: 3.0.8
     dev: false
 
-  /volar-service-json@0.0.13(@volar/language-service@1.10.2):
-    resolution: {integrity: sha512-1JVy/3jRY3bmZDaoLE0jk+rLrabYkUoNHodc0ir9T2VBIV4TK3jU9lee57HS9aoQoY0evI/XBdCqZHgxwz236A==}
+  /volar-service-json@0.0.14(@volar/language-service@1.10.3):
+    resolution: {integrity: sha512-lguNmmsGgPVY0wbYvY/iblKXtJS/pyTpBmWsY7sSHddtGXeNpoDJtrBUNZsVb74C6c8h5VAgchVZpnASCqHkLQ==}
     peerDependencies:
       '@volar/language-service': ~1.10.0
     peerDependenciesMeta:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 1.10.2
+      '@volar/language-service': 1.10.3
       vscode-json-languageservice: 5.3.6
       vscode-uri: 3.0.8
     dev: false
 
-  /volar-service-pug-beautify@0.0.13(@volar/language-service@1.10.2):
-    resolution: {integrity: sha512-86W2FrgHhfX8LyF0wzhjTXOKz352FHfkofm6r6ZRw2rTM4RJ4RSHfnFjtK+jTcg59uM+8xAl9Tcb15APivXosg==}
+  /volar-service-pug-beautify@0.0.14(@volar/language-service@1.10.3):
+    resolution: {integrity: sha512-z0PhM8w3N8A8zdUudzHEa0Um8Blj5uuNhDWkjPb5c/Y5jAFhMXSgj12h1jiFtpnb20T+FVZTeskpEo2WJ/94NQ==}
     peerDependencies:
       '@volar/language-service': ~1.10.0
     peerDependenciesMeta:
@@ -6290,35 +6286,35 @@ packages:
         optional: true
     dependencies:
       '@johnsoncodehk/pug-beautify': 0.2.2
-      '@volar/language-service': 1.10.2
+      '@volar/language-service': 1.10.3
     dev: false
 
-  /volar-service-pug@0.0.13:
-    resolution: {integrity: sha512-BAfyYtXZj+HTys0nTs81ivByGNdi7nAcSgWPDtKqy4H1Ts5gvfg0/hbLhv5KLJxsTONC3Ejw4vXDgCgQA/Vhiw==}
+  /volar-service-pug@0.0.14:
+    resolution: {integrity: sha512-HZRc5UPy0WsrtbwveDfKiqLECrCR/yGasAcOCIt+z/BcrXDbz6zIAbFkNk409gjam0uyX6vmWcT+z9X3T2bm/w==}
     dependencies:
-      '@volar/language-service': 1.10.2
-      '@volar/source-map': 1.10.2
+      '@volar/language-service': 1.10.3
+      '@volar/source-map': 1.10.3
       muggle-string: 0.3.1
       pug-lexer: 5.0.1
       pug-parser: 6.0.0
-      volar-service-html: 0.0.13(@volar/language-service@1.10.2)
+      volar-service-html: 0.0.14(@volar/language-service@1.10.3)
       vscode-html-languageservice: 5.1.0
       vscode-languageserver-textdocument: 1.0.11
     dev: false
 
-  /volar-service-typescript-twoslash-queries@0.0.13(@volar/language-service@1.10.2):
-    resolution: {integrity: sha512-KGk5ek2v7T8OSY9YdMmqGOT0KkoUQAe8RbPmoZibT9F3vgmmWVgaAoIlDZ1vwt7VfQeZvRmhvRJhqpCA80ZF8Q==}
+  /volar-service-typescript-twoslash-queries@0.0.14(@volar/language-service@1.10.3):
+    resolution: {integrity: sha512-Lg/AcacxyBmVbZhHZwnwvt+MEn/5YlbLiJ7DJG6Dt3xiuQmpXwZmM+JE7/ZMvPt4gxW6AL9zHz21M6JSPCkJ+g==}
     peerDependencies:
       '@volar/language-service': ~1.10.0
     peerDependenciesMeta:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 1.10.2
+      '@volar/language-service': 1.10.3
     dev: false
 
-  /volar-service-typescript@0.0.13(@volar/language-service@1.10.2)(@volar/typescript@1.10.2):
-    resolution: {integrity: sha512-fwpoA1L/bCXz5hl9W4EYJYNyorocfdfbLQ9lTM3rPVOzjRZVknEE8XP31RMPZhEg3sOxKh18+sLEL7j3bip8ew==}
+  /volar-service-typescript@0.0.14(@volar/language-service@1.10.3)(@volar/typescript@1.10.3):
+    resolution: {integrity: sha512-PGHFUbGPLE6/8ldNPO7FxwZdvRLlWBZ26RnJPCM48DBaGTc7qHGkXMtPQq5YCD10d8VwpZirz0eno8K0z+8bpg==}
     peerDependencies:
       '@volar/language-service': ~1.10.0
       '@volar/typescript': ~1.10.0
@@ -6326,8 +6322,8 @@ packages:
       '@volar/language-service':
         optional: true
     dependencies:
-      '@volar/language-service': 1.10.2
-      '@volar/typescript': 1.10.2
+      '@volar/language-service': 1.10.3
+      '@volar/typescript': 1.10.3
       semver: 7.5.4
       typescript-auto-import-cache: 0.3.0
       vscode-languageserver-textdocument: 1.0.11
@@ -6391,40 +6387,40 @@ packages:
       vscode-uri: 3.0.8
     dev: false
 
-  /vscode-jsonrpc@8.1.0:
-    resolution: {integrity: sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==}
+  /vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
 
-  /vscode-languageclient@8.1.0:
-    resolution: {integrity: sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==}
-    engines: {vscode: ^1.67.0}
+  /vscode-languageclient@9.0.1:
+    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
+    engines: {vscode: ^1.82.0}
     dependencies:
       minimatch: 5.1.6
       semver: 7.5.4
-      vscode-languageserver-protocol: 3.17.3
+      vscode-languageserver-protocol: 3.17.5
     dev: true
 
-  /vscode-languageserver-protocol@3.17.3:
-    resolution: {integrity: sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==}
+  /vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
     dependencies:
-      vscode-jsonrpc: 8.1.0
-      vscode-languageserver-types: 3.17.3
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
 
   /vscode-languageserver-textdocument@1.0.11:
     resolution: {integrity: sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==}
 
   /vscode-languageserver-types@3.17.3:
     resolution: {integrity: sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==}
+    dev: false
 
   /vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-    dev: false
 
-  /vscode-languageserver@8.1.0:
-    resolution: {integrity: sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==}
+  /vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
     hasBin: true
     dependencies:
-      vscode-languageserver-protocol: 3.17.3
+      vscode-languageserver-protocol: 3.17.5
 
   /vscode-nls@5.2.0:
     resolution: {integrity: sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==}


### PR DESCRIPTION
In 1.8.16, due to upgrading vscode-languageclient v9, the extension cannot run on VSCode versions lower than 1.82.0. We revert to v8 in 1.8.17 to re-release 1.8.16 changes for users of lower versions.

This PR will re-upgrade the dependencies, and we will release 1.8.18 separately for the VSCode 1.82.0 upgrade.