### PR TITLE
refactor(language-core): remove `experimentalAdditionalLanguageModules` and deprecated APIs

### DIFF
--- a/packages/component-meta/src/base.ts
+++ b/packages/component-meta/src/base.ts
@@ -149,7 +149,7 @@ export function baseCreate(
 		}
 	};
 
-	const vueLanguagePlugins = vue.createLanguages(
+	const vueLanguagePlugin = vue.createVueLanguagePlugin(
 		ts,
 		id => id,
 		host.getCompilationSettings(),
@@ -158,7 +158,7 @@ export function baseCreate(
 	const language = createLanguage(
 		ts,
 		ts.sys,
-		vueLanguagePlugins,
+		[vueLanguagePlugin],
 		configFileName,
 		host,
 		{

--- a/packages/language-core/schemas/vue-tsconfig.deprecated.schema.json
+++ b/packages/language-core/schemas/vue-tsconfig.deprecated.schema.json
@@ -51,6 +51,11 @@
 				"experimentalComponentOptionsWrapperEnable": {
 					"deprecated": true
 				},
+				"experimentalAdditionalLanguageModules": {
+					"deprecated": true,
+					"type": "array",
+					"markdownDescription": "https://github.com/vuejs/language-tools/pull/2267"
+				},
 				"bypassDefineComponentToExposePropsAndEmitsForJsScriptSetupComponents": {
 					"deprecated": true
 				},

--- a/packages/language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/language-core/schemas/vue-tsconfig.schema.json
@@ -106,10 +106,6 @@
 					},
 					"markdownDescription": "https://github.com/vuejs/language-tools/issues/1969"
 				},
-				"experimentalAdditionalLanguageModules": {
-					"type": "array",
-					"markdownDescription": "https://github.com/vuejs/language-tools/pull/2267"
-				},
 				"experimentalDefinePropProposal": {
 					"enum": [
 						"kevinEdition",

--- a/packages/language-core/src/languageModule.ts
+++ b/packages/language-core/src/languageModule.ts
@@ -50,7 +50,7 @@ function getFileRegistryKey(
 	return JSON.stringify(values);
 }
 
-export function createVueLanguage(
+export function createVueLanguagePlugin(
 	ts: typeof import('typescript'),
 	getFileName: (fileId: string) => string,
 	compilerOptions: ts.CompilerOptions = {},
@@ -159,21 +159,4 @@ export function createVueLanguage(
 			},
 		},
 	};
-}
-
-/**
- * @deprecated planed to remove in 2.0, please use createVueLanguage instead of
- */
-export function createLanguages(
-	ts: typeof import('typescript'),
-	getFileName: (fileId: string) => string,
-	compilerOptions: ts.CompilerOptions = {},
-	vueCompilerOptions: Partial<VueCompilerOptions> = {},
-	codegenStack: boolean = false,
-	globalTypesHolder?: string
-): LanguagePlugin[] {
-	return [
-		createVueLanguage(ts, getFileName, compilerOptions, vueCompilerOptions, codegenStack, globalTypesHolder),
-		...vueCompilerOptions.experimentalAdditionalLanguageModules?.map(module => require(module)) ?? [],
-	];
 }

--- a/packages/language-core/src/types.ts
+++ b/packages/language-core/src/types.ts
@@ -55,7 +55,6 @@ export interface VueCompilerOptions {
 	experimentalResolveStyleCssClasses: 'scoped' | 'always' | 'never';
 	experimentalModelPropName: Record<string, Record<string, boolean | Record<string, string> | Record<string, string>[]>>;
 	experimentalUseElementAccessInTemplate: boolean;
-	experimentalAdditionalLanguageModules: string[];
 }
 
 export type VueLanguagePlugin = (ctx: {

--- a/packages/language-core/src/utils/ts.ts
+++ b/packages/language-core/src/utils/ts.ts
@@ -178,11 +178,6 @@ function getPartialVueCompilerOptions(
 
 		result.plugins = plugins;
 	}
-	if (rawOptions.experimentalAdditionalLanguageModules) {
-		result.experimentalAdditionalLanguageModules = rawOptions.experimentalAdditionalLanguageModules
-			.map(resolvePath)
-			.filter((module): module is NonNullable<typeof module> => !!module);
-	}
 
 	return result;
 
@@ -266,7 +261,6 @@ export function resolveVueCompilerOptions(vueOptions: Partial<VueCompilerOptions
 
 		// experimental
 		experimentalDefinePropProposal: vueOptions.experimentalDefinePropProposal ?? false,
-		experimentalAdditionalLanguageModules: vueOptions.experimentalAdditionalLanguageModules ?? [],
 		experimentalResolveStyleCssClasses: vueOptions.experimentalResolveStyleCssClasses ?? 'scoped',
 		// https://github.com/vuejs/vue-next/blob/master/packages/compiler-dom/src/transforms/vModel.ts#L49-L51
 		// https://vuejs.org/guide/essentials/forms.html#form-input-bindings

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -1,5 +1,53 @@
 export * from '@volar/language-service';
 export * from '@vue/language-core';
 export * from './ideFeatures/nameCasing';
-export * from './languageService';
-export { TagNameCasing, AttrNameCasing } from './types';
+export * from './types';
+
+import type { ServiceEnvironment, ServicePlugin } from '@volar/language-service';
+import type { VueCompilerOptions } from './types';
+
+import { create as createEmmetServicePlugin } from 'volar-service-emmet';
+import { create as createJsonServicePlugin } from 'volar-service-json';
+import { create as createPugFormatServicePlugin } from 'volar-service-pug-beautify';
+import { create as createTypeScriptTwoslashQueriesServicePlugin } from 'volar-service-typescript-twoslash-queries';
+import { create as createCssServicePlugin } from './plugins/css';
+import { create as createTypeScriptServicePlugin } from './plugins/typescript';
+import { create as createVueAutoDotValueServicePlugin } from './plugins/vue-autoinsert-dotvalue';
+import { create as createVueAutoWrapParenthesesServicePlugin } from './plugins/vue-autoinsert-parentheses';
+import { create as createVueAutoAddSpaceServicePlugin } from './plugins/vue-autoinsert-space';
+import { create as createVueReferencesCodeLensServicePlugin } from './plugins/vue-codelens-references';
+import { create as createVueDirectiveCommentsServicePlugin } from './plugins/vue-directive-comments';
+import { create as createVueDocumentDropServicePlugin } from './plugins/vue-document-drop';
+import { create as createVueExtractFileServicePlugin } from './plugins/vue-extract-file';
+import { create as createVueSfcServicePlugin } from './plugins/vue-sfc';
+import { create as createVueTemplateServicePlugin } from './plugins/vue-template';
+import { create as createVueToggleVBindServicePlugin } from './plugins/vue-toggle-v-bind-codeaction';
+import { create as createVueTwoslashQueriesServicePlugin } from './plugins/vue-twoslash-queries';
+import { create as createVueVisualizeHiddenCallbackParamServicePlugin } from './plugins/vue-visualize-hidden-callback-param';
+
+export function createVueServicePlugins(
+	ts: typeof import('typescript'),
+	getVueOptions: (env: ServiceEnvironment) => VueCompilerOptions,
+): ServicePlugin[] {
+	return [
+		createTypeScriptServicePlugin(ts, getVueOptions),
+		createTypeScriptTwoslashQueriesServicePlugin(),
+		createCssServicePlugin(),
+		createPugFormatServicePlugin(),
+		createJsonServicePlugin(),
+		createVueTemplateServicePlugin('html', ts, getVueOptions),
+		createVueTemplateServicePlugin('pug', ts, getVueOptions),
+		createVueSfcServicePlugin(),
+		createVueTwoslashQueriesServicePlugin(ts),
+		createVueReferencesCodeLensServicePlugin(),
+		createVueDocumentDropServicePlugin(ts),
+		createVueAutoDotValueServicePlugin(ts),
+		createVueAutoWrapParenthesesServicePlugin(ts),
+		createVueAutoAddSpaceServicePlugin(),
+		createVueVisualizeHiddenCallbackParamServicePlugin(),
+		createVueDirectiveCommentsServicePlugin(),
+		createVueExtractFileServicePlugin(ts),
+		createVueToggleVBindServicePlugin(ts),
+		createEmmetServicePlugin(),
+	];
+}

--- a/packages/language-service/src/plugins/css.ts
+++ b/packages/language-service/src/plugins/css.ts
@@ -1,0 +1,24 @@
+import { ServicePlugin, ServicePluginInstance } from '@volar/language-service';
+import { create as baseCreate } from 'volar-service-css';
+
+export function create(): ServicePlugin {
+	const base = baseCreate({ scssDocumentSelector: ['scss', 'postcss'] });
+	return {
+		...base,
+		create(context): ServicePluginInstance {
+			const baseInstance = base.create(context);
+			return {
+				...baseInstance,
+				async provideDiagnostics(document, token) {
+					let diagnostics = await baseInstance.provideDiagnostics?.(document, token) ?? [];
+					if (document.languageId === 'postcss') {
+						diagnostics = diagnostics.filter(diag => diag.code !== 'css-semicolonexpected');
+						diagnostics = diagnostics.filter(diag => diag.code !== 'css-ruleorselectorexpected');
+						diagnostics = diagnostics.filter(diag => diag.code !== 'unknownAtRules');
+					}
+					return diagnostics;
+				},
+			};
+		},
+	};
+}

--- a/packages/language-service/src/plugins/vue-sfc.ts
+++ b/packages/language-service/src/plugins/vue-sfc.ts
@@ -15,7 +15,7 @@ export interface Provide {
 
 export function create(): ServicePlugin {
 	return {
-		name: 'vue-basic',
+		name: 'vue-sfc',
 		create(context): ServicePluginInstance<Provide> {
 
 			const htmlPlugin = createHtmlService({

--- a/packages/language-service/tests/utils/format.ts
+++ b/packages/language-service/tests/utils/format.ts
@@ -1,12 +1,12 @@
 import * as kit from '@volar/kit';
 import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
-import { resolveLanguages, resolveServices, resolveVueCompilerOptions } from '../../out';
+import { createVueLanguagePlugin, createVueServicePlugins, resolveVueCompilerOptions } from '../../out';
 
 const resolvedVueOptions = resolveVueCompilerOptions({});
-const languages = resolveLanguages({}, ts, fileId => formatter.env.typescript!.uriToFileName(fileId), {}, resolvedVueOptions);
-const services = resolveServices({}, ts, () => resolvedVueOptions);
-const formatter = kit.createFormatter(Object.values(languages), Object.values(services));
+const vueLanguagePlugin = createVueLanguagePlugin(ts, fileId => formatter.env.typescript!.uriToFileName(fileId), {}, resolvedVueOptions);
+const vueServicePLugins = createVueServicePlugins(ts, () => resolvedVueOptions);
+const formatter = kit.createFormatter([vueLanguagePlugin], vueServicePLugins);
 
 export function defineFormatTest(options: {
 	title: string;

--- a/packages/tsc/src/index.ts
+++ b/packages/tsc/src/index.ts
@@ -21,7 +21,7 @@ export function run() {
 				runExtensions.length === extensions.length
 				&& runExtensions.every(ext => extensions.includes(ext))
 			) {
-				return vue.createLanguages(
+				const vueLanguagePlugin = vue.createVueLanguagePlugin(
 					ts,
 					id => id,
 					options.options,
@@ -29,6 +29,7 @@ export function run() {
 					false,
 					createFakeGlobalTypesHolder(options)?.replace(windowsPathReg, '/'),
 				);
+				return [vueLanguagePlugin];
 			}
 			else {
 				runExtensions = extensions;

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -30,7 +30,7 @@ describe('vue-tsc-dts', () => {
 		const vueOptions = typeof configFilePath === 'string'
 			? vue.createParsedCommandLine(ts, ts.sys, configFilePath.replace(windowsPathReg, '/')).vueOptions
 			: {};
-		return vue.createLanguages(
+		const vueLanguagePlugin = vue.createVueLanguagePlugin(
 			ts,
 			id => id,
 			options.options,
@@ -38,6 +38,7 @@ describe('vue-tsc-dts', () => {
 			false,
 			fakeGlobalTypesHolder?.replace(windowsPathReg, '/'),
 		);
+		return [vueLanguagePlugin];
 	});
 	const program = createProgram(options);
 

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -6,7 +6,7 @@ const windowsPathReg = /\\/g;
 
 export = createLanguageServicePlugin((ts, info) => {
 	const vueOptions = vue.resolveVueCompilerOptions(getVueCompilerOptions());
-	const languagePlugins = vue.createLanguages(
+	const languagePlugin = vue.createVueLanguagePlugin(
 		ts,
 		id => id,
 		info.languageServiceHost.getCompilationSettings(),
@@ -22,7 +22,7 @@ export = createLanguageServicePlugin((ts, info) => {
 		return result;
 	};
 
-	return languagePlugins;
+	return [languagePlugin];
 
 	function getVueCompilerOptions() {
 		if (info.project.projectKind === ts.server.ProjectKind.Configured) {


### PR DESCRIPTION
## Changes

- Remove deprecated `createLanguages` API
- `createVueLanguage` API rename to `createVueLanguagePlugin`
- No longer support for `experimentalAdditionalLanguageModules`, alternatives will be provided (probably after v2 is released)