### PR TITLE
fix(language-service): wait for tsserver to be ready when requesting auto insert `.value`

### DIFF
--- a/packages/language-service/lib/plugins/vue-autoinsert-dotvalue.ts
+++ b/packages/language-service/lib/plugins/vue-autoinsert-dotvalue.ts
@@ -10,6 +10,7 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 	return {
 		name: 'vue-autoinsert-dotvalue',
 		create(context): ServicePluginInstance {
+			let currentReq = 0;
 			return {
 				async provideAutoInsertionEdit(document, position, lastChange) {
 
@@ -17,6 +18,12 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 						return;
 
 					if (!isCharacterTyping(document, lastChange))
+						return;
+
+					const req = ++currentReq;
+					// Wait for tsserver to sync
+					await sleep(250);
+					if (req !== currentReq)
 						return;
 
 					const enabled = await context.env.getConfiguration?.<boolean>('vue.autoInsert.dotValue') ?? true;
@@ -54,6 +61,10 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 			};
 		},
 	};
+}
+
+function sleep(ms: number) {
+	return new Promise<void>(resolve => setTimeout(resolve, ms));
 }
 
 function isTsDocument(document: TextDocument) {

--- a/packages/language-service/lib/plugins/vue-autoinsert-dotvalue.ts
+++ b/packages/language-service/lib/plugins/vue-autoinsert-dotvalue.ts
@@ -30,30 +30,42 @@ export function create(ts: typeof import('typescript')): ServicePlugin {
 					if (!enabled)
 						return;
 
-					const [_, file] = context.documents.getVirtualCodeByUri(document.uri);
+					const [code, file] = context.documents.getVirtualCodeByUri(document.uri);
+					if (!file)
+						return;
 
-					let fileName: string | undefined;
 					let ast: ts.SourceFile | undefined;
+					let sourceCodeOffset = document.offsetAt(position);
+
+					const fileName = context.env.typescript!.uriToFileName(file.id);
 
 					if (file?.generated) {
 						const script = file.generated.languagePlugin.typescript?.getScript(file.generated.code);
-						if (script) {
-							fileName = context.env.typescript!.uriToFileName(file.id);
-							ast = getAst(fileName, script.code.snapshot, script.scriptKind);
+						if (script?.code !== code) {
+							return;
+						}
+						ast = getAst(fileName, script.code.snapshot, script.scriptKind);
+						let mapped = false;
+						for (const [_1, [_2, map]] of context.language.files.getMaps(code)) {
+							const sourceOffset = map.getSourceOffset(document.offsetAt(position));
+							if (sourceOffset !== undefined) {
+								sourceCodeOffset = sourceOffset[0];
+								mapped = true;
+								break;
+							}
+						}
+						if (!mapped) {
+							return;
 						}
 					}
-					else if (file) {
-						fileName = context.env.typescript!.uriToFileName(file.id);
+					else {
 						ast = getAst(fileName, file.snapshot);
 					}
-
-					if (!ast || !fileName)
-						return;
 
 					if (isBlacklistNode(ts, ast, document.offsetAt(position), false))
 						return;
 
-					const props = await namedPipeClient.getPropertiesAtLocation(fileName, document.offsetAt(position)) ?? [];
+					const props = await namedPipeClient.getPropertiesAtLocation(fileName, sourceCodeOffset) ?? [];
 					if (props.some(prop => prop === 'value')) {
 						return '${1:.value}';
 					}

--- a/packages/typescript-plugin/lib/server.ts
+++ b/packages/typescript-plugin/lib/server.ts
@@ -1,5 +1,9 @@
 import * as fs from 'fs';
 import * as net from 'net';
+import { collectExtractProps } from './requests/collectExtractProps';
+import { getComponentEvents, getComponentNames, getComponentProps, getElementAttrs, getTemplateContextProps } from './requests/componentInfos';
+import { getPropertiesAtLocation } from './requests/getPropertiesAtLocation';
+import { getQuickInfoAtPosition } from './requests/getQuickInfoAtPosition';
 import { pipeFile } from './utils';
 
 export interface Request {
@@ -21,39 +25,39 @@ export function startNamedPipeServer() {
 	if (started) return;
 	started = true;
 	const server = net.createServer(connection => {
-		connection.on('data', async data => {
+		connection.on('data', data => {
 			const request: Request = JSON.parse(data.toString());
 			if (request.type === 'collectExtractProps') {
-				const result = (await import('./requests/collectExtractProps.js')).collectExtractProps.apply(null, request.args);
+				const result = collectExtractProps.apply(null, request.args);
 				connection.write(JSON.stringify(result ?? null));
 			}
 			else if (request.type === 'getPropertiesAtLocation') {
-				const result = (await import('./requests/getPropertiesAtLocation.js')).getPropertiesAtLocation.apply(null, request.args);
+				const result = getPropertiesAtLocation.apply(null, request.args);
 				connection.write(JSON.stringify(result ?? null));
 			}
 			else if (request.type === 'getQuickInfoAtPosition') {
-				const result = (await import('./requests/getQuickInfoAtPosition.js')).getQuickInfoAtPosition.apply(null, request.args);
+				const result = getQuickInfoAtPosition.apply(null, request.args);
 				connection.write(JSON.stringify(result ?? null));
 			}
 			// Component Infos
 			else if (request.type === 'getComponentProps') {
-				const result = (await import('./requests/componentInfos.js')).getComponentProps.apply(null, request.args);
+				const result = getComponentProps.apply(null, request.args);
 				connection.write(JSON.stringify(result ?? null));
 			}
 			else if (request.type === 'getComponentEvents') {
-				const result = (await import('./requests/componentInfos.js')).getComponentEvents.apply(null, request.args);
+				const result = getComponentEvents.apply(null, request.args);
 				connection.write(JSON.stringify(result ?? null));
 			}
 			else if (request.type === 'getTemplateContextProps') {
-				const result = (await import('./requests/componentInfos.js')).getTemplateContextProps.apply(null, request.args);
+				const result = getTemplateContextProps.apply(null, request.args);
 				connection.write(JSON.stringify(result ?? null));
 			}
 			else if (request.type === 'getComponentNames') {
-				const result = (await import('./requests/componentInfos.js')).getComponentNames.apply(null, request.args);
+				const result = getComponentNames.apply(null, request.args);
 				connection.write(JSON.stringify(result ?? null));
 			}
 			else if (request.type === 'getElementAttrs') {
-				const result = (await import('./requests/componentInfos.js')).getElementAttrs.apply(null, request.args);
+				const result = getElementAttrs.apply(null, request.args);
 				connection.write(JSON.stringify(result ?? null));
 			}
 			else {


### PR DESCRIPTION
The call to `provideAutoInsertionEdit` is too eager (called 100ms after the document is changed). At this time, the tsserver may not have obtained the latest script changes, and the requested position parameter may be calculated at the wrong position.

Even if an additional version is used to check whether the tsserver script has been synchronized, it does not mean that the type checker is currently available, because the tsserver must wait for the diagnosis to be completed to synchronize the internal state. If the TS API is called in advance in the request handle, it will also cause the tsserver status to be abnormal.

It is currently difficult to find a way to reliably handle tsserver state synchronization, so this PR simply waits 250ms to bypass the problem.