### PR TITLE
feat(component-meta): add typing resolution for defineModel modifiers

### DIFF
--- a/packages/component-meta/lib/base.ts
+++ b/packages/component-meta/lib/base.ts
@@ -299,15 +299,12 @@ ${vueCompilerOptions.target < 3 ? vue2TypeHelpersCode : typeHelpersCode}
 			if ($props) {
 				const type = typeChecker.getTypeOfSymbolAtLocation($props, symbolNode);
 				const properties = type.getProperties();
+				const {
+					resolveNestedProperties,
+				} = createSchemaResolvers(typeChecker, symbolNode, checkerOptions, ts, language);
 
 				result = properties
-					.map(prop => {
-						const {
-							resolveNestedProperties,
-						} = createSchemaResolvers(typeChecker, symbolNode, checkerOptions, ts, language);
-
-						return resolveNestedProperties(prop);
-					})
+					.map(prop => resolveNestedProperties(prop))
 					.filter(prop => !prop.name.match(propEventRegex));
 			}
 

--- a/packages/component-meta/lib/base.ts
+++ b/packages/component-meta/lib/base.ts
@@ -299,12 +299,15 @@ ${vueCompilerOptions.target < 3 ? vue2TypeHelpersCode : typeHelpersCode}
 			if ($props) {
 				const type = typeChecker.getTypeOfSymbolAtLocation($props, symbolNode);
 				const properties = type.getProperties();
-				const {
-					resolveNestedProperties,
-				} = createSchemaResolvers(typeChecker, symbolNode, checkerOptions, ts, language);
 
 				result = properties
-					.map(prop => resolveNestedProperties(prop))
+					.map(prop => {
+						const {
+							resolveNestedProperties,
+						} = createSchemaResolvers(typeChecker, symbolNode, checkerOptions, ts, language);
+
+						return resolveNestedProperties(prop);
+					})
 					.filter(prop => !prop.name.match(propEventRegex));
 			}
 

--- a/packages/component-meta/tests/index.spec.ts
+++ b/packages/component-meta/tests/index.spec.ts
@@ -19,7 +19,7 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) => describ
 		expect(meta.props.filter(prop => !prop.global)).toEqual([]);
 	});
 
-	test.only('reference-type-model', () => {
+	test('reference-type-model', () => {
 		const componentPath = path.resolve(__dirname, '../../../test-workspace/component-meta/reference-type-model/component.vue');
 		const meta = checker.getComponentMeta(componentPath);
 

--- a/packages/component-meta/tests/index.spec.ts
+++ b/packages/component-meta/tests/index.spec.ts
@@ -19,7 +19,7 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) => describ
 		expect(meta.props.filter(prop => !prop.global)).toEqual([]);
 	});
 
-	test('reference-type-model', () => {
+	test.only('reference-type-model', () => {
 		const componentPath = path.resolve(__dirname, '../../../test-workspace/component-meta/reference-type-model/component.vue');
 		const meta = checker.getComponentMeta(componentPath);
 
@@ -31,10 +31,17 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) => describ
 		const bar = meta.props.find(prop => prop.name === 'bar');
 		const onUpdateBar = meta.events.find(event => event.name === 'update:bar')
 
+		const qux = meta.props.find(prop => prop.name === 'qux');
+		const quxModifiers = meta.props.find(prop => prop.name === 'quxModifiers');
+		const onUpdateQux = meta.events.find(event => event.name === 'update:qux')
+
 		expect(foo).toBeDefined();
 		expect(bar).toBeDefined();
+		expect(qux).toBeDefined();
+		expect(quxModifiers).toBeDefined();
 		expect(onUpdateFoo).toBeDefined();
 		expect(onUpdateBar).toBeDefined();
+		expect(onUpdateQux).toBeDefined();
 	})
 
 	test('reference-type-props', () => {

--- a/packages/language-core/lib/generators/script.ts
+++ b/packages/language-core/lib/generators/script.ts
@@ -626,6 +626,7 @@ export function* generate(
 					const start = getGeneratedLength();
 					definePropMirrors.set(propName, start);
 					yield _(propName);
+
 				}
 				else {
 					yield _(propName);
@@ -645,6 +646,22 @@ export function* generate(
 				}
 				else {
 					yield _(`import('${vueCompilerOptions.lib}').PropType<${type}>,\n`);
+				}
+
+				if (defineProp.modifierType) {
+					let propModifierName = 'modelModifiers';
+
+					if (defineProp.name) {
+						propModifierName = `${scriptSetup.content.substring(defineProp.name.start + 1, defineProp.name.end - 1)}Modifiers`;
+					}
+
+					const modifierType = scriptSetup.content.substring(defineProp.modifierType.start, defineProp.modifierType.end);
+
+					const start = getGeneratedLength();
+					definePropMirrors.set(propModifierName, start);
+					yield _(propModifierName);
+					yield _(`: `);
+					yield _(`import('${vueCompilerOptions.lib}').PropType<Record<${modifierType}, true>>,\n`);
 				}
 			}
 			yield _(`};\n`);

--- a/packages/language-core/lib/parsers/scriptSetupRanges.ts
+++ b/packages/language-core/lib/parsers/scriptSetupRanges.ts
@@ -133,7 +133,7 @@ export function parseScriptSetupRanges(
 					name,
 					nameIsString: true,
 					type: node.typeArguments?.length ? _getStartEnd(node.typeArguments[0]) : undefined,
-					modifierType: node.typeArguments?.length === 2 ? _getStartEnd(node.typeArguments[1]) : undefined,
+					modifierType: node.typeArguments?.length >= 2 ? _getStartEnd(node.typeArguments[1]) : undefined,
 					defaultValue: undefined,
 					required,
 					isModel: true,

--- a/packages/language-core/lib/parsers/scriptSetupRanges.ts
+++ b/packages/language-core/lib/parsers/scriptSetupRanges.ts
@@ -133,7 +133,7 @@ export function parseScriptSetupRanges(
 					name,
 					nameIsString: true,
 					type: node.typeArguments?.length ? _getStartEnd(node.typeArguments[0]) : undefined,
-					modifierType: node.typeArguments?.length >= 2 ? _getStartEnd(node.typeArguments[1]) : undefined,
+					modifierType: node.typeArguments && node.typeArguments?.length >= 2 ? _getStartEnd(node.typeArguments[1]) : undefined,
 					defaultValue: undefined,
 					required,
 					isModel: true,

--- a/packages/language-core/lib/parsers/scriptSetupRanges.ts
+++ b/packages/language-core/lib/parsers/scriptSetupRanges.ts
@@ -40,6 +40,7 @@ export function parseScriptSetupRanges(
 		name: TextRange | undefined;
 		nameIsString: boolean;
 		type: TextRange | undefined;
+		modifierType?: TextRange | undefined;
 		defaultValue: TextRange | undefined;
 		required: boolean;
 		isModel?: boolean;
@@ -132,6 +133,7 @@ export function parseScriptSetupRanges(
 					name,
 					nameIsString: true,
 					type: node.typeArguments?.length ? _getStartEnd(node.typeArguments[0]) : undefined,
+					modifierType: node.typeArguments?.length === 2 ? _getStartEnd(node.typeArguments[1]) : undefined,
 					defaultValue: undefined,
 					required,
 					isModel: true,

--- a/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -242,15 +242,21 @@ exports[`vue-tsc-dts > Input: reference-type-model/component.vue, Output: refere
 "declare const _default: import("vue").DefineComponent<{
     foo: import("vue").PropType<number>;
     bar: import("vue").PropType<string[]>;
+    qux: import("vue").PropType<string>;
+    quxModifiers: import("vue").PropType<Record<"trim" | "lazy", true>>;
 }, {}, unknown, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {
     "update:foo": (foo: number) => void;
     "update:bar": (bar: string[]) => void;
+    "update:qux": (qux: string) => void;
 }, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<{
     foo: import("vue").PropType<number>;
     bar: import("vue").PropType<string[]>;
+    qux: import("vue").PropType<string>;
+    quxModifiers: import("vue").PropType<Record<"trim" | "lazy", true>>;
 }>> & {
     "onUpdate:foo"?: (foo: number) => any;
     "onUpdate:bar"?: (bar: string[]) => any;
+    "onUpdate:qux"?: (qux: string) => any;
 }, {}, {}>;
 export default _default;
 "

--- a/test-workspace/component-meta/reference-type-model/component.vue
+++ b/test-workspace/component-meta/reference-type-model/component.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
 const bar = defineModel<number>("foo")
 const baz = defineModel<string[]>("bar")
+const [qux, modifiers] = defineModel<string, 'lazy' | 'trim'>("qux")
 </script>


### PR DESCRIPTION
This PR aims to retrieve types of model modifiers from `defineModel` macro.

```ts
// default
const [modelValue, modelModifiers] = defineModel<string, 'lazy' | 'trim'>()

// modelValue: import("vue").PropType<string>
// modelModifiers: import("vue").PropType<Record<'lazy' | 'trim', true>>


// named
const [named, modifiers] = defineModel<string, 'foo'>('named')

// named: import("vue").PropType<string>
// namedModifiers: import("vue").PropType<Record<'foo', true>>
```

Here is a playground where we can see property being generated: https://play.vuejs.org/#eNqFkk1PwzAMhv+KlUtBqrYDnKZuEqAdQOJDgLgQDlHrlow0iZJ0DEr/O26qlQlN2y1+/dp+bKVlF9ZO1g2yGct87qQN4DE0FpTQ1Zyz4DlbcJ0b7QO81qZA9SJUgynE960pZCnR+TeYQ4Gl1EgSqswHJ3WVQqLE91cCP5CQUCeLk9OxmRY1FrHPkRalMVSYRH9C9dl0ICUuCgLWVomAFAFk1uGibaHtAxgY9/Kmg+E/Q5Q76Lps2nfqZ+30Zyndg+hLWU1W3mg6WhzEWW5qKxW6exskbcfZbIvAmVDKfN5ELTgi2er5O+Yfe/SV3/QaZw8OPbo1cjbmgnAVhiG9fLrDDb3HJG3RKHIfSD6iN6rpGQfbZaMLwt7xRdrr2hoX6PrPfrkJqP12qR40nij6OaOfc3Vg9T/cs8l5rOO6Y90vLZfTGA==