### PR TITLE
docs(language-service): update neovim lsp set up info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 [neovim/nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) ⚡ 🤝 \
 *Vue language server configuration for Neovim* \
-[[Multiple servers set up tutorial](https://github.com/vuejs/language-tools/discussions/606)]
+[[Volar 2.0 version set up tutorial](https://github.com/vuejs/language-tools/issues/3925)]
 
 [mattn/vim-lsp-settings](https://github.com/mattn/vim-lsp-settings) ⚡ \
 *Vue language server auto configuration for vim-lsp*


### PR DESCRIPTION
The tutorial for setting up Volar 2.0 on NeoVim has been updated. 

The use of multiple servers is no longer applicable in the new version. 

To help users who are updating Volar on Neovim quickly find the correct configuration, issue #3925 serve as the new link.