### PR TITLE
fix: don't camelize attributes for plain elements

### DIFF
--- a/packages/language-core/src/generators/template.ts
+++ b/packages/language-core/src/generators/template.ts
@@ -1348,6 +1348,7 @@ export function generate(
 				if (
 					hyphenateAttr(prop.name) === prop.name
 					&& !vueCompilerOptions.htmlAttributes.some(pattern => minimatch(attrNameText!, pattern))
+					&& node.tagType !== CompilerDOM.ElementTypes.ELEMENT
 				) {
 					attrNameText = camelize(prop.name);
 					camelized = true;

--- a/packages/language-core/src/generators/template.ts
+++ b/packages/language-core/src/generators/template.ts
@@ -1241,6 +1241,7 @@ export function generate(
 				if (
 					(!prop.arg || (prop.arg.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION && prop.arg.isStatic)) // isStatic
 					&& hyphenateAttr(attrNameText) === attrNameText
+					&& !nativeTags.has(node.tag)
 					&& !vueCompilerOptions.htmlAttributes.some(pattern => minimatch(attrNameText!, pattern))
 				) {
 					attrNameText = camelize(attrNameText);
@@ -1347,8 +1348,8 @@ export function generate(
 
 				if (
 					hyphenateAttr(prop.name) === prop.name
+					&& !nativeTags.has(node.tag)
 					&& !vueCompilerOptions.htmlAttributes.some(pattern => minimatch(attrNameText!, pattern))
-					&& node.tagType !== CompilerDOM.ElementTypes.ELEMENT
 				) {
 					attrNameText = camelize(prop.name);
 					camelized = true;

--- a/test-workspace/tsc/vue3_strictTemplate/dataAttributes/main.vue
+++ b/test-workspace/tsc/vue3_strictTemplate/dataAttributes/main.vue
@@ -1,0 +1,16 @@
+<template>
+    <div>
+        <svg><path stroke="#efefef" stroke-width="123" /></svg>
+        <foo stroke-width="123" />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { defineComponent } from 'vue';
+
+const Foo = defineComponent({
+    props: {
+        strokeWidth: { type: String, required: true },
+    }
+});
+</script>

--- a/test-workspace/tsc/vue3_strictTemplate/dataAttributes/main.vue
+++ b/test-workspace/tsc/vue3_strictTemplate/dataAttributes/main.vue
@@ -1,16 +1,16 @@
 <template>
-    <div>
-        <svg><path stroke="#efefef" stroke-width="123" /></svg>
-        <foo stroke-width="123" />
-    </div>
+	<div>
+		<svg><path stroke="#efefef" stroke-width="123" /></svg>
+		<foo stroke-width="123" />
+	</div>
 </template>
 
 <script setup lang="ts">
 import { defineComponent } from 'vue';
 
 const Foo = defineComponent({
-    props: {
-        strokeWidth: { type: String, required: true },
-    }
+	props: {
+		strokeWidth: { type: String, required: true },
+	}
 });
 </script>

--- a/test-workspace/tsc/vue3_strictTemplate/dataAttributes/main.vue
+++ b/test-workspace/tsc/vue3_strictTemplate/dataAttributes/main.vue
@@ -1,6 +1,9 @@
 <template>
 	<div>
-		<svg><path stroke="#efefef" stroke-width="123" pathLength="10" /></svg>
+		<svg>
+			<path stroke="#efefef" stroke-width="123" pathLength="10" />
+			<path stroke="#efefef" :stroke-width="123" :pathLength="10" />
+		</svg>
 		<foo stroke-width="123" />
 	</div>
 </template>

--- a/test-workspace/tsc/vue3_strictTemplate/dataAttributes/main.vue
+++ b/test-workspace/tsc/vue3_strictTemplate/dataAttributes/main.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<svg><path stroke="#efefef" stroke-width="123" /></svg>
+		<svg><path stroke="#efefef" stroke-width="123" pathLength="10" /></svg>
 		<foo stroke-width="123" />
 	</div>
 </template>


### PR DESCRIPTION
Plain (native) elements should not have their props camelized as then the attribute names won't match the type definition if the element has those. For example `path` element defines type for the `stroke-width` attribute but since Volar "camelizes" the attribute name by default, it triggers type error due to `strokeWidth` not matching the `stroke-width` key.

I suppose the `ElementTypes.ELEMENT` type does not necessarily mean "native element" but hopefully it's close enough and correct to not camelize attributes by default for those elements.