### PR TITLE
Add LSP package name to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 *Component props, events, slots types information extract tool*
 - [vite-plugin-vue-component-preview](https://github.com/johnsoncodehk/vite-plugin-vue-component-preview) \
 *Vite plugin for support Vue component preview view with `Vue Language Features`*
+- [`@vue/language-server`](/packages/language-server/) \
+*The language server itself*.
+- [`@vue/typescript-plugin`](/packages/typescript-plugin/) \
+*Typescript plugin for the language server*.
 
 ## Community Integration
 


### PR DESCRIPTION
The README contains no direct reference to the language server itself. Given past  renames and the legacy Vetur, it's not straightforward to fine the correct package online.

Include the LSP and its package name in the README. This will assist people trying to install the language server.

Additionally, as of 2.0.0, a plug-in is required for TypeScript support. This is mentioned in the changelog, but the name of the plug-in itself is not made evident anywhere. Also add this to the README.