### PR TITLE
fix: type checking for unknown components when `strictTemplates` enabled

### DIFF
--- a/packages/language-core/src/generators/template.ts
+++ b/packages/language-core/src/generators/template.ts
@@ -243,6 +243,7 @@ export function generate(
 									...capabilitiesPresets.tagHover,
 									...capabilitiesPresets.diagnosticOnly,
 								} : {},
+								...vueCompilerOptions.strictTemplates ? capabilitiesPresets.diagnosticOnly : {},
 							},
 						]),
 						';',

--- a/test-workspace/tsc/vue3_strictTemplate/#3539/main.vue
+++ b/test-workspace/tsc/vue3_strictTemplate/#3539/main.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const msg = ref('Hello World!');
+</script>
+
+<template>
+	<!-- @vue-expect-error -->
+	<Hello :msg="msg"></Hello>
+</template>


### PR DESCRIPTION
fixes #3539

`vue-ignore` doesn't work tho