### PR TITLE
Added simple tests for vue-tsc and custom SFC extensions.

### DIFF
--- a/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -22,7 +22,82 @@ export default _default;
 "
 `;
 
+exports[`vue-tsc-dts > Input: empty-component/custom-extension-component.cext, Output: empty-component/custom-extension-component.cext.d.ts 1`] = `
+"declare const _default: import("vue").DefineComponent<{}, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<{}>>, {}, {}>;
+export default _default;
+"
+`;
+
 exports[`vue-tsc-dts > Input: generic/component.vue, Output: generic/component.vue.d.ts 1`] = `
+"declare const _default: <T>(__VLS_props: {
+    onBar?: (data: number) => any;
+    foo: number;
+} & import("vue").VNodeProps & import("vue").AllowedComponentProps & import("vue").ComponentCustomProps, __VLS_ctx?: {
+    attrs: any;
+    emit: (e: 'bar', data: number) => void;
+    slots: Readonly<{
+        default?(data: {
+            foo: number;
+        }): any;
+    }> & {
+        default?(data: {
+            foo: number;
+        }): any;
+    };
+}, __VLS_expose?: (exposed: import("vue").ShallowUnwrapRef<{
+    baz: number;
+}>) => void, __VLS_setup?: Promise<{
+    props: {
+        onBar?: (data: number) => any;
+        foo: number;
+    } & import("vue").VNodeProps & import("vue").AllowedComponentProps & import("vue").ComponentCustomProps;
+    expose(exposed: import("vue").ShallowUnwrapRef<{
+        baz: number;
+    }>): void;
+    attrs: any;
+    slots: Readonly<{
+        default?(data: {
+            foo: number;
+        }): any;
+    }> & {
+        default?(data: {
+            foo: number;
+        }): any;
+    };
+    emit: (e: 'bar', data: number) => void;
+}>) => import("vue").VNode<import("vue").RendererNode, import("vue").RendererElement, {
+    [key: string]: any;
+}> & {
+    __ctx?: {
+        props: {
+            onBar?: (data: number) => any;
+            foo: number;
+        } & import("vue").VNodeProps & import("vue").AllowedComponentProps & import("vue").ComponentCustomProps;
+        expose(exposed: import("vue").ShallowUnwrapRef<{
+            baz: number;
+        }>): void;
+        attrs: any;
+        slots: Readonly<{
+            default?(data: {
+                foo: number;
+            }): any;
+        }> & {
+            default?(data: {
+                foo: number;
+            }): any;
+        };
+        emit: (e: 'bar', data: number) => void;
+    };
+};
+export default _default;
+type __VLS_OmitKeepDiscriminatedUnion<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
+type __VLS_Prettify<T> = {
+    [K in keyof T]: T[K];
+} & {};
+"
+`;
+
+exports[`vue-tsc-dts > Input: generic/custom-extension-component.cext, Output: generic/custom-extension-component.cext.d.ts 1`] = `
 "declare const _default: <T>(__VLS_props: {
     onBar?: (data: number) => any;
     foo: number;

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -25,7 +25,7 @@ describe('vue-tsc-dts', () => {
 		options: compilerOptions
 	};
 	const fakeGlobalTypesHolder = createFakeGlobalTypesHolder(options);
-	const createProgram = proxyCreateProgram(ts, ts.createProgram, ['.vue'], (ts, options) => {
+	const createProgram = proxyCreateProgram(ts, ts.createProgram, ['.vue', '.cext'], (ts, options) => {
 		const { configFilePath } = options.options;
 		const vueOptions = typeof configFilePath === 'string'
 			? vue.createParsedCommandLine(ts, ts.sys, configFilePath.replace(windowsPathReg, '/')).vueOptions

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -25,11 +25,12 @@ describe('vue-tsc-dts', () => {
 		options: compilerOptions
 	};
 	const fakeGlobalTypesHolder = createFakeGlobalTypesHolder(options);
-	const createProgram = proxyCreateProgram(ts, ts.createProgram, ['.vue', '.cext'], (ts, options) => {
+	const extensions = ['.vue', '.cext'];
+	const createProgram = proxyCreateProgram(ts, ts.createProgram, extensions, (ts, options) => {
 		const { configFilePath } = options.options;
 		const vueOptions = typeof configFilePath === 'string'
 			? vue.createParsedCommandLine(ts, ts.sys, configFilePath.replace(windowsPathReg, '/')).vueOptions
-			: vue.resolveVueCompilerOptions({});
+			: vue.resolveVueCompilerOptions({ extensions });
 		const vueLanguagePlugin = vue.createVueLanguagePlugin(
 			ts,
 			id => id,

--- a/test-workspace/component-meta/empty-component/custom-extension-component.cext
+++ b/test-workspace/component-meta/empty-component/custom-extension-component.cext
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+const internalProp = 42;
+</script>
+
+<template>
+	{{ internalProp }}
+</template>

--- a/test-workspace/component-meta/generic/custom-extension-component.cext
+++ b/test-workspace/component-meta/generic/custom-extension-component.cext
@@ -1,0 +1,6 @@
+<script setup lang="ts" generic="T">
+defineProps<{ foo: number }>();
+defineEmits<{ (e: 'bar', data: number): void }>();
+defineExpose({ baz: {} as number });
+defineSlots<{ default?(data: { foo: number }): any }>();
+</script>


### PR DESCRIPTION
Adds two simple tests for vue-tsc to ensure volarjs/volar.js#155 is working correctly. So this should not be merged until that is merged.

These basically duplicate two of the existing `component.vue` test files with a custom extension and then update the dts suite to enable that custom extension.