### PR TITLE
chore(readme): update discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ⚡ High-performance Vue language tooling based-on [Volar.js](https://volarjs.dev/)
 
-Discord: https://discord.gg/5bnSSSSBbK
+💬 **#language-tools** on our [Discord Server](https://discord.gg/vue)  
 
 <table>
 	<tbody>


### PR DESCRIPTION
Hello, I am currently using this project from within nvim via mason and was hoping to contribute.

I found that following the `README.md` to the discord link brought me to mostly NFT spam and unanswered community questions. I think it is probably best to remove this link until there is enough of a community around this project in particular to support moderation / questions from the community.

Also, if anyone can point me in a good direction to get information about a pipeline to build and load this within the nvim ecosystem I would really appreciate it.

Thanks for all your hard work!

```
there is no active moderation / community activity here. this is mostly filled with spam and unanswered questions.
```
Fixes N/A