### PR TITLE
fix: Revert the dark pattern advertisement in the statusbar

### DIFF
--- a/extensions/vscode/src/common.ts
+++ b/extensions/vscode/src/common.ts
@@ -97,44 +97,7 @@ async function doActivate(context: vscode.ExtensionContext, createLc: CreateLang
 		hybridModeStatus.severity = vscode.LanguageStatusSeverity.Warning;
 	}
 
-	if (!context.extension.packageJSON.version.includes('-insider')) {
-		const createLanguageStatus = () => {
-			const item = vscode.languages.createLanguageStatusItem('vue-upgrade', 'vue');
-			item.text = '✨ Upgrade Vue - Official';
-			item.severity = vscode.LanguageStatusSeverity.Warning;
-			item.command = {
-				title: 'Open Link',
-				command: 'vscode.open',
-				arguments: ['https://github.com/vuejs/language-tools/discussions/4127'],
-			};
-		};
-		const yyyymmdd = new Date().toISOString().split('T')[0].replace(/-/g, '');
-		if (context.globalState.get('vue-upgrade-promote-date') !== yyyymmdd) {
-			context.globalState.update('vue-upgrade-promote-date', yyyymmdd);
-			let s = 10;
-			const upgradeStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 10000);
-			const interval = setInterval(() => {
-				s--;
-				upgradeStatus.text = `✨ Upgrade Vue - Official (${s})`;
-				if (s <= 0) {
-					upgradeStatus.dispose();
-					clearInterval(interval);
-					createLanguageStatus();
-				}
-			}, 1000);
-			upgradeStatus.text = `✨ Upgrade Vue - Official (${s})`;
-			upgradeStatus.color = '#ebb549';
-			upgradeStatus.command = {
-				title: 'Open Link',
-				command: 'vscode.open',
-				arguments: ['https://github.com/vuejs/language-tools/discussions/4127'],
-			};
-			upgradeStatus.show();
-		}
-		else {
-			createLanguageStatus();
-		}
-	}
+	createLanguageStatus();
 
 	async function requestReloadVscode(msg: string) {
 		const reload = await vscode.window.showInformationMessage(msg, 'Reload Window');

--- a/extensions/vscode/src/common.ts
+++ b/extensions/vscode/src/common.ts
@@ -97,8 +97,6 @@ async function doActivate(context: vscode.ExtensionContext, createLc: CreateLang
 		hybridModeStatus.severity = vscode.LanguageStatusSeverity.Warning;
 	}
 
-	createLanguageStatus();
-
 	async function requestReloadVscode(msg: string) {
 		const reload = await vscode.window.showInformationMessage(msg, 'Reload Window');
 		if (reload === undefined) return; // cancel


### PR DESCRIPTION
This PR reverts the advertisement that is being shown in the status bar. The status bar is not a place to advertise. We should stick to the regular spaces for asking for sponsorships, including the about page, the extension information page, the repository readme.md file, etc. Using the status bar for this purpose is also explicitly against the Visual Studio Code UX Guidelines for extensions (https://code.visualstudio.com/api/ux-guidelines/overview).

We should respect the developers that use our product. They are the reason we can exist. 