### PR TITLE
refactor(language-core): plugin api v2

### DIFF
--- a/packages/language-core/lib/plugins.ts
+++ b/packages/language-core/lib/plugins.ts
@@ -9,7 +9,7 @@ import useVueSfcStyles from './plugins/vue-sfc-styles';
 import useVueSfcTemplate from './plugins/vue-sfc-template';
 import useHtmlTemplatePlugin from './plugins/vue-template-html';
 import useVueTsx from './plugins/vue-tsx';
-import type { VueCompilerOptions, VueLanguagePlugin } from './types';
+import { pluginVersion, type VueCompilerOptions, type VueLanguagePlugin } from './types';
 import * as CompilerVue2 from './utils/vue2TemplateCompiler';
 
 export function createPluginContext(
@@ -61,9 +61,9 @@ export function getDefaultVueLanguagePlugins(pluginContext: Parameters<VueLangua
 		});
 
 	return pluginInstances.filter((plugin) => {
-		const valid = plugin.version >= 2 && plugin.version < 3;
+		const valid = plugin.version === pluginVersion;
 		if (!valid) {
-			console.warn(`Plugin ${JSON.stringify(plugin.name)} API version incompatible, expected 2.x but got ${JSON.stringify(plugin.version)}`);
+			console.warn(`Plugin ${JSON.stringify(plugin.name)} API version incompatible, expected ${JSON.stringify(pluginVersion)} but got ${JSON.stringify(plugin.version)}`);
 		}
 		return valid;
 	});

--- a/packages/language-core/lib/plugins/vue-sfc-customblocks.ts
+++ b/packages/language-core/lib/plugins/vue-sfc-customblocks.ts
@@ -7,14 +7,14 @@ const plugin: VueLanguagePlugin = () => {
 
 		version: 2,
 
-		getEmbeddedFiles(_fileName, sfc) {
+		getEmbeddedCodes(_fileName, sfc) {
 			return sfc.customBlocks.map((customBlock, i) => ({
 				id: 'customBlock_' + i,
 				lang: customBlock.lang,
 			}));
 		},
 
-		resolveEmbeddedFile(_fileName, sfc, embeddedFile) {
+		resolveEmbeddedCode(_fileName, sfc, embeddedFile) {
 			if (embeddedFile.id.startsWith('customBlock_')) {
 				const index = parseInt(embeddedFile.id.slice('customBlock_'.length));
 				const customBlock = sfc.customBlocks[index];

--- a/packages/language-core/lib/plugins/vue-sfc-scripts.ts
+++ b/packages/language-core/lib/plugins/vue-sfc-scripts.ts
@@ -7,7 +7,7 @@ const plugin: VueLanguagePlugin = () => {
 
 		version: 2,
 
-		getEmbeddedFiles(_fileName, sfc) {
+		getEmbeddedCodes(_fileName, sfc) {
 			const names: {
 				id: string;
 				lang: string;
@@ -21,7 +21,7 @@ const plugin: VueLanguagePlugin = () => {
 			return names;
 		},
 
-		resolveEmbeddedFile(_fileName, sfc, embeddedFile) {
+		resolveEmbeddedCode(_fileName, sfc, embeddedFile) {
 			const script = embeddedFile.id === 'scriptFormat' ? sfc.script
 				: embeddedFile.id === 'scriptSetupFormat' ? sfc.scriptSetup
 					: undefined;

--- a/packages/language-core/lib/plugins/vue-sfc-styles.ts
+++ b/packages/language-core/lib/plugins/vue-sfc-styles.ts
@@ -7,14 +7,14 @@ const plugin: VueLanguagePlugin = () => {
 
 		version: 2,
 
-		getEmbeddedFiles(_fileName, sfc) {
+		getEmbeddedCodes(_fileName, sfc) {
 			return sfc.styles.map((style, i) => ({
 				id: 'style_' + i,
 				lang: style.lang,
 			}));
 		},
 
-		resolveEmbeddedFile(_fileName, sfc, embeddedFile) {
+		resolveEmbeddedCode(_fileName, sfc, embeddedFile) {
 			if (embeddedFile.id.startsWith('style_')) {
 				const index = parseInt(embeddedFile.id.slice('style_'.length));
 				const style = sfc.styles[index];

--- a/packages/language-core/lib/plugins/vue-sfc-template.ts
+++ b/packages/language-core/lib/plugins/vue-sfc-template.ts
@@ -7,7 +7,7 @@ const plugin: VueLanguagePlugin = () => {
 
 		version: 2,
 
-		getEmbeddedFiles(_fileName, sfc) {
+		getEmbeddedCodes(_fileName, sfc) {
 			if (sfc.template) {
 				return [{
 					id: 'template',
@@ -17,7 +17,7 @@ const plugin: VueLanguagePlugin = () => {
 			return [];
 		},
 
-		resolveEmbeddedFile(_fileName, sfc, embeddedFile) {
+		resolveEmbeddedCode(_fileName, sfc, embeddedFile) {
 			if (embeddedFile.id === 'template' && sfc.template) {
 				embeddedFile.content.push([
 					sfc.template.content,

--- a/packages/language-core/lib/plugins/vue-tsx.ts
+++ b/packages/language-core/lib/plugins/vue-tsx.ts
@@ -20,7 +20,7 @@ const plugin: VueLanguagePlugin = (ctx) => {
 			'exactOptionalPropertyTypes',
 		],
 
-		getEmbeddedFiles(fileName, sfc) {
+		getEmbeddedCodes(fileName, sfc) {
 
 			const tsx = useTsx(fileName, sfc);
 			const files: {
@@ -40,7 +40,7 @@ const plugin: VueLanguagePlugin = (ctx) => {
 			return files;
 		},
 
-		resolveEmbeddedFile(fileName, sfc, embeddedFile) {
+		resolveEmbeddedCode(fileName, sfc, embeddedFile) {
 
 			const _tsx = useTsx(fileName, sfc);
 
@@ -61,7 +61,7 @@ const plugin: VueLanguagePlugin = (ctx) => {
 			}
 			else if (embeddedFile.id === 'template_format') {
 
-				embeddedFile.parentFileId = 'template';
+				embeddedFile.parentCodeId = 'template';
 
 				const template = _tsx.generatedTemplate();
 				if (template) {
@@ -88,7 +88,7 @@ const plugin: VueLanguagePlugin = (ctx) => {
 			}
 			else if (embeddedFile.id === 'template_style') {
 
-				embeddedFile.parentFileId = 'template';
+				embeddedFile.parentCodeId = 'template';
 
 				const template = _tsx.generatedTemplate();
 				if (template) {

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -1,7 +1,7 @@
 import type * as CompilerDOM from '@vue/compiler-dom';
 import type { SFCParseResult } from '@vue/compiler-sfc';
 import type * as ts from 'typescript';
-import type { VueEmbeddedFile } from './virtualFile/embeddedFile';
+import type { VueEmbeddedCode } from './virtualFile/embeddedFile';
 import type { CodeInformation, Segment } from '@volar/language-core';
 
 export type { SFCParseResult } from '@vue/compiler-sfc';
@@ -57,6 +57,8 @@ export interface VueCompilerOptions {
 	experimentalUseElementAccessInTemplate: boolean;
 }
 
+export const pluginVersion = 2;
+
 export type VueLanguagePlugin = (ctx: {
 	modules: {
 		typescript: typeof import('typescript');
@@ -67,7 +69,7 @@ export type VueLanguagePlugin = (ctx: {
 	codegenStack: boolean;
 	globalTypesHolder: string | undefined;
 }) => {
-	version: 2;
+	version: typeof pluginVersion;
 	name?: string;
 	order?: number;
 	requiredCompilerOptions?: string[];
@@ -76,8 +78,8 @@ export type VueLanguagePlugin = (ctx: {
 	resolveTemplateCompilerOptions?(options: CompilerDOM.CompilerOptions): CompilerDOM.CompilerOptions;
 	compileSFCTemplate?(lang: string, template: string, options: CompilerDOM.CompilerOptions): CompilerDOM.CodegenResult | undefined;
 	updateSFCTemplate?(oldResult: CompilerDOM.CodegenResult, textChange: { start: number, end: number, newText: string; }): CompilerDOM.CodegenResult | undefined;
-	getEmbeddedFiles?(fileName: string, sfc: Sfc): { id: string; lang: string; }[];
-	resolveEmbeddedFile?(fileName: string, sfc: Sfc, embeddedFile: VueEmbeddedFile): void;
+	getEmbeddedCodes?(fileName: string, sfc: Sfc): { id: string; lang: string; }[];
+	resolveEmbeddedCode?(fileName: string, sfc: Sfc, embeddedFile: VueEmbeddedCode): void;
 };
 
 export interface SfcBlock {

--- a/packages/language-core/lib/virtualFile/embeddedFile.ts
+++ b/packages/language-core/lib/virtualFile/embeddedFile.ts
@@ -1,11 +1,11 @@
 import type { Mapping, StackNode } from '@volar/language-core';
 import type { Code } from '../types';
 
-export class VueEmbeddedFile {
+export class VueEmbeddedCode {
 
-	public parentFileId?: string;
+	public parentCodeId?: string;
 	public linkedCodeMappings: Mapping[] = [];
-	public embeddedFiles: VueEmbeddedFile[] = [];
+	public embeddedCodes: VueEmbeddedCode[] = [];
 
 	constructor(
 		public id: string,


### PR DESCRIPTION
The Plugin API changed from v1 to v2, but please note that there are no improvements here, it is just a renaming of part of the API to match Volar v2's terminology.

- `getEmbeddedFiles` -> `getEmbeddedCodes`
- `VueEmbeddedFile` -> `VueEmbeddedCode`
	- `parentFileId` -> `parentCodeId`
- `resolveEmbeddedFile` -> `resolveEmbeddedCode`