### PR TITLE
chore(server): use `os.tempdir()` instead of hardcoded `pipeFile` paths

### DIFF
--- a/packages/typescript-plugin/lib/server.ts
+++ b/packages/typescript-plugin/lib/server.ts
@@ -8,6 +8,8 @@ import { getPropertiesAtLocation } from './requests/getPropertiesAtLocation';
 import { getQuickInfoAtPosition } from './requests/getQuickInfoAtPosition';
 import { NamedPipeServer, connect, readPipeTable, updatePipeTable } from './utils';
 import type { Language, VueCompilerOptions } from '@vue/language-core';
+import * as path from 'path';
+import * as os from 'os';
 
 export interface Request {
 	type: 'containsFile'
@@ -35,10 +37,8 @@ export function startNamedPipeServer(
 		return;
 	}
 	started = true;
+	const pipeFile = path.join(os.tmpdir(), `vue-tsp-${process.pid}`);
 
-	const pipeFile = process.platform === 'win32'
-		? `\\\\.\\pipe\\vue-tsp-${process.pid}`
-		: `/tmp/vue-tsp-${process.pid}`;
 	const server = net.createServer(connection => {
 		connection.on('data', data => {
 			const text = data.toString();


### PR DESCRIPTION
 As [this change](https://github.com/vuejs/language-tools/commit/72e38d52d95cdbd1aa29011a6a60657eb619deef#diff-cec35c50723f4febc3d6909d21749dbe907bc561d74f6e52b8a0de6dd9d9f7e4R13-R15) was indroduces in 2.0.2 it looks logical to use the same logic to create `pipeFiles` too.
 
P.S.: I found this inconsistency during debugging #3976 (see [this comment](https://github.com/vuejs/language-tools/issues/3976#issuecomment-1979105927) for more information) as this still was an issue on my windows machine. At some moment I mentioned a warning in the `tsconfig.json` which complains on the absense of the `dist/schemas/vue-tsconfig.schema.json` file.

![image](https://github.com/vuejs/language-tools/assets/74474615/96bf8064-9316-4166-90b1-4a6ef5f3d952)

So I manually run `npm run build` in the `extensions/vscode` directory and then the issue was resolved, so I have some related questions.

1.  How to debug `packages/typescript-plugin/index.ts`, `packages/typescript-plugin/lib/server.ts` etc? Breakpoints do not work there if using `Launch client`/`Attach to server`
2. As I can see `npm run watch` in root do not create `dist` dir in `extensions/vscode`. Is this desired behaviour? Every time I open project with `tsconfig` in dev mode I see a warning like on screenshot above.


