### PR TITLE
fix: revert url to previous working url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 
 - [Vue Language Features](https://github.com/vuejs/language-tools/tree/master/extensions/vscode) \
 *Vue, Vitepress, petite-vue language support extension for VSCode*
-- [TypeScript Vue Plugin](https://github.com/vuejs/language-tools/tree/master/extensions/vscode-typescript-plugin) \
+- [TypeScript Vue Plugin](https://github.com/vuejs/language-tools/tree/master/packages/typescript-plugin) \
 *VSCode extension to support Vue in TS server*
 - [vue-tsc](https://github.com/vuejs/language-tools/tree/master/packages/tsc) \
 *Type-check and dts build command line tool*


### PR DESCRIPTION
## Problem
There is a link in the README.md that doesn't have an associated URL. 
![Screenshot 2024-01-09 at 12 59 00 PM](https://github.com/vuejs/language-tools/assets/55567604/8bdc6a4b-6125-47aa-b574-b53406bd2ac7)
![Screenshot 2024-01-09 at 12 33 28 PM](https://github.com/vuejs/language-tools/assets/55567604/1d4cea72-2290-4c54-840e-2c9f7c213598)

It appears like this link url was [changed](https://github.com/vuejs/language-tools/commit/ce5623e52a31c99797052727a817d422266f210d#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to a path that doesn't exist. The previous URL seems to be the correct location for the extension source code. My context to this repo is very low and this is my first OS contribution, let me know if I am missing something 👍 