### PR TITLE
refactor(language-server): re-export `@vue/typescript-plugin`

### DIFF
--- a/packages/language-server/typescript-plugin.ts
+++ b/packages/language-server/typescript-plugin.ts
@@ -1,2 +1,1 @@
-import tsPlugin = require('@vue/typescript-plugin');
-export = tsPlugin;
+export = require('@vue/typescript-plugin');

--- a/packages/language-server/typescript-plugin.ts
+++ b/packages/language-server/typescript-plugin.ts
@@ -1,0 +1,2 @@
+import tsPlugin = require('@vue/typescript-plugin');
+export = tsPlugin;

--- a/packages/typescript-plugin/README.md
+++ b/packages/typescript-plugin/README.md
@@ -16,7 +16,7 @@ configuration to the language server:
         {
           "name": "@vue/typescript-plugin",
           "location": "/usr/local/lib/node_modules/@vue/typescript-plugin",
-          "languages": ["javascript", "typescript", "vue"],
+          "languages": ["vue"],
         },
     ],
   },

--- a/packages/typescript-plugin/README.md
+++ b/packages/typescript-plugin/README.md
@@ -1,12 +1,8 @@
 # typescript plugin
 
-This is a plug-in for `tsserver` or `typescript-language-server`. It must be
-installed in a file-system location accessible by the language server or in the
-`node_modules` directory of projects being edited.
+This is a plug-in for `tsserver` or `typescript-language-server`. It must be installed in a file-system location accessible by the language server or in the `node_modules` directory of projects being edited.
 
-The LSP client must be configured to explicitly enable this plug-in. This is
-done by passing `initializationOptions` with the appropriate [`plugins`]
-configuration to the language server:
+The LSP client must be configured to explicitly enable this plug-in. This is done by passing `initializationOptions` with the appropriate [`plugins`] configuration to the language server:
 
 [`plugins`]: https://github.com/typescript-language-server/typescript-language-server/blob/b224b878652438bcdd639137a6b1d1a6630129e4/docs/configuration.md?plain=1#L27-L31
 
@@ -22,9 +18,7 @@ configuration to the language server:
   },
 ```
 
-The `languages` field must specify file-types for which the plug-in will be
-enabled. If the plug-in package is installed in the local `node_modules`, the
-`location` field may contain any arbitrary string, but MUST be present.
+The `languages` field must specify file-types for which the plug-in will be enabled. If the plug-in package is installed in the local `node_modules`, the `location` field may contain any arbitrary string, but MUST be present.
 
 ## Client-specific configuration
 

--- a/packages/typescript-plugin/README.md
+++ b/packages/typescript-plugin/README.md
@@ -11,7 +11,7 @@ The LSP client must be configured to explicitly enable this plug-in. This is don
     "plugins": [
         {
           "name": "@vue/typescript-plugin",
-          "location": "/usr/local/lib/node_modules/@vue/typescript-plugin",
+          "location": "/usr/local/lib/node_modules/@vue/typescript-plugin", // or "/usr/local/lib/node_modules/@vue/language-server/typescript-plugin",
           "languages": ["vue"],
         },
     ],


### PR DESCRIPTION
Re-export the typescript plugin from `@vue/language-server/typescript-plugin` to avoid users having to ensure version consistency themselves.