### PR TITLE
fix(language-core): avoid `globalTypesHolder` being specified from a `node_modules` file

### DIFF
--- a/packages/component-meta/lib/base.ts
+++ b/packages/component-meta/lib/base.ts
@@ -152,6 +152,13 @@ export function baseCreate(
 	const vueLanguagePlugin = vue.createVueLanguagePlugin(
 		ts,
 		id => id,
+		() => {
+			for (const fileName of host.getScriptFileNames()) {
+				if (vueCompilerOptions.extensions.some(ext => fileName.endsWith(ext))) {
+					return fileName;
+				}
+			}
+		},
 		host.getCompilationSettings(),
 		vueCompilerOptions,
 	);

--- a/packages/component-meta/lib/base.ts
+++ b/packages/component-meta/lib/base.ts
@@ -152,11 +152,18 @@ export function baseCreate(
 	const vueLanguagePlugin = vue.createVueLanguagePlugin(
 		ts,
 		id => id,
-		() => {
-			for (const fileName of host.getScriptFileNames()) {
-				if (vueCompilerOptions.extensions.some(ext => fileName.endsWith(ext))) {
-					return fileName;
+		fileName => {
+			if (ts.sys.useCaseSensitiveFileNames) {
+				return host.getScriptFileNames().includes(fileName) ?? false;
+			}
+			else {
+				const lowerFileName = fileName.toLowerCase();
+				for (const rootFile of host.getScriptFileNames()) {
+					if (rootFile.toLowerCase() === lowerFileName) {
+						return true;
+					}
 				}
+				return false;
 			}
 		},
 		host.getCompilationSettings(),

--- a/packages/language-core/lib/generators/script.ts
+++ b/packages/language-core/lib/generators/script.ts
@@ -437,7 +437,7 @@ type __VLS_PrettifyGlobal<T> = { [K in keyof T]: T[K]; } & {};
 				let propName = 'modelValue';
 				if (defineProp.name) {
 					propName = scriptSetup.content.substring(defineProp.name.start, defineProp.name.end);
-					propName = propName.replace(/['"]+/g, '')
+					propName = propName.replace(/['"]+/g, '');
 				}
 				yield _(`'update:${propName}': [${propName}:`);
 				if (defineProp.type) {
@@ -545,7 +545,7 @@ type __VLS_PrettifyGlobal<T> = { [K in keyof T]: T[K]; } & {};
 			}
 			yield _(`;\n`);
 
-			yield* generateModelEmits()
+			yield* generateModelEmits();
 
 			yield _(`let __VLS_fnPropsDefineComponent!: InstanceType<typeof __VLS_fnComponent>['$props'];\n`);
 			yield _(`let __VLS_fnPropsSlots!: `);
@@ -755,7 +755,7 @@ type __VLS_PrettifyGlobal<T> = { [K in keyof T]: T[K]; } & {};
 			yield _(`};\n`);
 		}
 
-		yield* generateModelEmits()
+		yield* generateModelEmits();
 		yield* generateTemplate(functional);
 
 		if (mode === 'return' || mode === 'export') {
@@ -856,9 +856,9 @@ type __VLS_PrettifyGlobal<T> = { [K in keyof T]: T[K]; } & {};
 				}
 				yield _(`},\n`);
 			}
-			yield _(`emits: ({} as __VLS_NormalizeEmits<typeof __VLS_modelEmitsType`)
+			yield _(`emits: ({} as __VLS_NormalizeEmits<typeof __VLS_modelEmitsType`);
 			if (ranges.emits.define) {
-				yield _(` & typeof `)
+				yield _(` & typeof `);
 				yield _(ranges.emits.name ?? '__VLS_emit');
 			}
 			yield _(`>),\n`);

--- a/packages/language-core/lib/languageModule.ts
+++ b/packages/language-core/lib/languageModule.ts
@@ -1,25 +1,35 @@
 import { forEachEmbeddedCode, type LanguagePlugin } from '@volar/language-core';
 import type * as ts from 'typescript';
-import { createPluginContext, getDefaultVueLanguagePlugins } from './plugins';
-import type { VueCompilerOptions } from './types';
+import { getDefaultVueLanguagePlugins } from './plugins';
+import type { VueCompilerOptions, VueLanguagePlugin } from './types';
 import { VueGeneratedCode } from './virtualFile/vueFile';
+import * as CompilerDOM from '@vue/compiler-dom';
+import * as CompilerVue2 from './utils/vue2TemplateCompiler';
 
 export function createVueLanguagePlugin(
 	ts: typeof import('typescript'),
 	getFileName: (fileId: string) => string,
-	getGlobalTypesHolder: () => string | undefined,
+	isValidGlobalTypesHolder: (fileName: string) => boolean,
 	compilerOptions: ts.CompilerOptions,
 	vueCompilerOptions: VueCompilerOptions,
 	codegenStack: boolean = false,
 ): LanguagePlugin<VueGeneratedCode> {
 	const allowLanguageIds = new Set(['vue']);
-	const pluginContext = createPluginContext(
-		ts,
+	const pluginContext: Parameters<VueLanguagePlugin>[0] = {
+		modules: {
+			'@vue/compiler-dom': vueCompilerOptions.target < 3
+				? {
+					...CompilerDOM,
+					compile: CompilerVue2.compile,
+				}
+				: CompilerDOM,
+			typescript: ts,
+		},
 		compilerOptions,
 		vueCompilerOptions,
 		codegenStack,
-		getGlobalTypesHolder,
-	);
+		globalTypesHolder: undefined,
+	};
 	const plugins = getDefaultVueLanguagePlugins(pluginContext);
 
 	if (vueCompilerOptions.extensions.includes('.md')) {
@@ -29,11 +39,17 @@ export function createVueLanguagePlugin(
 		allowLanguageIds.add('html');
 	}
 
+	const createdCodes = new Map<string, VueGeneratedCode>();
+
 	return {
 		createVirtualCode(fileId, languageId, snapshot) {
 			if (allowLanguageIds.has(languageId)) {
-				return new VueGeneratedCode(
-					getFileName(fileId),
+				const fileName = getFileName(fileId);
+				if (!pluginContext.globalTypesHolder && isValidGlobalTypesHolder(fileName)) {
+					pluginContext.globalTypesHolder = fileName;
+				}
+				const code = new VueGeneratedCode(
+					fileName,
 					languageId,
 					snapshot,
 					vueCompilerOptions,
@@ -41,11 +57,32 @@ export function createVueLanguagePlugin(
 					ts,
 					codegenStack,
 				);
+				createdCodes.set(fileId, code);
+				return code;
 			}
 		},
-		updateVirtualCode(_fileId, vueFile, snapshot) {
-			vueFile.update(snapshot);
-			return vueFile;
+		updateVirtualCode(_fileId, code, snapshot) {
+			code.update(snapshot);
+			return code;
+		},
+		disposeVirtualCode(fileId, code, files) {
+			createdCodes.delete(fileId);
+			if (code.fileName === pluginContext.globalTypesHolder) {
+				pluginContext.globalTypesHolder = undefined;
+				for (const [fileId, code] of createdCodes) {
+					if (isValidGlobalTypesHolder(code.fileName)) {
+						pluginContext.globalTypesHolder = code.fileName;
+						// force dirty
+						files?.delete(fileId);
+						files?.set(
+							fileId,
+							code.languageId,
+							code.snapshot,
+						);
+						break;
+					}
+				}
+			}
 		},
 		typescript: {
 			extraFileExtensions: vueCompilerOptions.extensions.map<ts.FileExtensionInfo>(ext => ({

--- a/packages/language-core/lib/languageModule.ts
+++ b/packages/language-core/lib/languageModule.ts
@@ -1,72 +1,24 @@
 import { forEachEmbeddedCode, type LanguagePlugin } from '@volar/language-core';
 import type * as ts from 'typescript';
 import { createPluginContext, getDefaultVueLanguagePlugins } from './plugins';
-import type { VueCompilerOptions, VueLanguagePlugin } from './types';
-import { resolveVueCompilerOptions } from './utils/ts';
+import type { VueCompilerOptions } from './types';
 import { VueGeneratedCode } from './virtualFile/vueFile';
-
-const fileRegistries: {
-	key: string;
-	plugins: VueLanguagePlugin[];
-	files: Map<string, VueGeneratedCode>;
-}[] = [];
-
-function getVueFileRegistry(key: string, plugins: VueLanguagePlugin[]) {
-
-	let fileRegistry = fileRegistries.find(r =>
-		r.key === key
-		&& r.plugins.length === plugins.length
-		&& r.plugins.every(plugin => plugins.includes(plugin))
-	)?.files;
-
-	if (!fileRegistry) {
-		fileRegistry = new Map();
-		fileRegistries.push({
-			key: key,
-			plugins: plugins,
-			files: fileRegistry,
-		});
-	}
-
-	return fileRegistry;
-}
-
-function getFileRegistryKey(
-	compilerOptions: ts.CompilerOptions,
-	vueCompilerOptions: VueCompilerOptions,
-	plugins: ReturnType<VueLanguagePlugin>[],
-	globalTypesHolder: string | undefined,
-) {
-	const values = [
-		globalTypesHolder,
-		...Object.keys(vueCompilerOptions)
-			.sort()
-			.filter(key => key !== 'plugins')
-			.map(key => [key, vueCompilerOptions[key as keyof VueCompilerOptions]]),
-		[...new Set(plugins.map(plugin => plugin.requiredCompilerOptions ?? []).flat())]
-			.sort()
-			.map(key => [key, compilerOptions[key as keyof ts.CompilerOptions]]),
-	];
-	return JSON.stringify(values);
-}
 
 export function createVueLanguagePlugin(
 	ts: typeof import('typescript'),
 	getFileName: (fileId: string) => string,
-	compilerOptions: ts.CompilerOptions = {},
-	_vueCompilerOptions: Partial<VueCompilerOptions> = {},
+	getGlobalTypesHolder: () => string | undefined,
+	compilerOptions: ts.CompilerOptions,
+	vueCompilerOptions: VueCompilerOptions,
 	codegenStack: boolean = false,
-	globalTypesHolder?: string
 ): LanguagePlugin<VueGeneratedCode> {
-
-	const vueCompilerOptions = resolveVueCompilerOptions(_vueCompilerOptions);
 	const allowLanguageIds = new Set(['vue']);
 	const pluginContext = createPluginContext(
 		ts,
 		compilerOptions,
 		vueCompilerOptions,
 		codegenStack,
-		globalTypesHolder,
+		getGlobalTypesHolder,
 	);
 	const plugins = getDefaultVueLanguagePlugins(pluginContext);
 
@@ -77,64 +29,23 @@ export function createVueLanguagePlugin(
 		allowLanguageIds.add('html');
 	}
 
-	let generatedCodeRegistry: Map<string, VueGeneratedCode> | undefined;
-
 	return {
 		createVirtualCode(fileId, languageId, snapshot) {
 			if (allowLanguageIds.has(languageId)) {
-
-				const fileName = getFileName(fileId);
-
-				if (!generatedCodeRegistry) {
-
-					pluginContext.globalTypesHolder ??= fileName;
-
-					generatedCodeRegistry = getVueFileRegistry(
-						getFileRegistryKey(compilerOptions, vueCompilerOptions, plugins, pluginContext.globalTypesHolder),
-						vueCompilerOptions.plugins,
-					);
-				}
-
-				if (generatedCodeRegistry.has(fileId)) {
-					const reusedResult = generatedCodeRegistry.get(fileId)!;
-					reusedResult.update(snapshot);
-					return reusedResult;
-				}
-				const vueFile = new VueGeneratedCode(fileName, languageId, snapshot, vueCompilerOptions, plugins, ts, codegenStack);
-				generatedCodeRegistry.set(fileId, vueFile);
-				return vueFile;
+				return new VueGeneratedCode(
+					getFileName(fileId),
+					languageId,
+					snapshot,
+					vueCompilerOptions,
+					plugins,
+					ts,
+					codegenStack,
+				);
 			}
 		},
 		updateVirtualCode(_fileId, vueFile, snapshot) {
 			vueFile.update(snapshot);
 			return vueFile;
-		},
-		disposeVirtualCode(fileId, vueFile, files) {
-			generatedCodeRegistry?.delete(fileId);
-			if (vueFile.fileName === pluginContext.globalTypesHolder) {
-				if (generatedCodeRegistry?.size) {
-					for (const [fileName, file] of generatedCodeRegistry!) {
-						pluginContext.globalTypesHolder = fileName;
-
-						generatedCodeRegistry = getVueFileRegistry(
-							getFileRegistryKey(compilerOptions, vueCompilerOptions, plugins, pluginContext.globalTypesHolder),
-							vueCompilerOptions.plugins,
-						);
-
-						files?.set(
-							fileId,
-							file.languageId,
-							// force dirty
-							{ ...file.snapshot },
-						);
-						break;
-					}
-				}
-				else {
-					generatedCodeRegistry = undefined;
-					pluginContext.globalTypesHolder = undefined;
-				}
-			}
 		},
 		typescript: {
 			extraFileExtensions: vueCompilerOptions.extensions.map<ts.FileExtensionInfo>(ext => ({

--- a/packages/language-core/lib/plugins.ts
+++ b/packages/language-core/lib/plugins.ts
@@ -1,5 +1,3 @@
-import * as CompilerDOM from '@vue/compiler-dom';
-import type * as ts from 'typescript';
 import useHtmlFilePlugin from './plugins/file-html';
 import useMdFilePlugin from './plugins/file-md';
 import useVueFilePlugin from './plugins/file-vue';
@@ -9,35 +7,7 @@ import useVueSfcStyles from './plugins/vue-sfc-styles';
 import useVueSfcTemplate from './plugins/vue-sfc-template';
 import useHtmlTemplatePlugin from './plugins/vue-template-html';
 import useVueTsx from './plugins/vue-tsx';
-import { pluginVersion, type VueCompilerOptions, type VueLanguagePlugin } from './types';
-import * as CompilerVue2 from './utils/vue2TemplateCompiler';
-
-export function createPluginContext(
-	ts: typeof import('typescript'),
-	compilerOptions: ts.CompilerOptions,
-	vueCompilerOptions: VueCompilerOptions,
-	codegenStack: boolean,
-	getGlobalTypesHolder: () => string | undefined,
-) {
-	const pluginCtx: Parameters<VueLanguagePlugin>[0] = {
-		modules: {
-			'@vue/compiler-dom': vueCompilerOptions.target < 3
-				? {
-					...CompilerDOM,
-					compile: CompilerVue2.compile,
-				}
-				: CompilerDOM,
-			typescript: ts,
-		},
-		compilerOptions,
-		vueCompilerOptions,
-		codegenStack,
-		get globalTypesHolder() {
-			return getGlobalTypesHolder();
-		},
-	};
-	return pluginCtx;
-}
+import { pluginVersion, type VueLanguagePlugin } from './types';
 
 export function getDefaultVueLanguagePlugins(pluginContext: Parameters<VueLanguagePlugin>[0]) {
 

--- a/packages/language-core/lib/plugins.ts
+++ b/packages/language-core/lib/plugins.ts
@@ -17,7 +17,7 @@ export function createPluginContext(
 	compilerOptions: ts.CompilerOptions,
 	vueCompilerOptions: VueCompilerOptions,
 	codegenStack: boolean,
-	globalTypesHolder: string | undefined,
+	getGlobalTypesHolder: () => string | undefined,
 ) {
 	const pluginCtx: Parameters<VueLanguagePlugin>[0] = {
 		modules: {
@@ -32,7 +32,9 @@ export function createPluginContext(
 		compilerOptions,
 		vueCompilerOptions,
 		codegenStack,
-		globalTypesHolder,
+		get globalTypesHolder() {
+			return getGlobalTypesHolder();
+		},
 	};
 	return pluginCtx;
 }

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -67,7 +67,7 @@ export type VueLanguagePlugin = (ctx: {
 	compilerOptions: ts.CompilerOptions;
 	vueCompilerOptions: VueCompilerOptions;
 	codegenStack: boolean;
-	readonly globalTypesHolder: string | undefined;
+	globalTypesHolder: string | undefined;
 }) => {
 	version: typeof pluginVersion;
 	name?: string;

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -67,7 +67,7 @@ export type VueLanguagePlugin = (ctx: {
 	compilerOptions: ts.CompilerOptions;
 	vueCompilerOptions: VueCompilerOptions;
 	codegenStack: boolean;
-	globalTypesHolder: string | undefined;
+	readonly globalTypesHolder: string | undefined;
 }) => {
 	version: typeof pluginVersion;
 	name?: string;

--- a/packages/language-server/node.ts
+++ b/packages/language-server/node.ts
@@ -45,11 +45,18 @@ connection.onInitialize(async params => {
 				const vueLanguagePlugin = createVueLanguagePlugin(
 					tsdk.typescript,
 					serviceEnv.typescript!.uriToFileName,
-					() => {
-						for (const fileName of projectContext.typescript?.host.getScriptFileNames() ?? []) {
-							if (resolvedVueOptions.extensions.some(ext => fileName.endsWith(ext))) {
-								return fileName;
+					fileName => {
+						if (projectContext.typescript?.sys.useCaseSensitiveFileNames ?? false) {
+							return projectContext.typescript?.host.getScriptFileNames().includes(fileName) ?? false;
+						}
+						else {
+							const lowerFileName = fileName.toLowerCase();
+							for (const rootFile of projectContext.typescript?.host.getScriptFileNames() ?? []) {
+								if (rootFile.toLowerCase() === lowerFileName) {
+									return true;
+								}
 							}
+							return false;
 						}
 					},
 					commandLine?.options ?? {},

--- a/packages/language-server/node.ts
+++ b/packages/language-server/node.ts
@@ -42,7 +42,20 @@ connection.onInitialize(async params => {
 			async getLanguagePlugins(serviceEnv, projectContext) {
 				const [commandLine, vueOptions] = await parseCommandLine();
 				const resolvedVueOptions = resolveVueCompilerOptions(vueOptions);
-				const vueLanguagePlugin = createVueLanguagePlugin(tsdk.typescript, serviceEnv.typescript!.uriToFileName, commandLine?.options ?? {}, resolvedVueOptions, options.codegenStack);
+				const vueLanguagePlugin = createVueLanguagePlugin(
+					tsdk.typescript,
+					serviceEnv.typescript!.uriToFileName,
+					() => {
+						for (const fileName of projectContext.typescript?.host.getScriptFileNames() ?? []) {
+							if (resolvedVueOptions.extensions.some(ext => fileName.endsWith(ext))) {
+								return fileName;
+							}
+						}
+					},
+					commandLine?.options ?? {},
+					resolvedVueOptions,
+					options.codegenStack,
+				);
 
 				envToVueOptions.set(serviceEnv, resolvedVueOptions);
 

--- a/packages/language-service/tests/utils/createTester.ts
+++ b/packages/language-service/tests/utils/createTester.ts
@@ -30,11 +30,18 @@ function createTester(rootUri: string) {
 	const vueLanguagePlugin = createVueLanguagePlugin(
 		ts,
 		serviceEnv.typescript!.uriToFileName,
-		() => {
-			for (const fileName of projectHost.getScriptFileNames()) {
-				if (resolvedVueOptions.extensions.some(ext => fileName.endsWith(ext))) {
-					return fileName;
+		fileName => {
+			if (ts.sys.useCaseSensitiveFileNames) {
+				return projectHost.getScriptFileNames().includes(fileName);
+			}
+			else {
+				const lowerFileName = fileName.toLowerCase();
+				for (const rootFile of projectHost.getScriptFileNames()) {
+					if (rootFile.toLowerCase() === lowerFileName) {
+						return true;
+					}
 				}
+				return false;
 			}
 		},
 		parsedCommandLine.options,

--- a/packages/language-service/tests/utils/createTester.ts
+++ b/packages/language-service/tests/utils/createTester.ts
@@ -27,7 +27,19 @@ function createTester(rootUri: string) {
 		getLanguageId: resolveCommonLanguageId,
 	};
 	const resolvedVueOptions = resolveVueCompilerOptions(parsedCommandLine.vueOptions);
-	const vueLanguagePlugin = createVueLanguagePlugin(ts, serviceEnv.typescript!.uriToFileName, parsedCommandLine.options, resolvedVueOptions);
+	const vueLanguagePlugin = createVueLanguagePlugin(
+		ts,
+		serviceEnv.typescript!.uriToFileName,
+		() => {
+			for (const fileName of projectHost.getScriptFileNames()) {
+				if (resolvedVueOptions.extensions.some(ext => fileName.endsWith(ext))) {
+					return fileName;
+				}
+			}
+		},
+		parsedCommandLine.options,
+		resolvedVueOptions,
+	);
 	const vueServicePlugins = createVueServicePlugins(ts, () => resolvedVueOptions);
 	const defaultVSCodeSettings: any = {
 		'typescript.preferences.quoteStyle': 'single',

--- a/packages/language-service/tests/utils/format.ts
+++ b/packages/language-service/tests/utils/format.ts
@@ -7,7 +7,7 @@ const resolvedVueOptions = resolveVueCompilerOptions({});
 const vueLanguagePlugin = createVueLanguagePlugin(
 	ts,
 	fileId => formatter.env.typescript!.uriToFileName(fileId),
-	() => undefined,
+	() => false,
 	{},
 	resolvedVueOptions,
 );

--- a/packages/language-service/tests/utils/format.ts
+++ b/packages/language-service/tests/utils/format.ts
@@ -4,7 +4,13 @@ import { describe, expect, it } from 'vitest';
 import { createVueLanguagePlugin, createVueServicePlugins, resolveVueCompilerOptions } from '../..';
 
 const resolvedVueOptions = resolveVueCompilerOptions({});
-const vueLanguagePlugin = createVueLanguagePlugin(ts, fileId => formatter.env.typescript!.uriToFileName(fileId), {}, resolvedVueOptions);
+const vueLanguagePlugin = createVueLanguagePlugin(
+	ts,
+	fileId => formatter.env.typescript!.uriToFileName(fileId),
+	() => undefined,
+	{},
+	resolvedVueOptions,
+);
 const vueServicePLugins = createVueServicePlugins(ts, () => resolvedVueOptions);
 const formatter = kit.createFormatter([vueLanguagePlugin], vueServicePLugins);
 

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -18,7 +18,7 @@ export function run() {
 				? vue.createParsedCommandLine(ts, ts.sys, configFilePath.replace(windowsPathReg, '/')).vueOptions
 				: {};
 			const resolvedVueOptions = vue.resolveVueCompilerOptions(vueOptions);
-			const extensions = vueOptions.extensions ?? ['.vue'];
+			const { extensions } = resolvedVueOptions;
 			const fakeGlobalTypesHolder = createFakeGlobalTypesHolder(options);
 			if (
 				runExtensions.length === extensions.length

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -2,11 +2,12 @@ import { runTsc } from '@volar/typescript/lib/quickstart/runTsc';
 import * as vue from '@vue/language-core';
 import type * as ts from 'typescript';
 
+const windowsPathReg = /\\/g;
+
 export function run() {
 
 	let runExtensions = ['.vue'];
 
-	const windowsPathReg = /\\/g;
 	const extensionsChangedException = new Error('extensions changed');
 	const main = () => runTsc(
 		require.resolve('typescript/lib/tsc'),
@@ -16,7 +17,9 @@ export function run() {
 			const vueOptions = typeof configFilePath === 'string'
 				? vue.createParsedCommandLine(ts, ts.sys, configFilePath.replace(windowsPathReg, '/')).vueOptions
 				: {};
+			const resolvedVueOptions = vue.resolveVueCompilerOptions(vueOptions);
 			const extensions = vueOptions.extensions ?? ['.vue'];
+			const fakeGlobalTypesHolder = createFakeGlobalTypesHolder(options);
 			if (
 				runExtensions.length === extensions.length
 				&& runExtensions.every(ext => extensions.includes(ext))
@@ -24,10 +27,10 @@ export function run() {
 				const vueLanguagePlugin = vue.createVueLanguagePlugin(
 					ts,
 					id => id,
+					() => fakeGlobalTypesHolder,
 					options.options,
-					vueOptions,
+					resolvedVueOptions,
 					false,
-					createFakeGlobalTypesHolder(options)?.replace(windowsPathReg, '/'),
 				);
 				return [vueLanguagePlugin];
 			}
@@ -77,6 +80,6 @@ export function createFakeGlobalTypesHolder(options: ts.CreateProgramOptions) {
 			return writeFile(fileName, ...args);
 		};
 
-		return fakeFileName;
+		return fakeFileName.replace(windowsPathReg, '/');
 	}
 }

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -27,7 +27,7 @@ export function run() {
 				const vueLanguagePlugin = vue.createVueLanguagePlugin(
 					ts,
 					id => id,
-					() => fakeGlobalTypesHolder,
+					fileName => fileName === fakeGlobalTypesHolder,
 					options.options,
 					resolvedVueOptions,
 					false,

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -44,7 +44,7 @@ describe('vue-tsc-dts', () => {
 
 	for (const intputFile of options.rootNames) {
 
-		if (intputFile === fakeGlobalTypesHolder)
+		if (intputFile.endsWith('__VLS_globalTypes.vue'))
 			continue;
 
 		const expectedOutputFile = intputFile.endsWith('.ts')

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -33,7 +33,7 @@ describe('vue-tsc-dts', () => {
 		const vueLanguagePlugin = vue.createVueLanguagePlugin(
 			ts,
 			id => id,
-			() => fakeGlobalTypesHolder,
+			fileName => fileName === fakeGlobalTypesHolder,
 			options.options,
 			vue.resolveVueCompilerOptions(vueOptions),
 			false,

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -33,10 +33,10 @@ describe('vue-tsc-dts', () => {
 		const vueLanguagePlugin = vue.createVueLanguagePlugin(
 			ts,
 			id => id,
+			() => fakeGlobalTypesHolder,
 			options.options,
-			vueOptions,
+			vue.resolveVueCompilerOptions(vueOptions),
 			false,
-			fakeGlobalTypesHolder?.replace(windowsPathReg, '/'),
 		);
 		return [vueLanguagePlugin];
 	});

--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -32,6 +32,7 @@ function createLanguageServicePlugin(): ts.server.PluginModuleFactory {
 					const languagePlugin = vue.createVueLanguagePlugin(
 						ts,
 						id => id,
+						() => externalFiles.get(info.project)?.[0],
 						info.languageServiceHost.getCompilationSettings(),
 						vueOptions,
 					);

--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -220,11 +220,9 @@ function createLanguageServicePlugin(): ts.server.PluginModuleFactory {
 					const oldFiles = externalFiles.get(project);
 					const newFiles = new Set(searchExternalFiles(ts, project, projectExternalFileExtensions.get(project)!));
 					externalFiles.set(project, newFiles);
-					console.log('volar-n', oldFiles?.size, newFiles.size);
 					if (oldFiles && !twoSetsEqual(oldFiles, newFiles)) {
 						for (const oldFile of oldFiles) {
 							if (!newFiles.has(oldFile)) {
-								console.log('volar-n delete', oldFile);
 								projects.get(project)?.files.delete(oldFile);
 							}
 						}


### PR DESCRIPTION
This fix fixes the issue where `globalTypesHolder` in the nuxt project is specified as a vue file in `node_modules`, causing the global type to be missing in the project root vue files.