### PR TITLE
docs: remove vue3-eslint-stylelint-demo broken link

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -13,7 +13,7 @@ Vue Language Features is a language support extension built for Vue, Vitepress a
 - [create-vue](https://github.com/vuejs/create-vue)
 - [Vitesse](https://github.com/antfu/vitesse)
 - [petite](https://github.com/JessicaSachs/petite)
-- [vue3-eslint-stylelint-demo](https://github.com/sethidden/vue3-eslint-stylelint-demo) (Volar + ESLint + stylelint + husky)
+
 - [volar-starter](https://github.com/johnsoncodehk/volar-starter) (For bug report and experiment features testing)
 
 ## Usage


### PR DESCRIPTION
I discovered a broken link in the extensions/vscode directory (vue3-eslint-stylelint-demo). The link is no longer valid, and I was unable to locate a suitable replacement. I've removed the broken link in this pull request.