### PR TITLE
fix: syntax highlighting for `.prop` shorthand

### DIFF
--- a/extensions/vscode/syntaxes/vue.tmLanguage.json
+++ b/extensions/vscode/syntaxes/vue.tmLanguage.json
@@ -953,7 +953,7 @@
 			]
 		},
 		"vue-directives-original": {
-			"begin": "(?:\\b(v-)|(:)|(@)|(#))(\\[?)([\\w\\-]*)(\\]?)(?:\\.([\\w\\-]*))*",
+			"begin": "(?:\\b(v-)|([:\\.])|(@)|(#))(\\[?)([\\w\\-]*)(\\]?)(?:\\.([\\w\\-]*))*",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.other.attribute-name.html.vue"

--- a/test-workspace/language-service/syntax/directives.vue
+++ b/test-workspace/language-service/syntax/directives.vue
@@ -14,6 +14,7 @@
 	<div v-if="true" v-else-if="true" v-else></div>
 	<div :foo="':foo=123'"></div>
 	<div :foo="[{ bar: []}]"></div>
+	<div .prop="[1, 2]"></div>
 	<div style="width: 100%; height: auto;"></div>
 </template>
 
@@ -33,6 +34,7 @@ div(v-for="n in []")
 div(v-if="true" v-else-if="true" v-else)
 div(:foo="':foo=123'")
 div(:foo="[{ bar: []}]")
+div(.prop="[1, 2]")
 div(style="width: 100%; height: auto;")
 </template>
 
@@ -59,5 +61,6 @@ h1#myId(class="text-right") hello
 	<div v-if="true" v-else-if="true" v-else></div>
 	<div :foo="':foo=123'"></div>
 	<div :foo="[{ bar: []}]"></div>
+	<div .prop="[1, 2]"></div>
 	<div style="width: 100%; height: auto;"></div>
 </template>

--- a/test-workspace/language-service/syntax/dotprop-shorthand.vue
+++ b/test-workspace/language-service/syntax/dotprop-shorthand.vue
@@ -1,3 +1,0 @@
-<template>
-	<div .prop="[1, 2]"></div>
-</template>

--- a/test-workspace/language-service/syntax/dotprop-shorthand.vue
+++ b/test-workspace/language-service/syntax/dotprop-shorthand.vue
@@ -1,0 +1,3 @@
+<template>
+	<div .prop="[1, 2]"></div>
+</template>


### PR DESCRIPTION
fixes #3727