### PR TITLE
fix: exclude vue directive syntax injection in Angular bindings

### DIFF
--- a/extensions/vscode/syntaxes/vue-directives.json
+++ b/extensions/vscode/syntaxes/vue-directives.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"fileTypes": [],
-	"injectionSelector": "L:meta.tag -meta.attribute -entity.name.tag.pug -attribute_value -source.tsx -source.js.jsx, L:meta.element -meta.attribute",
+	"injectionSelector": "L:meta.tag -meta.attribute -meta.ng-binding -entity.name.tag.pug -attribute_value -source.tsx -source.js.jsx, L:meta.element -meta.attribute",
 	"patterns": [
 		{
 			"include": "source.vue#vue-directives"


### PR DESCRIPTION
Vue directive syntax captures take over required terminating characters for expressions inside Angular template bindings. These bindings are identifiable with `meta.ng-binding` (https://github.com/angular/vscode-ng-language-service/blob/5d73b53115db57ea868f11aa5caa4bc0d890bb12/syntaxes/template-tag.json#L43).

https://github.com/angular/vscode-ng-language-service/issues/1989 https://github.com/angular/vscode-ng-language-service/issues/2005


reviewer note: I'm the maintainer of the Angular VSCode extension. While I don't think it's necessary that we always maintain compatibility, it would be nice if our syntaxes played nicely together when there are simple solutions. This seemed like the cleanest solution but I'm open to other suggestions. I built this extension locally and it seems to resolve the issues.