### PR TITLE
feat(language-core): add emit codegen for defineModel

### DIFF
--- a/packages/component-meta/tests/index.spec.ts
+++ b/packages/component-meta/tests/index.spec.ts
@@ -19,6 +19,24 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) => describ
 		expect(meta.props.filter(prop => !prop.global)).toEqual([]);
 	});
 
+	test('reference-type-model', () => {
+		const componentPath = path.resolve(__dirname, '../../../test-workspace/component-meta/reference-type-model/component.vue');
+		const meta = checker.getComponentMeta(componentPath);
+
+		// expect(meta.type).toEqual(TypeMeta.Class);
+
+		const foo = meta.props.find(prop => prop.name === 'foo');
+		const onUpdateFoo = meta.events.find(event => event.name === 'update:foo')
+
+		const bar = meta.props.find(prop => prop.name === 'bar');
+		const onUpdateBar = meta.events.find(event => event.name === 'update:bar')
+
+		expect(foo).toBeDefined();
+		expect(bar).toBeDefined();
+		expect(onUpdateFoo).toBeDefined();
+		expect(onUpdateBar).toBeDefined();
+	})
+
 	test('reference-type-props', () => {
 		const componentPath = path.resolve(__dirname, '../../../test-workspace/component-meta/reference-type-props/component.vue');
 		const meta = checker.getComponentMeta(componentPath);

--- a/packages/language-core/src/parsers/scriptSetupRanges.ts
+++ b/packages/language-core/src/parsers/scriptSetupRanges.ts
@@ -42,6 +42,7 @@ export function parseScriptSetupRanges(
 		type: TextRange | undefined;
 		defaultValue: TextRange | undefined;
 		required: boolean;
+		isModel?: boolean;
 	}[] = [];
 	const bindings = parseBindingRanges(ts, ast);
 	const text = ast.text;
@@ -133,6 +134,7 @@ export function parseScriptSetupRanges(
 					type: node.typeArguments?.length ? _getStartEnd(node.typeArguments[0]) : undefined,
 					defaultValue: undefined,
 					required,
+					isModel: true,
 				});
 			}
 			else if (callText === 'defineProp') {

--- a/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -238,6 +238,24 @@ export default _default;
 "
 `;
 
+exports[`vue-tsc-dts > Input: reference-type-model/component.vue, Output: reference-type-model/component.vue.d.ts 1`] = `
+"declare const _default: import("vue").DefineComponent<{
+    foo: import("vue").PropType<number>;
+    bar: import("vue").PropType<string[]>;
+}, {}, unknown, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {
+    "update:foo": (foo: number) => void;
+    "update:bar": (bar: string[]) => void;
+}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<{
+    foo: import("vue").PropType<number>;
+    bar: import("vue").PropType<string[]>;
+}>> & {
+    "onUpdate:foo"?: (foo: number) => any;
+    "onUpdate:bar"?: (bar: string[]) => any;
+}, {}, {}>;
+export default _default;
+"
+`;
+
 exports[`vue-tsc-dts > Input: reference-type-props/component.vue, Output: reference-type-props/component.vue.d.ts 1`] = `
 "import { MyProps } from './my-props';
 declare const _default: import("vue").DefineComponent<__VLS_WithDefaults<__VLS_TypePropsToOption<MyProps>, {

--- a/test-workspace/component-meta/reference-type-model/component.vue
+++ b/test-workspace/component-meta/reference-type-model/component.vue
@@ -1,0 +1,4 @@
+<script setup lang="ts">
+const bar = defineModel<number>("foo")
+const baz = defineModel<string[]>("bar")
+</script>

--- a/test-workspace/tsc/vue2/tsconfig.json
+++ b/test-workspace/tsc/vue2/tsconfig.json
@@ -19,6 +19,7 @@
 		"../vue3/#3672",
 		"../vue3/components",
 		"../vue3/defineEmits",
+		"../vue3/defineModel",
 		"../vue3/defineProp_B",
 		"../vue3/events",
 		"../vue3/no-script-block",

--- a/test-workspace/tsc/vue3/defineModel/main.vue
+++ b/test-workspace/tsc/vue3/defineModel/main.vue
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script setup lang="ts">
 import { exactType } from '../../shared';
 import { defineComponent, PropType } from 'vue';
 import ScriptSetup from './script-setup.vue';
@@ -12,6 +12,14 @@ const ScriptSetupExact = defineComponent({
 		f: { type: PropType<string>, required: true };
 		g: PropType<string>;
 	},
+	emits: {} as {
+		"update:modelValue": (_:string) => void
+		"update:c": (_:number) => void
+		"update:d": (_:number) => void
+		"update:e": (_:string) => void
+		"update:f": (_:string) => void
+		"update:g": (_:string) => void
+	},
 	setup() {
 		return {};
 	},
@@ -19,3 +27,16 @@ const ScriptSetupExact = defineComponent({
 
 exactType(ScriptSetup, ScriptSetupExact);
 </script>
+
+<template>
+	<ScriptSetup 
+		:c="0"
+		f=""
+		@update:model-value="(x) => exactType(x, {} as string)"
+		@update:c="(x) => exactType(x, {} as number)"
+		@update:d="(x) => exactType(x, {} as number)"
+		@update:e="(x) => exactType(x, {} as string)"
+		@update:f="(x) => exactType(x, {} as string)"
+		@update:g="(x) => exactType(x, {} as string)"
+	/>
+</template>


### PR DESCRIPTION
Added defineModel emit definition code generation, i.e. `update:{propName}`

I've also added the missing test for defineModel in component-meta

I belive it fix #3894