### PR TITLE
feat(vscode): re-add restart server command

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -391,6 +391,11 @@
 		},
 		"commands": [
 			{
+				"command": "vue.action.restartServer",
+				"title": "Restart Vue and TS servers",
+				"category": "Vue"
+			},
+			{
 				"command": "vue.action.doctor",
 				"title": "Doctor",
 				"category": "Vue"

--- a/extensions/vscode/src/common.ts
+++ b/extensions/vscode/src/common.ts
@@ -145,17 +145,21 @@ async function doActivate(context: vscode.ExtensionContext, createLc: CreateLang
 				);
 			}
 			else if (e.affectsConfiguration('vue')) {
-				vscode.commands.executeCommand('vue.action.restartServer');
+				vscode.commands.executeCommand('vue.action.restartServer', false);
 			}
 		}));
 	}
 
 	async function activateRestartRequest() {
-		context.subscriptions.push(vscode.commands.registerCommand('vue.action.restartServer', async () => {
+		context.subscriptions.push(vscode.commands.registerCommand('vue.action.restartServer', async (restartTsServer: boolean = true) => {
 			await client.stop();
 			outputChannel.clear();
 			client.clientOptions.initializationOptions = await getInitializationOptions(context);
 			await client.start();
+			nameCasing.activate(context, client, selectors);
+			if (restartTsServer) {
+				await vscode.commands.executeCommand('typescript.restartTsServer');
+			}
 		}));
 	}
 }


### PR DESCRIPTION
close #4164

In versions 2.0.0 ~ 2.0.6, TS support in .vue files was provided by tsserver. The "TypeScript: Restart TS Server" command should be used instead of the original restart command, so the original restart command has been removed.

In version 2.0.7, full TS support was re-implemented by the Vue server, so the restart vue server command is needed again.

The situation is a bit confusing in 2.0.7:

- When Hybrid Mode is disabled, the restart command should restart the vue language server.
- When Hybrid Mode is enabled, the restart command should restart tsserver.

To avoid confusion, the restart command will now always restart both the vue language server and tsserver.