### PR TITLE
fix(tsc): remove fake global types holder

### DIFF
--- a/packages/language-core/lib/generators/globalTypes.ts
+++ b/packages/language-core/lib/generators/globalTypes.ts
@@ -4,11 +4,12 @@ import { getSlotsPropertyName } from '../utils/shared';
 export function generateGlobalTypes(vueCompilerOptions: VueCompilerOptions) {
 	const fnPropsType = `(K extends { $props: infer Props } ? Props : any)${vueCompilerOptions.strictTemplates ? '' : ' & Record<string, unknown>'}`;
 	return `
-; declare global {
+; export const __VLS_globalTypesStart = {};
+declare global {
 // @ts-ignore
-type __VLS_IntrinsicElements = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.IntrinsicElements, __VLS_PickNotAny<JSX.IntrinsicElements, Record<string, any>>>;
+type __VLS_IntrinsicElements = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.IntrinsicElements, __VLS_PickNotAny<globalThis.JSX.IntrinsicElements, Record<string, any>>>;
 // @ts-ignore
-type __VLS_Element = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.Element, JSX.Element>;
+type __VLS_Element = __VLS_PickNotAny<import('vue/jsx-runtime').JSX.Element, globalThis.JSX.Element>;
 // @ts-ignore
 type __VLS_GlobalComponents = ${[
 			`__VLS_PickNotAny<import('vue').GlobalComponents, {}>`,
@@ -125,5 +126,6 @@ type __VLS_NormalizeEmits<T> = __VLS_PrettifyGlobal<
 	>
 >;
 type __VLS_PrettifyGlobal<T> = { [K in keyof T]: T[K]; } & {};
-}`;
+}
+export const __VLS_globalTypesEnd = {};`;
 };


### PR DESCRIPTION
composite projects currently do not rebuild efficently because we attach a fake place holder vue file. This is used to generate global types once for the project.

As the fake placeholder file is added the the roots file, the second build will detect a change because the root file does not exist for discovery with tsc.

> Project 'packages/design-system/tsconfig.json' is out of date because buildinfo file
> 'packages/design-system/tsconfig.tsbuildinfo' indicates that file '[.../path/to/fake-file.vue]'
> was root file of compilation but not any more.

remove adding the fake file to the roots, and instead apply the globals to the first vue file and then remove them when writing .d.ts. 