### PR TITLE
chore(vscode): remove embedded language IDs

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -108,18 +108,6 @@
 			{
 				"id": "plaintext",
 				"configuration": "./languages/sfc-template-language-configuration.json"
-			},
-			{
-				"id": "vue-injection-markdown"
-			},
-			{
-				"id": "vue-directives"
-			},
-			{
-				"id": "vue-interpolations"
-			},
-			{
-				"id": "vue-sfc-style-variable-injection"
 			}
 		],
 		"typescriptServerPlugins": [
@@ -173,7 +161,6 @@
 				]
 			},
 			{
-				"language": "vue-injection-markdown",
 				"scopeName": "markdown.vue.codeblock",
 				"path": "./syntaxes/markdown-vue.json",
 				"injectTo": [
@@ -209,7 +196,6 @@
 				}
 			},
 			{
-				"language": "vue-directives",
 				"scopeName": "vue.directives",
 				"path": "./syntaxes/vue-directives.json",
 				"injectTo": [
@@ -220,7 +206,6 @@
 				]
 			},
 			{
-				"language": "vue-interpolations",
 				"scopeName": "vue.interpolations",
 				"path": "./syntaxes/vue-interpolations.json",
 				"injectTo": [
@@ -231,7 +216,6 @@
 				]
 			},
 			{
-				"language": "vue-sfc-style-variable-injection",
 				"scopeName": "vue.sfc.style.variable.injection",
 				"path": "./syntaxes/vue-sfc-style-variable-injection.json",
 				"injectTo": [


### PR DESCRIPTION
The language ID isn’t needed for injections. Only `scopeName` is needed. The language ID appears in the VSCode language selector, which isn’t desired behaviour.

![VSCode language selector showing the various Vue related language IDs](https://github.com/vuejs/language-tools/assets/779047/f480f8b8-5cab-440d-a1f0-0aac46d8c894)

This is based on https://github.com/microsoft/vscode/issues/207406#issuecomment-1991393649. Also I didn’t notice problems when trying this myself.