### PR TITLE
fix(language-core): generate each interpolation into separate virtual code

### DIFF
--- a/packages/language-core/lib/generators/inlineCss.ts
+++ b/packages/language-core/lib/generators/inlineCss.ts
@@ -3,6 +3,11 @@ import { forEachElementNode } from './template';
 import { enableAllFeatures } from './utils';
 import type { Code } from '../types';
 
+const codeFeatures = enableAllFeatures({
+	format: false,
+	structure: false,
+});
+
 export function* generate(templateAst: NonNullable<CompilerDOM.RootNode>): Generator<Code> {
 	for (const node of forEachElementNode(templateAst)) {
 		for (const prop of node.props) {
@@ -24,10 +29,7 @@ export function* generate(templateAst: NonNullable<CompilerDOM.RootNode>): Gener
 					content,
 					'template',
 					prop.arg.loc.start.offset + start,
-					enableAllFeatures({
-						format: false,
-						structure: false,
-					}),
+					codeFeatures,
 				];
 				yield ` }\n`;
 			}

--- a/packages/language-core/lib/plugins.ts
+++ b/packages/language-core/lib/plugins.ts
@@ -7,6 +7,7 @@ import useVueSfcStyles from './plugins/vue-sfc-styles';
 import useVueSfcTemplate from './plugins/vue-sfc-template';
 import useVueTemplateHtmlPlugin from './plugins/vue-template-html';
 import useVueTemplateInlineCssPlugin from './plugins/vue-template-inline-css';
+import useVueTemplateInlineTsPlugin from './plugins/vue-template-inline-ts';
 import useVueTsx from './plugins/vue-tsx';
 import { pluginVersion, type VueLanguagePlugin } from './types';
 
@@ -18,6 +19,7 @@ export function getDefaultVueLanguagePlugins(pluginContext: Parameters<VueLangua
 		useVueFilePlugin, // .vue and others for Vue
 		useVueTemplateHtmlPlugin,
 		useVueTemplateInlineCssPlugin,
+		useVueTemplateInlineTsPlugin,
 		useVueSfcStyles,
 		useVueSfcCustomBlocks,
 		useVueSfcScriptsFormat,

--- a/packages/language-core/lib/plugins/vue-sfc-styles.ts
+++ b/packages/language-core/lib/plugins/vue-sfc-styles.ts
@@ -8,23 +8,55 @@ const plugin: VueLanguagePlugin = () => {
 		version: 2,
 
 		getEmbeddedCodes(_fileName, sfc) {
-			return sfc.styles.map((style, i) => ({
-				id: 'style_' + i,
-				lang: style.lang,
-			}));
+			const result: {
+				id: string;
+				lang: string;
+			}[] = [];
+			for (let i = 0; i < sfc.styles.length; i++) {
+				const style = sfc.styles[i];
+				if (style) {
+					result.push({
+						id: 'style_' + i,
+						lang: style.lang,
+					});
+					if (style.cssVars.length) {
+						result.push({
+							id: 'style_' + i + '_inline_ts',
+							lang: 'ts',
+						});
+					}
+				}
+			}
+			return result;
 		},
 
 		resolveEmbeddedCode(_fileName, sfc, embeddedFile) {
 			if (embeddedFile.id.startsWith('style_')) {
-				const index = parseInt(embeddedFile.id.slice('style_'.length));
+				const index = parseInt(embeddedFile.id.split('_')[1]);
 				const style = sfc.styles[index];
-
-				embeddedFile.content.push([
-					style.content,
-					style.name,
-					0,
-					enableAllFeatures({}),
-				]);
+				if (embeddedFile.id.endsWith('_inline_ts')) {
+					embeddedFile.parentCodeId = 'style_' + index;
+					for (const cssVar of style.cssVars) {
+						embeddedFile.content.push(
+							'(',
+							[
+								cssVar.text,
+								style.name,
+								cssVar.offset,
+								enableAllFeatures({}),
+							],
+							');\n',
+						);
+					}
+				}
+				else {
+					embeddedFile.content.push([
+						style.content,
+						style.name,
+						0,
+						enableAllFeatures({}),
+					]);
+				}
 			}
 		},
 	};

--- a/packages/language-core/lib/plugins/vue-template-inline-css.ts
+++ b/packages/language-core/lib/plugins/vue-template-inline-css.ts
@@ -8,19 +8,18 @@ const plugin: VueLanguagePlugin = () => {
 		version: 2,
 
 		getEmbeddedCodes(_fileName, sfc) {
-			if (sfc.template?.ast) {
-				return [{ id: 'template_inline_css', lang: 'css' }];
+			if (!sfc.template?.ast) {
+				return [];
 			}
-			return [];
+			return [{ id: 'template_inline_css', lang: 'css' }];
 		},
 
 		resolveEmbeddedCode(_fileName, sfc, embeddedFile) {
-			if (embeddedFile.id === 'template_inline_css') {
-				embeddedFile.parentCodeId = 'template';
-				if (sfc.template?.ast) {
-					embeddedFile.content.push(...generateInlineCss(sfc.template.ast));
-				}
+			if (embeddedFile.id !== 'template_inline_css' || !sfc.template?.ast) {
+				return;
 			}
+			embeddedFile.parentCodeId = 'template';
+			embeddedFile.content.push(...generateInlineCss(sfc.template.ast));
 		},
 	};
 };

--- a/packages/language-core/lib/plugins/vue-template-inline-ts.ts
+++ b/packages/language-core/lib/plugins/vue-template-inline-ts.ts
@@ -1,0 +1,190 @@
+import { createTsAst, isCompoundExpression, parseVForNode, parseInterpolationNode } from '../generators/template';
+import { disableAllFeatures } from '../generators/utils';
+import type { Code, Sfc, VueLanguagePlugin } from '../types';
+import * as CompilerDOM from '@vue/compiler-dom';
+
+const codeFeatures = disableAllFeatures({
+	format: true,
+	// autoInserts: true, // TODO: support vue-autoinsert-parentheses
+});
+const formatBrackets = {
+	normal: ['`${', '}`;'] as [string, string],
+	if: ['if (', ') { }'] as [string, string],
+	for: ['for (', ') { }'] as [string, string],
+	// fix https://github.com/vuejs/language-tools/issues/3572
+	params: ['(', ') => {};'] as [string, string],
+	// fix https://github.com/vuejs/language-tools/issues/1210
+	// fix https://github.com/vuejs/language-tools/issues/2305
+	curly: ['0 +', '+ 0;'] as [string, string],
+	event: ['() => ', ';'] as [string, string],
+};
+
+const plugin: VueLanguagePlugin = ctx => {
+
+	const parseds = new WeakMap<Sfc, ReturnType<typeof parse>>();
+
+	return {
+
+		version: 2,
+
+		getEmbeddedCodes(_fileName, sfc) {
+			if (!sfc.template?.ast) {
+				return [];
+			}
+			const parsed = parse(sfc);
+			parseds.set(sfc, parsed);
+			const result: {
+				id: string;
+				lang: string;
+			}[] = [];
+			for (const [id] of parsed) {
+				result.push({ id, lang: 'ts' });
+			}
+			return result;
+		},
+
+		resolveEmbeddedCode(_fileName, sfc, embeddedFile) {
+			// access template content to watch change
+			(() => sfc.template?.content)();
+
+			const parsed = parseds.get(sfc);
+			if (parsed) {
+				const codes = parsed.get(embeddedFile.id);
+				if (codes) {
+					embeddedFile.content.push(...codes);
+					embeddedFile.parentCodeId = 'template';
+				}
+			}
+		},
+	};
+
+	function parse(sfc: Sfc) {
+		const data = new Map<string, Code[]>();
+		if (!sfc.template?.ast) {
+			return data;
+		}
+		const templateContent = sfc.template.content;
+		let i = 0;
+		sfc.template.ast.children.forEach(visit);
+		return data;
+
+		function visit(node: CompilerDOM.TemplateChildNode | CompilerDOM.SimpleExpressionNode) {
+			if (node.type === CompilerDOM.NodeTypes.ELEMENT) {
+				for (const prop of node.props) {
+					if (prop.type !== CompilerDOM.NodeTypes.DIRECTIVE) {
+						continue;
+					}
+					const isShorthand = prop.arg?.loc.start.offset === prop.exp?.loc.start.offset; // vue 3.4+
+					if (isShorthand) {
+						continue;
+					}
+					if (prop.arg?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION && !prop.arg.isStatic) {
+						addFormatCodes(
+							prop.arg.content,
+							prop.arg.loc.start.offset,
+							formatBrackets.normal,
+						);
+					}
+					if (
+						prop.exp?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION
+						&& prop.exp.constType !== CompilerDOM.ConstantTypes.CAN_STRINGIFY // style='z-index: 2' will compile to {'z-index':'2'}
+					) {
+						if (prop.name === 'on') {
+							const ast = createTsAst(ctx.modules.typescript, prop.exp, prop.exp.content);
+							addFormatCodes(
+								prop.exp.content,
+								prop.exp.loc.start.offset,
+								isCompoundExpression(ctx.modules.typescript, ast)
+									? formatBrackets.event
+									: formatBrackets.normal,
+							);
+						}
+						else {
+							addFormatCodes(
+								prop.exp.content,
+								prop.exp.loc.start.offset,
+								formatBrackets.normal,
+							);
+						}
+					}
+				}
+				for (const child of node.children) {
+					visit(child);
+				}
+			}
+			else if (node.type === CompilerDOM.NodeTypes.IF) {
+				for (let i = 0; i < node.branches.length; i++) {
+					const branch = node.branches[i];
+					if (branch.condition?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION) {
+						addFormatCodes(
+							branch.condition.content,
+							branch.condition.loc.start.offset,
+							formatBrackets.if,
+						);
+					}
+
+					for (const childNode of branch.children) {
+						visit(childNode);
+					}
+				}
+			}
+			else if (node.type === CompilerDOM.NodeTypes.FOR) {
+				const { leftExpressionRange, leftExpressionText } = parseVForNode(node);
+				const { source } = node.parseResult;
+				if (leftExpressionRange && leftExpressionText && source.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION) {
+					const start = leftExpressionRange.start;
+					const end = source.loc.start.offset + source.content.length;
+					addFormatCodes(
+						templateContent.substring(start, end),
+						start,
+						formatBrackets.for,
+					);
+				}
+				for (const child of node.children) {
+					visit(child);
+				}
+			}
+			else if (node.type === CompilerDOM.NodeTypes.TEXT_CALL) {
+				// {{ var }}
+				visit(node.content);
+			}
+			else if (node.type === CompilerDOM.NodeTypes.COMPOUND_EXPRESSION) {
+				// {{ ... }} {{ ... }}
+				for (const childNode of node.children) {
+					if (typeof childNode === 'object') {
+						visit(childNode);
+					}
+				}
+			}
+			else if (node.type === CompilerDOM.NodeTypes.INTERPOLATION) {
+				// {{ ... }}
+				const [content, start] = parseInterpolationNode(node, templateContent);
+				const lines = content.split('\n');
+				addFormatCodes(
+					content,
+					start,
+					lines.length <= 1 ? formatBrackets.curly : [
+						lines[0].trim() === '' ? '(' : formatBrackets.curly[0],
+						lines[lines.length - 1].trim() === '' ? ');' : formatBrackets.curly[1],
+					],
+				);
+			}
+		}
+
+		function addFormatCodes(code: string, offset: number, wrapper: [string, string]) {
+			const id = 'template_inline_ts_' + i++;
+			data.set(id, [
+				wrapper[0],
+				[
+					code,
+					'template',
+					offset,
+					codeFeatures,
+				],
+				wrapper[1],
+			]);
+		}
+	}
+};
+
+export default plugin;

--- a/packages/language-core/lib/virtualFile/computedFiles.ts
+++ b/packages/language-core/lib/virtualFile/computedFiles.ts
@@ -46,16 +46,7 @@ export function computedFiles(
 			}
 		}
 
-		for (const { file, snapshot, mappings, codegenStacks } of remain) {
-			embeddedCodes.push({
-				id: file.id,
-				languageId: resolveCommonLanguageId(`/dummy.${file.lang}`),
-				linkedCodeMappings: file.linkedCodeMappings,
-				snapshot,
-				mappings,
-				codegenStacks,
-				embeddedCodes: [],
-			});
+		for (const { file } of remain) {
 			console.error('Unable to resolve embedded: ' + file.parentCodeId + ' -> ' + file.id);
 		}
 

--- a/packages/language-service/lib/plugins/vue-autoinsert-parentheses.ts
+++ b/packages/language-service/lib/plugins/vue-autoinsert-parentheses.ts
@@ -20,7 +20,7 @@ export function create(ts: typeof import('typescript')): LanguageServicePlugin {
 					const decoded = context.decodeEmbeddedDocumentUri(document.uri);
 					const sourceScript = decoded && context.language.scripts.get(decoded[0]);
 					const virtualCode = decoded && sourceScript?.generated?.embeddedCodes.get(decoded[1]);
-					if (virtualCode?.id !== 'template_format') {
+					if (!virtualCode?.id.startsWith('template_inline_ts_')) {
 						return;
 					}
 

--- a/packages/language-service/tests/format/2105.spec.ts
+++ b/packages/language-service/tests/format/2105.spec.ts
@@ -4,8 +4,6 @@ defineFormatTest({
 	title: '#' + __filename.split('.')[0],
 	languageId: 'vue',
 	input: `
-<template></template>
-
 <style>
 a {
 	background: v-bind(' props.background|| "var(--primary-lighter)"');
@@ -13,8 +11,6 @@ a {
 </style>
 	`.trim(),
 	output: `
-<template></template>
-
 <style>
 a {
 	background: v-bind('props.background || "var(--primary-lighter)"');

--- a/packages/language-service/tests/format/deep-interpolation-indent.spec.ts
+++ b/packages/language-service/tests/format/deep-interpolation-indent.spec.ts
@@ -1,0 +1,30 @@
+import { defineFormatTest } from '../utils/format';
+
+defineFormatTest({
+	title: '#' + __filename.split('.')[0],
+	languageId: 'vue',
+	input: `
+<template>
+	{{
+		foo
+	}}
+	<div>
+	{{
+		bar
+	}}
+	</div>
+</template>
+	`.trim(),
+	output: `
+<template>
+	{{
+		foo
+	}}
+	<div>
+		{{
+			bar
+		}}
+	</div>
+</template>
+	`.trim(),
+});


### PR DESCRIPTION
close #3973, #4078

After Volar 2.1, there has been a change in the handling of indentation for embedded code. It now only calculates the initial indentation of the entire virtual document instead of the each interpolation segment. Therefore, each interpolation segment now needs to be generated into a separate virtual document so that Volar can handle the initial indentation of each segment independently.
