### PR TITLE
fix(typescript-plugin): JSON parsing error when server data length > 8192

### DIFF
--- a/packages/language-server/node.ts
+++ b/packages/language-server/node.ts
@@ -124,9 +124,9 @@ connection.onRequest(GetConvertAttrCasingEditsRequest.type, async params => {
 });
 
 connection.onRequest(GetConnectedNamedPipeServerRequest.type, async fileName => {
-	const connected = await tsPluginClient.connectForFile(fileName);
-	if (connected) {
-		return connected[1];
+	const server = await tsPluginClient.searchNamedPipeServerForFile(fileName);
+	if (server) {
+		return server;
 	}
 });
 

--- a/packages/typescript-plugin/lib/server.ts
+++ b/packages/typescript-plugin/lib/server.ts
@@ -77,6 +77,7 @@ export function startNamedPipeServer(serverKind: ts.server.ProjectKind, currentD
 				console.warn('[Vue Named Pipe Server] Unknown request type:', request.type);
 				connection.write(JSON.stringify(null));
 			}
+			connection.end();
 		});
 		connection.on('error', err => console.error('[Vue Named Pipe Server]', err.message));
 	});


### PR DESCRIPTION
Fixes #3937

This problem can be reproduced with https://github.com/elk-zone/elk. The result length of getComponentNames is 17823 in elk, which is greater than the 8192 limit that can be received at a time, thus causing JSON parsing to fail with incomplete result.