### PR TITLE
fix(typescript-plugin): more reliable connection to named pipe server

### DIFF
--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -61,7 +61,7 @@ function createLanguageServicePlugin(): ts.server.PluginModuleFactory {
 
 					decorateLanguageService(files, info.languageService);
 					decorateLanguageServiceHost(files, info.languageServiceHost, ts);
-					startNamedPipeServer(info.project.projectKind);
+					startNamedPipeServer(info.project.projectKind, info.project.getCurrentDirectory());
 
 					const getCompletionsAtPosition = info.languageService.getCompletionsAtPosition;
 					const getCompletionEntryDetails = info.languageService.getCompletionEntryDetails;

--- a/packages/typescript-plugin/lib/utils.ts
+++ b/packages/typescript-plugin/lib/utils.ts
@@ -1,17 +1,18 @@
 import type { FileRegistry, VueCompilerOptions } from '@vue/language-core';
 import * as os from 'os';
+import * as net from 'net';
 import * as path from 'path';
 import type * as ts from 'typescript';
 
-export interface PipeTable {
-	[pid: string]: {
-		pid: number;
-		pipeFile: string;
-		serverKind: ts.server.ProjectKind;
-	};
+export interface NamedPipeServer {
+	path: string;
+	serverKind: ts.server.ProjectKind;
+	currentDirectory: string;
 }
 
-export const pipeTable = path.join(os.tmpdir(), 'vue-tsp-table.json');
+const { version } = require('../package.json');
+
+export const pipeTable = path.join(os.tmpdir(), `vue-tsp-table-${version}.json`);
 
 export const projects = new Map<ts.server.Project, {
 	info: ts.server.PluginCreateInfo;
@@ -26,4 +27,16 @@ export function getProject(fileName: string) {
 			return data;
 		}
 	}
+}
+
+export function connect(path: string) {
+	return new Promise<net.Socket | undefined>(resolve => {
+		const client = net.connect(path);
+		client.on('connect', () => {
+			resolve(client);
+		});
+		client.on('error', () => {
+			return resolve(undefined);
+		});
+	});
 }


### PR DESCRIPTION
- Warnings are not reported when filtering invalid named pipe servers
- Select Inferred Project based on workspace path instead of pid
- Each time a request is sent to the named pipe server, the connection is initiated once instead of twice
- Named pipe servers table json file name includes version number to prevent language servers from establishing connections with incompatible named pipe servers.

closes #3931, closes #3927