### PR TITLE
test: increate timeout for riscv64

### DIFF
--- a/packages/tsc/tests/index.spec.ts
+++ b/packages/tsc/tests/index.spec.ts
@@ -75,6 +75,6 @@ function runVueTsc(cwd: string) {
 
 describe(`vue-tsc`, () => {
 	for (const [path, isRoot] of tests) {
-		it(`vue-tsc no errors (${prettyPath(path, isRoot)})`, () => runVueTsc(path), 40_000);
+		it(`vue-tsc no errors (${prettyPath(path, isRoot)})`, () => runVueTsc(path), 400_000);
 	}
 });


### PR DESCRIPTION
Test fails on slow RISC-V architecture.
Fix by increasing the timeout.

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 7 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  packages/tsc/tests/index.spec.ts > vue-tsc > vue-tsc no errors (#2472)
 FAIL  packages/tsc/tests/index.spec.ts > vue-tsc > vue-tsc no errors (#3373)
 FAIL  packages/tsc/tests/index.spec.ts > vue-tsc > vue-tsc no errors (noPropertyAccessFromIndexSignature)
 FAIL  packages/tsc/tests/index.spec.ts > vue-tsc > vue-tsc no errors (vue2)
 FAIL  packages/tsc/tests/index.spec.ts > vue-tsc > vue-tsc no errors (vue2_strictTemplate)
 FAIL  packages/tsc/tests/index.spec.ts > vue-tsc > vue-tsc no errors (vue3)
 FAIL  packages/tsc/tests/index.spec.ts > vue-tsc > vue-tsc no errors (vue3_strictTemplate)
Error: Test timed out in 40000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/7]⎯

 Test Files  1 failed | 27 passed (28)
      Tests  7 failed | 147 passed (154)
   Start at  22:29:13
   Duration  723.88s (transform 45.53s, setup 4ms, collect 122.36s, tests 590.33s, environment 3ms, prepare 2.64s)
```
