### PR TITLE
feat(language-service): migrate to named pipe server using TypeScript LanguageService

### DIFF
--- a/extensions/vscode/src/common.ts
+++ b/extensions/vscode/src/common.ts
@@ -79,7 +79,7 @@ async function doActivate(context: vscode.ExtensionContext, createLc: CreateLang
 		selectors.push({ language: 'markdown' });
 	}
 
-	activateAutoInsertion(selectors, client); // TODO: implement auto insert .value
+	activateAutoInsertion(selectors, client);
 	activateDocumentDropEdit(selectors, client);
 	activateWriteVirtualFiles('volar.action.writeVirtualFiles', client);
 

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -25,6 +25,7 @@
 		"@vue/shared": "^3.4.0",
 		"computeds": "^0.0.1",
 		"path-browserify": "^1.0.1",
+		"typescript-vue-plugin": "1.8.27",
 		"volar-service-css": "0.0.31",
 		"volar-service-emmet": "0.0.31",
 		"volar-service-html": "0.0.31",

--- a/packages/language-service/src/plugins/typescript.ts
+++ b/packages/language-service/src/plugins/typescript.ts
@@ -1,18 +1,33 @@
 import { ServiceEnvironment, ServicePlugin, ServicePluginInstance } from '@volar/language-service';
 import { VueCompilerOptions, VueGeneratedCode, hyphenateTag, scriptRanges } from '@vue/language-core';
 import { capitalize } from '@vue/shared';
-import { Provide as TSProvide, create as baseCreate } from 'volar-service-typescript';
+import * as ts from 'typescript';
+import { create as baseCreate } from 'volar-service-typescript';
 import type { Data } from 'volar-service-typescript/lib/features/completions/basic';
-import type * as vscode from 'vscode-languageserver-protocol';
 import { getNameCasing } from '../ideFeatures/nameCasing';
 import { TagNameCasing } from '../types';
 import { createAddComponentToOptionEdit } from './vue-extract-file';
+
+// TODO: migrate patchs to ts plugin
+
+const asts = new WeakMap<ts.IScriptSnapshot, ts.SourceFile>();
+
+export function getAst(fileName: string, snapshot: ts.IScriptSnapshot, scriptKind?: ts.ScriptKind) {
+	let ast = asts.get(snapshot);
+	if (!ast) {
+		ast = ts.createSourceFile(fileName, snapshot.getText(0, snapshot.getLength()), ts.ScriptTarget.Latest, undefined, scriptKind);
+		asts.set(snapshot, ast);
+	}
+	return ast;
+}
 
 export function create(
 	ts: typeof import('typescript'),
 	getVueOptions: (env: ServiceEnvironment) => VueCompilerOptions,
 ): ServicePlugin {
+
 	const base = baseCreate(ts);
+
 	return {
 		...base,
 		create(context): ServicePluginInstance {
@@ -72,10 +87,6 @@ export function create(
 
 					let newName: string | undefined;
 
-					if (itemData?.uri && item.additionalTextEdits) {
-						patchAdditionalTextEdits(itemData.uri, item.additionalTextEdits);
-					}
-
 					for (const ext of getVueOptions(context.env).extensions) {
 						const suffix = capitalize(ext.substring('.'.length)); // .vue -> Vue
 						if (
@@ -117,22 +128,26 @@ export function create(
 
 					const data: Data = item.data;
 					if (item.data?.__isComponentAutoImport && data && item.additionalTextEdits?.length && item.textEdit && itemData?.uri) {
-						const langaugeService = context.inject<TSProvide, 'typescript/languageService'>('typescript/languageService');
-						const [virtualCode] = context.documents.getVirtualCodeByUri(itemData.uri);
-						const ast = langaugeService.getProgram()?.getSourceFile(itemData.uri);
-						const exportDefault = ast ? scriptRanges.parseScriptRanges(ts, ast, false, true).exportDefault : undefined;
-						if (virtualCode && ast && exportDefault) {
-							const componentName = newName ?? item.textEdit.newText;
-							const optionEdit = createAddComponentToOptionEdit(ts, ast, componentName);
-							if (optionEdit) {
-								const textDoc = context.documents.get(context.documents.getVirtualCodeUri(context.language.files.getByVirtualCode(virtualCode).id, virtualCode.id), virtualCode.languageId, virtualCode.snapshot);
-								item.additionalTextEdits.push({
-									range: {
-										start: textDoc.positionAt(optionEdit.range.start),
-										end: textDoc.positionAt(optionEdit.range.end),
-									},
-									newText: optionEdit.newText,
-								});
+						const [virtualCode, sourceFile] = context.documents.getVirtualCodeByUri(itemData.uri);
+						if (virtualCode && (sourceFile.generated?.code instanceof VueGeneratedCode)) {
+							const script = sourceFile.generated.languagePlugin.typescript?.getScript(sourceFile.generated.code);
+							if (script) {
+								const ast = getAst(sourceFile.generated.code.fileName, script.code.snapshot, script.scriptKind);
+								const exportDefault = scriptRanges.parseScriptRanges(ts, ast, false, true).exportDefault;
+								if (exportDefault) {
+									const componentName = newName ?? item.textEdit.newText;
+									const optionEdit = createAddComponentToOptionEdit(ts, ast, componentName);
+									if (optionEdit) {
+										const textDoc = context.documents.get(context.documents.getVirtualCodeUri(sourceFile.id, virtualCode.id), virtualCode.languageId, virtualCode.snapshot);
+										item.additionalTextEdits.push({
+											range: {
+												start: textDoc.positionAt(optionEdit.range.start),
+												end: textDoc.positionAt(optionEdit.range.end),
+											},
+											newText: optionEdit.newText,
+										});
+									}
+								}
 							}
 						}
 					}
@@ -142,28 +157,6 @@ export function create(
 				async provideCodeActions(document, range, context, token) {
 					const result = await baseInstance.provideCodeActions?.(document, range, context, token);
 					return result?.filter(codeAction => codeAction.title.indexOf('__VLS_') === -1);
-				},
-				async resolveCodeAction(item, token) {
-
-					const result = await baseInstance.resolveCodeAction?.(item, token) ?? item;
-
-					if (result?.edit?.changes) {
-						for (const uri in result.edit.changes) {
-							const edits = result.edit.changes[uri];
-							if (edits) {
-								patchAdditionalTextEdits(uri, edits);
-							}
-						}
-					}
-					if (result?.edit?.documentChanges) {
-						for (const documentChange of result.edit.documentChanges) {
-							if ('textDocument' in documentChange) {
-								patchAdditionalTextEdits(documentChange.textDocument.uri, documentChange.edits);
-							}
-						}
-					}
-
-					return result;
 				},
 				async provideSemanticDiagnostics(document, token) {
 					const result = await baseInstance.provideSemanticDiagnostics?.(document, token);
@@ -183,25 +176,4 @@ export function create(
 			};
 		},
 	};
-}
-
-// fix https://github.com/vuejs/language-tools/issues/916
-function patchAdditionalTextEdits(uri: string, edits: vscode.TextEdit[]) {
-	if (
-		uri.endsWith('.vue.js')
-		|| uri.endsWith('.vue.ts')
-		|| uri.endsWith('.vue.jsx')
-		|| uri.endsWith('.vue.tsx')
-	) {
-		for (const edit of edits) {
-			if (
-				edit.range.start.line === 0
-				&& edit.range.start.character === 0
-				&& edit.range.end.line === 0
-				&& edit.range.end.character === 0
-			) {
-				edit.newText = '\n' + edit.newText;
-			}
-		}
-	}
 }

--- a/packages/language-service/src/plugins/vue-autoinsert-dotvalue.ts
+++ b/packages/language-service/src/plugins/vue-autoinsert-dotvalue.ts
@@ -1,9 +1,10 @@
 import { ServicePlugin, ServicePluginInstance } from '@volar/language-service';
 import { hyphenateAttr } from '@vue/language-core';
 import type * as ts from 'typescript';
-import { Provide } from 'volar-service-typescript';
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
+import { getAst } from './typescript';
+import { sendGetPropertiesAtLocation } from 'typescript-vue-plugin/out/requests/client';
 
 export function create(ts: typeof import('typescript')): ServicePlugin {
 	return {
@@ -22,53 +23,32 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 					if (!enabled)
 						return;
 
-					const program = context.inject<Provide, 'typescript/languageService'>('typescript/languageService').getProgram();
-					if (!program)
-						return;
+					const [_, file] = context.documents.getVirtualCodeByUri(document.uri);
 
-					const sourceFile = program.getSourceFile(context.env.typescript!.uriToFileName(document.uri));
-					if (!sourceFile)
-						return;
+					let fileName: string | undefined;
+					let ast: ts.SourceFile | undefined;
 
-					if (isBlacklistNode(ts, sourceFile, document.offsetAt(position), false))
-						return;
-
-					const node = findPositionIdentifier(sourceFile, sourceFile, document.offsetAt(position));
-					if (!node)
-						return;
-
-					const token = context.inject<Provide, 'typescript/languageServiceHost'>('typescript/languageServiceHost').getCancellationToken?.();
-					if (token) {
-						context.inject<Provide, 'typescript/languageService'>('typescript/languageService').getQuickInfoAtPosition(context.env.typescript!.uriToFileName(document.uri), node.end);
-						if (token?.isCancellationRequested()) {
-							return; // check cancel here because type checker do not use cancel token
+					if (file?.generated) {
+						const script = file.generated.languagePlugin.typescript?.getScript(file.generated.code);
+						if (script) {
+							fileName = context.env.typescript!.uriToFileName(file.id);
+							ast = getAst(fileName, script.code.snapshot, script.scriptKind);
 						}
 					}
-
-					const checker = program.getTypeChecker();
-					const type = checker.getTypeAtLocation(node);
-					const props = type.getProperties();
-
-					if (props.some(prop => prop.name === 'value')) {
-						return '${1:.value}';
+					else if (file) {
+						fileName = context.env.typescript!.uriToFileName(file.id);
+						ast = getAst(fileName, file.snapshot);
 					}
 
-					function findPositionIdentifier(sourceFile: ts.SourceFile, node: ts.Node, offset: number) {
+					if (!ast || !fileName)
+						return;
 
-						let result: ts.Node | undefined;
+					if (isBlacklistNode(ts, ast, document.offsetAt(position), false))
+						return;
 
-						node.forEachChild(child => {
-							if (!result) {
-								if (child.end === offset && ts.isIdentifier(child)) {
-									result = child;
-								}
-								else if (child.end >= offset && child.getStart(sourceFile) < offset) {
-									result = findPositionIdentifier(sourceFile, child, offset);
-								}
-							}
-						});
-
-						return result;
+					const props = await sendGetPropertiesAtLocation(fileName, document.offsetAt(position)) ?? [];
+					if (props.some(prop => prop === 'value')) {
+						return '${1:.value}';
 					}
 				},
 			};

--- a/packages/language-service/src/plugins/vue-extract-file.ts
+++ b/packages/language-service/src/plugins/vue-extract-file.ts
@@ -1,8 +1,8 @@
 import { CreateFile, ServicePlugin, TextDocumentEdit, TextEdit } from '@volar/language-service';
 import { ExpressionNode, type TemplateChildNode } from '@vue/compiler-dom';
-import { Sfc, SourceFile, VueGeneratedCode, isSemanticTokensEnabled, scriptRanges } from '@vue/language-core';
+import { Sfc, VueGeneratedCode, scriptRanges } from '@vue/language-core';
 import type * as ts from 'typescript';
-import type { Provide } from 'volar-service-typescript';
+import { sendCollectExtractPropsRequest } from 'typescript-vue-plugin/out/requests/client';
 import type * as vscode from 'vscode-languageserver-protocol';
 
 interface ActionData {
@@ -26,11 +26,11 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 						return;
 					}
 
-					const [vueFile] = context.documents.getVirtualCodeByUri(document.uri);
-					if (!vueFile || !(vueFile instanceof VueGeneratedCode))
+					const [code, vueCode] = context.documents.getVirtualCodeByUri(document.uri);
+					if (!(vueCode?.generated?.code instanceof VueGeneratedCode) || code?.id !== 'template')
 						return;
 
-					const { sfc } = vueFile;
+					const { sfc } = vueCode.generated.code;
 					const script = sfc.scriptSetup ?? sfc.script;
 
 					if (!sfc.template || !script)
@@ -57,9 +57,13 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 
 					const { uri, range, newName } = codeAction.data as ActionData;
 					const [startOffset, endOffset]: [number, number] = range;
-					const [vueCode, fileSource] = context.documents.getVirtualCodeByUri(uri) as [VueGeneratedCode, SourceFile];
-					const document = context.documents.get(uri, vueCode.languageId, vueCode.snapshot)!;
-					const { sfc } = vueCode;
+					const [code, sourceFile] = context.documents.getVirtualCodeByUri(uri);
+					if (!(sourceFile?.generated?.code instanceof VueGeneratedCode) || code?.id !== 'template')
+						return codeAction;
+
+					const document = context.documents.get(uri, code.languageId, code.snapshot)!;
+					const sfcDocument = context.documents.get(sourceFile.id, sourceFile.languageId, sourceFile.snapshot)!;
+					const { sfc } = sourceFile.generated.code;
 					const script = sfc.scriptSetup ?? sfc.script;
 
 					if (!sfc.template || !script)
@@ -69,12 +73,13 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 					if (!templateCodeRange)
 						return codeAction;
 
-					const languageService = context.inject<Provide, 'typescript/languageService'>('typescript/languageService');
-					const sourceFile = languageService.getProgram()!.getSourceFile(vueCode.fileName)!;
-					const toExtract = collectExtractProps();
+					const toExtract = await sendCollectExtractPropsRequest(sourceFile.generated.code.fileName, templateCodeRange) ?? [];
+					if (!toExtract)
+						return codeAction;
+
 					const templateInitialIndent = await context.env.getConfiguration!<boolean>('vue.format.template.initialIndent') ?? true;
 					const scriptInitialIndent = await context.env.getConfiguration!<boolean>('vue.format.script.initialIndent') ?? false;
-					const newUri = document.uri.substring(0, document.uri.lastIndexOf('/') + 1) + `${newName}.vue`;
+					const newUri = sfcDocument.uri.substring(0, sfcDocument.uri.lastIndexOf('/') + 1) + `${newName}.vue`;
 					const lastImportNode = getLastImportNode(ts, script.ast);
 
 					let newFileTags = [];
@@ -92,21 +97,24 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 						newFileTags = newFileTags.reverse();
 					}
 
-					const currentFileEdits: vscode.TextEdit[] = [
+					const templateEdits: vscode.TextEdit[] = [
 						{
 							range: {
-								start: document.positionAt(sfc.template.startTagEnd + templateCodeRange[0]),
-								end: document.positionAt(sfc.template.startTagEnd + templateCodeRange[1]),
+								start: document.positionAt(templateCodeRange[0]),
+								end: document.positionAt(templateCodeRange[1]),
 							},
 							newText: generateReplaceTemplate(),
 						},
+					];
+
+					const sfcEdits: vscode.TextEdit[] = [
 						{
 							range: lastImportNode ? {
-								start: document.positionAt(script.startTagEnd + lastImportNode.end),
-								end: document.positionAt(script.startTagEnd + lastImportNode.end),
+								start: sfcDocument.positionAt(script.startTagEnd + lastImportNode.end),
+								end: sfcDocument.positionAt(script.startTagEnd + lastImportNode.end),
 							} : {
-								start: document.positionAt(script.startTagEnd),
-								end: document.positionAt(script.startTagEnd),
+								start: sfcDocument.positionAt(script.startTagEnd),
+								end: sfcDocument.positionAt(script.startTagEnd),
 							},
 							newText: `\nimport ${newName} from './${newName}.vue'`,
 						},
@@ -115,10 +123,10 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 					if (sfc.script) {
 						const edit = createAddComponentToOptionEdit(ts, sfc.script.ast, newName);
 						if (edit) {
-							currentFileEdits.push({
+							sfcEdits.push({
 								range: {
-									start: document.positionAt(sfc.script.startTagEnd + edit.range.start),
-									end: document.positionAt(sfc.script.startTagEnd + edit.range.end),
+									start: sfcDocument.positionAt(sfc.script.startTagEnd + edit.range.start),
+									end: sfcDocument.positionAt(sfc.script.startTagEnd + edit.range.end),
 								},
 								newText: edit.newText,
 							});
@@ -129,13 +137,22 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 						...codeAction,
 						edit: {
 							documentChanges: [
-								// editing current file
+								// editing template virtual document
 								{
 									textDocument: {
 										uri: document.uri,
 										version: null,
 									},
-									edits: currentFileEdits,
+									edits: templateEdits,
+								} satisfies TextDocumentEdit,
+
+								// editing vue sfc
+								{
+									textDocument: {
+										uri: sourceFile.id,
+										version: null,
+									},
+									edits: sfcEdits,
 								} satisfies TextDocumentEdit,
 
 								// creating new file with content
@@ -162,60 +179,10 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 						},
 					};
 
-					function collectExtractProps() {
-
-						const result = new Map<string, {
-							name: string;
-							type: string;
-							model: boolean;
-						}>();
-						const checker = languageService.getProgram()!.getTypeChecker();
-						const script = fileSource.generated?.languagePlugin.typescript?.getScript(vueCode);
-						const maps = script ? [...context.documents.getMaps(script.code)] : [];
-
-						sourceFile.forEachChild(function visit(node) {
-							if (
-								ts.isPropertyAccessExpression(node)
-								&& ts.isIdentifier(node.expression)
-								&& node.expression.text === '__VLS_ctx'
-								&& ts.isIdentifier(node.name)
-							) {
-								const { name } = node;
-								for (const map of maps) {
-									const source = map.map.getSourceOffset(name.getEnd());
-									if (
-										source
-										&& source[0] >= sfc.template!.startTagEnd + templateCodeRange![0]
-										&& source[0] <= sfc.template!.startTagEnd + templateCodeRange![1]
-										&& isSemanticTokensEnabled(source[1].data)
-									) {
-										if (!result.has(name.text)) {
-											const type = checker.getTypeAtLocation(node);
-											const typeString = checker.typeToString(type, node, ts.TypeFormatFlags.NoTruncation);
-											result.set(name.text, {
-												name: name.text,
-												type: typeString.includes('__VLS_') ? 'any' : typeString,
-												model: false,
-											});
-										}
-										const isModel = ts.isPostfixUnaryExpression(node.parent) || ts.isBinaryExpression(node.parent);
-										if (isModel) {
-											result.get(name.text)!.model = true;
-										}
-										break;
-									}
-								}
-							}
-							node.forEachChild(visit);
-						});
-
-						return [...result.values()];
-					}
-
 					function generateNewScriptContents() {
 						const lines = [];
-						const props = [...toExtract.values()].filter(p => !p.model);
-						const models = [...toExtract.values()].filter(p => p.model);
+						const props = toExtract.filter(p => !p.model);
+						const models = toExtract.filter(p => p.model);
 						if (props.length) {
 							lines.push(`defineProps<{ \n\t${props.map(p => `${p.name}: ${p.type};`).join('\n\t')}\n}>()`);
 						}
@@ -226,8 +193,8 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 					}
 
 					function generateReplaceTemplate() {
-						const props = [...toExtract.values()].filter(p => !p.model);
-						const models = [...toExtract.values()].filter(p => p.model);
+						const props = toExtract.filter(p => !p.model);
+						const models = toExtract.filter(p => p.model);
 						return [
 							`<${newName}`,
 							...props.map(p => `:${p.name}="${p.name}"`),
@@ -236,26 +203,19 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 						].join(' ');
 					}
 				},
-
-				transformCodeAction(item) {
-					return item; // ignore mapping
-				},
 			};
 		},
 	};
 }
 
-function selectTemplateCode(startOffset: number, endOffset: number, templateBlock: NonNullable<Sfc['template']>) {
-
-	if (startOffset < templateBlock.startTagEnd || endOffset > templateBlock.endTagStart)
-		return;
+function selectTemplateCode(startOffset: number, endOffset: number, templateBlock: NonNullable<Sfc['template']>): [number, number] | undefined {
 
 	const insideNodes: (TemplateChildNode | ExpressionNode)[] = [];
 
 	templateBlock.ast?.children.forEach(function visit(node: TemplateChildNode | ExpressionNode) {
 		if (
-			node.loc.start.offset + templateBlock.startTagEnd >= startOffset
-			&& node.loc.end.offset + templateBlock.startTagEnd <= endOffset
+			node.loc.start.offset >= startOffset
+			&& node.loc.end.offset <= endOffset
 		) {
 			insideNodes.push(node);
 		}

--- a/packages/language-service/src/plugins/vue-twoslash-queries.ts
+++ b/packages/language-service/src/plugins/vue-twoslash-queries.ts
@@ -1,7 +1,7 @@
 import { ServicePlugin, ServicePluginInstance } from '@volar/language-service';
 import * as vue from '@vue/language-core';
-import { Provide } from 'volar-service-typescript';
 import type * as vscode from 'vscode-languageserver-protocol';
+import { sendGetQuickInfoAtPosition } from 'typescript-vue-plugin/out/requests/client';
 
 const twoslashReg = /<!--\s*\^\?\s*-->/g;
 
@@ -10,60 +10,45 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 		name: 'vue-twoslash-queries',
 		create(context): ServicePluginInstance {
 			return {
-				provideInlayHints(document, range) {
-					return worker(document.uri, (vueFile, { generated }) => {
+				async provideInlayHints(document, range) {
 
-						const hoverOffsets: [vscode.Position, number][] = [];
-						const inlayHints: vscode.InlayHint[] = [];
-						const languageService = context.inject<Provide, 'typescript/languageService'>('typescript/languageService');
+					const [virtualCode, sourceFile] = context.documents.getVirtualCodeByUri(document.uri);
+					if (!(sourceFile?.generated?.code instanceof vue.VueGeneratedCode) || virtualCode?.id !== 'template')
+						return;
 
-						for (const pointer of document.getText(range).matchAll(twoslashReg)) {
-							const offset = pointer.index! + pointer[0].indexOf('^?') + document.offsetAt(range.start);
-							const position = document.positionAt(offset);
-							hoverOffsets.push([position, document.offsetAt({
-								line: position.line - 1,
-								character: position.character,
-							})]);
-						}
+					const hoverOffsets: [vscode.Position, number][] = [];
+					const inlayHints: vscode.InlayHint[] = [];
 
-						if (generated) {
-							const script = generated.languagePlugin.typescript?.getScript(vueFile);
-							if (script) {
-								for (const map of context.documents.getMaps(script.code)) {
-									for (const [pointerPosition, hoverOffset] of hoverOffsets) {
-										for (const [tsOffset, mapping] of map.map.getGeneratedOffsets(hoverOffset)) {
-											if (vue.isHoverEnabled(mapping.data)) {
-												const fileName = context.env.typescript!.uriToFileName(vueFile.id);
-												const quickInfo = languageService.getQuickInfoAtPosition(fileName, tsOffset);
-												if (quickInfo) {
-													inlayHints.push({
-														position: { line: pointerPosition.line, character: pointerPosition.character + 2 },
-														label: ts.displayPartsToString(quickInfo.displayParts),
-														paddingLeft: true,
-														paddingRight: false,
-													});
-												}
-												break;
-											}
-										}
-									}
+					for (const pointer of document.getText(range).matchAll(twoslashReg)) {
+						const offset = pointer.index! + pointer[0].indexOf('^?') + document.offsetAt(range.start);
+						const position = document.positionAt(offset);
+						hoverOffsets.push([position, document.offsetAt({
+							line: position.line - 1,
+							character: position.character,
+						})]);
+					}
+
+					for (const [pointerPosition, hoverOffset] of hoverOffsets) {
+						for (const [_1, [_2, map]] of context.language.files.getMaps(virtualCode)) {
+							for (const [sourceOffset] of map.getSourceOffsets(hoverOffset)) {
+								const quickInfo = await sendGetQuickInfoAtPosition(sourceFile.generated.code.fileName, sourceOffset);
+								if (quickInfo) {
+									inlayHints.push({
+										position: { line: pointerPosition.line, character: pointerPosition.character + 2 },
+										label: ts.displayPartsToString(quickInfo.displayParts),
+										paddingLeft: true,
+										paddingRight: false,
+									});
+									break;
 								}
 							}
+							break;
 						}
+					}
 
-						return inlayHints;
-					});
+					return inlayHints;
 				},
 			};
-
-			function worker<T>(uri: string, callback: (vueSourceFile: vue.VueGeneratedCode, sourceFile: vue.SourceFile) => T) {
-
-				const [virtualCode, sourceFile] = context.documents.getVirtualCodeByUri(uri);
-				if (!(virtualCode instanceof vue.VueGeneratedCode))
-					return;
-
-				return callback(virtualCode, sourceFile!);
-			}
 		},
 	};
 }

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -15,5 +15,8 @@
 	"dependencies": {
 		"@volar/typescript": "~2.1.0",
 		"@vue/language-core": "1.8.27"
+	},
+	"devDependencies": {
+		"@types/node": "latest"
 	}
 }

--- a/packages/typescript-plugin/src/createLanguageServicePlugin.ts
+++ b/packages/typescript-plugin/src/createLanguageServicePlugin.ts
@@ -1,0 +1,87 @@
+import type * as ts from 'typescript';
+import { decorateLanguageService } from '@volar/typescript/lib/node/decorateLanguageService';
+import { decorateLanguageServiceHost, searchExternalFiles } from '@volar/typescript/lib/node/decorateLanguageServiceHost';
+import { createFileRegistry, LanguagePlugin, resolveCommonLanguageId } from '@vue/language-core';
+import { projects } from './requests/utils';
+
+const externalFiles = new WeakMap<ts.server.Project, string[]>();
+const projectExternalFileExtensions = new WeakMap<ts.server.Project, string[]>();
+const decoratedLanguageServices = new WeakSet<ts.LanguageService>();
+const decoratedLanguageServiceHosts = new WeakSet<ts.LanguageServiceHost>();
+
+export function createLanguageServicePlugin(
+	loadLanguagePlugins: (
+		ts: typeof import('typescript'),
+		info: ts.server.PluginCreateInfo
+	) => LanguagePlugin[]
+): ts.server.PluginModuleFactory {
+	return modules => {
+		const { typescript: ts } = modules;
+		const pluginModule: ts.server.PluginModule = {
+			create(info) {
+				if (
+					!decoratedLanguageServices.has(info.languageService)
+					&& !decoratedLanguageServiceHosts.has(info.languageServiceHost)
+				) {
+					decoratedLanguageServices.add(info.languageService);
+					decoratedLanguageServiceHosts.add(info.languageServiceHost);
+
+					const languagePlugins = loadLanguagePlugins(ts, info);
+					const extensions = languagePlugins
+						.map(plugin => plugin.typescript?.extraFileExtensions.map(ext => '.' + ext.extension) ?? [])
+						.flat();
+					projectExternalFileExtensions.set(info.project, extensions);
+					const getScriptSnapshot = info.languageServiceHost.getScriptSnapshot.bind(info.languageServiceHost);
+					const files = createFileRegistry(
+						languagePlugins,
+						ts.sys.useCaseSensitiveFileNames,
+						fileName => {
+							const snapshot = getScriptSnapshot(fileName);
+							if (snapshot) {
+								files.set(fileName, resolveCommonLanguageId(fileName), snapshot);
+							}
+							else {
+								files.delete(fileName);
+							}
+						}
+					);
+
+					projects.set(info.project, [info, files, ts]);
+
+					decorateLanguageService(files, info.languageService);
+					decorateLanguageServiceHost(files, info.languageServiceHost, ts);
+				}
+
+				return info.languageService;
+			},
+			getExternalFiles(project, updateLevel = 0) {
+				if (
+					updateLevel >= (1 satisfies ts.ProgramUpdateLevel.RootNamesAndUpdate)
+					|| !externalFiles.has(project)
+				) {
+					const oldFiles = externalFiles.get(project);
+					const newFiles = searchExternalFiles(ts, project, projectExternalFileExtensions.get(project)!);
+					externalFiles.set(project, newFiles);
+					if (oldFiles && !arrayItemsEqual(oldFiles, newFiles)) {
+						project.refreshDiagnostics();
+					}
+				}
+				return externalFiles.get(project)!;
+			},
+		};
+		return pluginModule;
+	};
+}
+
+export function arrayItemsEqual(a: string[], b: string[]) {
+	if (a.length !== b.length) {
+		return false;
+	}
+	const set = new Set(a);
+	for (const file of b) {
+		if (!set.has(file)) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/packages/typescript-plugin/src/index.ts
+++ b/packages/typescript-plugin/src/index.ts
@@ -1,10 +1,13 @@
-import { createLanguageServicePlugin } from '@volar/typescript/lib/quickstart/createLanguageServicePlugin';
+import { createLanguageServicePlugin } from './createLanguageServicePlugin';
 import * as vue from '@vue/language-core';
-import type * as _ from 'typescript';
+import { startNamedPipeServer } from './requests/server';
 
 const windowsPathReg = /\\/g;
 
 export = createLanguageServicePlugin((ts, info) => {
+
+	startNamedPipeServer();
+
 	const vueOptions = vue.resolveVueCompilerOptions(getVueCompilerOptions());
 	const languagePlugin = vue.createVueLanguagePlugin(
 		ts,

--- a/packages/typescript-plugin/src/requests/client.ts
+++ b/packages/typescript-plugin/src/requests/client.ts
@@ -1,0 +1,53 @@
+import * as net from 'net';
+import type { collectExtractProps } from './collectExtractProps';
+import type { getPropertiesAtLocation } from './getPropertiesAtLocation';
+import { Request } from './server';
+import { pipeFile } from './utils';
+import { getQuickInfoAtPosition } from './getQuickInfoAtPosition';
+
+export function sendCollectExtractPropsRequest(fileName: string, templateCodeRange: [number, number]) {
+	return sendRequest<ReturnType<typeof collectExtractProps>>({
+		type: 'collectExtractProps',
+		fileName,
+		templateCodeRange,
+	});
+}
+
+export function sendGetPropertiesAtLocation(fileName: string, position: number) {
+	return sendRequest<ReturnType<typeof getPropertiesAtLocation>>({
+		type: 'getPropertiesAtLocation',
+		fileName,
+		position,
+	});
+}
+
+export function sendGetQuickInfoAtPosition(fileName: string, position: number) {
+	return sendRequest<ReturnType<typeof getQuickInfoAtPosition>>({
+		type: 'getQuickInfoAtPosition',
+		fileName,
+		position,
+	});
+}
+
+function sendRequest<T>(request: Request) {
+	return new Promise<T | undefined | null>(resolve => {
+		try {
+			const client = net.connect(pipeFile);
+			client.on('connect', () => {
+				client.write(JSON.stringify(request));
+			});
+			client.on('data', data => {
+				const text = data.toString();
+				resolve(JSON.parse(text));
+				client.end();
+			});
+			client.on('error', err => {
+				console.error(err);
+				return resolve(undefined);
+			});
+		} catch (e) {
+			console.error(e);
+			return resolve(undefined);
+		}
+	});
+}

--- a/packages/typescript-plugin/src/requests/collectExtractProps.ts
+++ b/packages/typescript-plugin/src/requests/collectExtractProps.ts
@@ -1,0 +1,66 @@
+import { VueGeneratedCode, isSemanticTokensEnabled } from '@vue/language-core';
+import { getProject } from './utils';
+
+export function collectExtractProps(fileName: string, templateCodeRange: [number, number], isTsPlugin: boolean = true) {
+
+	const match = getProject(fileName);
+	if (!match) {
+		return;
+	}
+
+	const [info, files, ts] = match;
+	const volarFile = files.get(fileName);
+	if (!(volarFile?.generated?.code instanceof VueGeneratedCode)) {
+		return;
+	}
+
+	const result = new Map<string, {
+		name: string;
+		type: string;
+		model: boolean;
+	}>();
+	const languageService = info.languageService;
+	const sourceFile = languageService.getProgram()!.getSourceFile(fileName)!;
+	const checker = languageService.getProgram()!.getTypeChecker();
+	const script = volarFile.generated?.languagePlugin.typescript?.getScript(volarFile.generated.code);
+	const maps = script ? [...files.getMaps(script.code).values()] : [];
+	const sfc = volarFile.generated.code.sfc;
+
+	sourceFile.forEachChild(function visit(node) {
+		if (
+			ts.isPropertyAccessExpression(node)
+			&& ts.isIdentifier(node.expression)
+			&& node.expression.text === '__VLS_ctx'
+			&& ts.isIdentifier(node.name)
+		) {
+			const { name } = node;
+			for (const [_, map] of maps) {
+				const source = map.getSourceOffset(name.getEnd() - (isTsPlugin ? volarFile.snapshot.getLength() : 0));
+				if (
+					source
+					&& source[0] >= sfc.template!.startTagEnd + templateCodeRange[0]
+					&& source[0] <= sfc.template!.startTagEnd + templateCodeRange[1]
+					&& isSemanticTokensEnabled(source[1].data)
+				) {
+					if (!result.has(name.text)) {
+						const type = checker.getTypeAtLocation(node);
+						const typeString = checker.typeToString(type, node, ts.TypeFormatFlags.NoTruncation);
+						result.set(name.text, {
+							name: name.text,
+							type: typeString.includes('__VLS_') ? 'any' : typeString,
+							model: false,
+						});
+					}
+					const isModel = ts.isPostfixUnaryExpression(node.parent) || ts.isBinaryExpression(node.parent);
+					if (isModel) {
+						result.get(name.text)!.model = true;
+					}
+					break;
+				}
+			}
+		}
+		node.forEachChild(visit);
+	});
+
+	return [...result.values()];
+}

--- a/packages/typescript-plugin/src/requests/getPropertiesAtLocation.ts
+++ b/packages/typescript-plugin/src/requests/getPropertiesAtLocation.ts
@@ -1,0 +1,52 @@
+import { getProject } from './utils';
+import type * as ts from 'typescript';
+
+export function getPropertiesAtLocation(fileName: string, position: number, isTsPlugin: boolean = true) {
+
+	const match = getProject(fileName);
+	if (!match) {
+		return;
+	}
+
+	const [info, files, ts] = match;
+	const languageService = info.languageService;
+	const program = languageService.getProgram();
+	if (!program) {
+		return;
+	}
+
+	const sourceFile = program.getSourceFile(fileName);
+	if (!sourceFile) {
+		return;
+	}
+
+	const volarFile = files.get(fileName);
+	const node = findPositionIdentifier(sourceFile, sourceFile, position + (isTsPlugin ? (volarFile?.snapshot.getLength() ?? 0) : 0));
+	if (!node) {
+		return;
+	}
+
+	const checker = program.getTypeChecker();
+	const type = checker.getTypeAtLocation(node);
+	const props = type.getProperties();
+
+	return props.map(prop => prop.name);
+
+	function findPositionIdentifier(sourceFile: ts.SourceFile, node: ts.Node, offset: number) {
+
+		let result: ts.Node | undefined;
+
+		node.forEachChild(child => {
+			if (!result) {
+				if (child.end === offset && ts.isIdentifier(child)) {
+					result = child;
+				}
+				else if (child.end >= offset && child.getStart(sourceFile) < offset) {
+					result = findPositionIdentifier(sourceFile, child, offset);
+				}
+			}
+		});
+
+		return result;
+	}
+}

--- a/packages/typescript-plugin/src/requests/getQuickInfoAtPosition.ts
+++ b/packages/typescript-plugin/src/requests/getQuickInfoAtPosition.ts
@@ -1,0 +1,14 @@
+import { getProject } from './utils';
+
+export function getQuickInfoAtPosition(fileName: string, position: number) {
+
+	const match = getProject(fileName);
+	if (!match) {
+		return;
+	}
+
+	const [info] = match;
+	const languageService = info.languageService;
+
+	return languageService.getQuickInfoAtPosition(fileName, position);
+}

--- a/packages/typescript-plugin/src/requests/server.ts
+++ b/packages/typescript-plugin/src/requests/server.ts
@@ -1,0 +1,62 @@
+import * as net from 'net';
+import * as fs from 'fs';
+import { collectExtractProps } from './collectExtractProps';
+import { pipeFile } from './utils';
+import { getPropertiesAtLocation } from './getPropertiesAtLocation';
+import { getQuickInfoAtPosition } from './getQuickInfoAtPosition';
+
+export interface CollectExtractPropsRequest {
+	type: 'collectExtractProps';
+	fileName: string;
+	templateCodeRange: [number, number];
+}
+
+export interface GetPropertiesAtLocationRequest {
+	type: 'getPropertiesAtLocation';
+	fileName: string;
+	position: number;
+}
+
+export interface GetQuickInfoAtPosition {
+	type: 'getQuickInfoAtPosition';
+	fileName: string;
+	position: number;
+}
+
+export type Request = CollectExtractPropsRequest
+	| GetPropertiesAtLocationRequest
+	| GetQuickInfoAtPosition;
+
+let started = false;
+
+export function startNamedPipeServer() {
+	if (started) return;
+	started = true;
+	const server = net.createServer(connection => {
+		connection.on('data', data => {
+			const request: Request = JSON.parse(data.toString());
+			if (request.type === 'collectExtractProps') {
+				const result = collectExtractProps(request.fileName, request.templateCodeRange);
+				connection.write(JSON.stringify(result ?? null));
+			}
+			else if (request.type === 'getPropertiesAtLocation') {
+				const result = getPropertiesAtLocation(request.fileName, request.position);
+				connection.write(JSON.stringify(result ?? null));
+			}
+			else if (request.type === 'getQuickInfoAtPosition') {
+				const result = getQuickInfoAtPosition(request.fileName, request.position);
+				connection.write(JSON.stringify(result ?? null));
+			}
+			else {
+				connection.write(JSON.stringify(null));
+			}
+		});
+		connection.on('error', err => console.error(err.message));
+	});
+
+	try {
+		fs.unlinkSync(pipeFile);
+	} catch (error) { }
+
+	server.listen(pipeFile);
+}

--- a/packages/typescript-plugin/src/requests/utils.ts
+++ b/packages/typescript-plugin/src/requests/utils.ts
@@ -1,0 +1,14 @@
+import type * as ts from 'typescript';
+import type { FileRegistry } from '@vue/language-core';
+
+export const pipeFile = process.platform === 'win32' ? '\\\\.\\pipe\\vue-tsp' : '/tmp/vue-tsp';
+
+export const projects = new Map<ts.server.Project, [ts.server.PluginCreateInfo, FileRegistry, typeof ts]>();
+
+export function getProject(fileName: string): [ts.server.PluginCreateInfo, FileRegistry, typeof ts] | undefined {
+	for (const [project, [info, files, ts]] of projects) {
+		if (project.containsFile(fileName as ts.server.NormalizedPath)) {
+			return [info, files, ts];
+		}
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
+      typescript-vue-plugin:
+        specifier: 1.8.27
+        version: link:../typescript-plugin
       volar-service-css:
         specifier: 0.0.31
         version: 0.0.31(@volar/language-service@2.1.0)
@@ -270,6 +273,10 @@ importers:
       '@vue/language-core':
         specifier: 1.8.27
         version: link:../language-core
+    devDependencies:
+      '@types/node':
+        specifier: latest
+        version: 20.11.21
 
   test-workspace:
     devDependencies:


### PR DESCRIPTION
After migrating to the TS Plugin, the LSP Server no longer provides the semantic functionality of the TypeScript LanguageService instance. It needs to communicate with tsserver to invoke its LanguageService instance.

The communication between LSP Server and tsserver is based on named pipes instead of websockets. This is to avoid occupying local ports and dependencies on the ws package.

The following features have been migrated to the named pipe server that uses the TypeScript LanguageService:

- [x] Component Extract CodeAction
- [x] Template Twoslash Queries
- [x] Auto Insert `.value`
- [ ] Tag and Props Name Casing Detect / Convert
- [ ] Detect Missing `lang="ts"` / `"allowJs": true` / `jsconfig.json`
- [ ] Missing Required Props InlayHints
- [ ] Tag and Props Completion in Template