### PR TITLE
feat(vscode): automatically enable Hybrid Mode

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -221,7 +221,12 @@
 				},
 				"vue.server.hybridMode": {
 					"type": "boolean",
-					"default": false,
+					"default": "auto",
+					"enum": [
+						"auto",
+						true,
+						false
+					],
 					"description": "Vue language server only handles CSS and HTML language support, and tsserver takes over TS language support via TS plugin."
 				},
 				"vue.server.maxFileSize": {

--- a/extensions/vscode/src/common.ts
+++ b/extensions/vscode/src/common.ts
@@ -48,6 +48,7 @@ function getCurrentHybridModeStatus(report = false) {
 					|| extension.id === 'astro-build.astro-vscode'
 					|| extension.id === 'ije.esm-vscode'
 					|| extension.id === 'johnsoncodehk.vscode-tsslint'
+					|| extension.id === 'VisualStudioExptTeam.vscodeintellicode'
 				) {
 					continue;
 				}
@@ -127,7 +128,7 @@ async function doActivate(context: vscode.ExtensionContext, createLc: CreateLang
 		command: 'workbench.action.openSettings',
 		arguments: ['vue.server.hybridMode'],
 	};
-	if (currentHybridModeStatus) {
+	if (!currentHybridModeStatus) {
 		hybridModeStatus.severity = vscode.LanguageStatusSeverity.Warning;
 	}
 

--- a/extensions/vscode/src/common.ts
+++ b/extensions/vscode/src/common.ts
@@ -299,7 +299,7 @@ async function getInitializationOptions(
 		typescript: { tsdk: (await lsp.getTsdk(context)).tsdk },
 		maxFileSize: config.server.maxFileSize,
 		semanticTokensLegend: {
-			tokenTypes: ['component'],
+			tokenTypes: [],
 			tokenModifiers: [],
 		},
 		vue: {

--- a/extensions/vscode/src/common.ts
+++ b/extensions/vscode/src/common.ts
@@ -38,6 +38,7 @@ export const currentHybridModeStatus = getCurrentHybridModeStatus();
 
 function getCurrentHybridModeStatus(report = false) {
 	if (config.server.hybridMode === 'auto') {
+		const unknownExtensions: string[] = [];
 		for (const extension of vscode.extensions.all) {
 			const hasTsPlugin = !!extension.packageJSON?.contributes?.typescriptServerPlugins;
 			if (hasTsPlugin) {
@@ -45,23 +46,28 @@ function getCurrentHybridModeStatus(report = false) {
 					extension.id === 'Vue.volar'
 					|| extension.id === 'unifiedjs.vscode-mdx'
 					|| extension.id === 'astro-build.astro-vscode'
+					|| extension.id === 'ije.esm-vscode'
+					|| extension.id === 'johnsoncodehk.vscode-tsslint'
 				) {
 					continue;
 				}
 				else {
-					if (report) {
-						vscode.window.showInformationMessage(
-							`Hybrid Mode is disabled automatically because there is a potentially incompatible "${extension.id}" TypeScript plugin installed.`,
-							'Report a false positive',
-						).then(value => {
-							if (value) {
-								vscode.env.openExternal(vscode.Uri.parse(''));
-							}
-						});
-					}
-					return false;
+					unknownExtensions.push(extension.id);
 				}
 			}
+		}
+		if (unknownExtensions.length) {
+			if (report) {
+				vscode.window.showInformationMessage(
+					`Hybrid Mode is disabled automatically because there is a potentially incompatible ${unknownExtensions.join(', ')} TypeScript plugin installed.`,
+					'Report a false positive',
+				).then(value => {
+					if (value) {
+						vscode.env.openExternal(vscode.Uri.parse('https://github.com/vuejs/language-tools/pull/4206'));
+					}
+				});
+			}
+			return false;
 		}
 		return true;
 	}

--- a/extensions/vscode/src/common.ts
+++ b/extensions/vscode/src/common.ts
@@ -37,7 +37,7 @@ export async function activate(context: vscode.ExtensionContext, createLc: Creat
 	}
 }
 
-export let currentHybridModeStatus = getCurrentHybridModeStatus();
+export const currentHybridModeStatus = getCurrentHybridModeStatus();
 
 function getCurrentHybridModeStatus(report = false) {
 	if (config.server.hybridMode === 'auto') {

--- a/extensions/vscode/src/config.ts
+++ b/extensions/vscode/src/config.ts
@@ -16,7 +16,7 @@ export const config = {
 		return _config().get('doctor')!;
 	},
 	get server(): Readonly<{
-		hybridMode: boolean;
+		hybridMode: 'auto' | boolean;
 		maxOldSpaceSize: number;
 		maxFileSize: number;
 		diagnosticModel: 'push' | 'pull';

--- a/extensions/vscode/src/features/doctor.ts
+++ b/extensions/vscode/src/features/doctor.ts
@@ -231,27 +231,6 @@ export async function register(context: vscode.ExtensionContext, client: BaseLan
 			});
 		}
 
-		if (config.server.hybridMode) {
-			// #3942, https://github.com/microsoft/TypeScript/issues/57633
-			for (const extId of [
-				'svelte.svelte-vscode',
-				'styled-components.vscode-styled-components',
-				'Divlo.vscode-styled-jsx-languageserver',
-			]) {
-				const ext = vscode.extensions.getExtension(extId);
-				if (ext) {
-					problems.push({
-						title: `Recommended to disable "${ext.packageJSON.displayName || extId}" in Vue workspace`,
-						message: [
-							`This extension's TypeScript Plugin and Vue's TypeScript Plugin are known to cause some conflicts. Until the problem is resolved, it is recommended that you temporarily disable the this extension in the Vue workspace.`,
-							'',
-							'Issues: https://github.com/vuejs/language-tools/issues/3942, https://github.com/microsoft/TypeScript/issues/57633',
-						].join('\n'),
-					});
-				}
-			}
-		}
-
 		// check outdated vue language plugins
 		// check node_modules has more than one vue versions
 		// check ESLint, Prettier...

--- a/extensions/vscode/src/nodeClientMain.ts
+++ b/extensions/vscode/src/nodeClientMain.ts
@@ -3,7 +3,7 @@ import * as serverLib from '@vue/language-server';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as lsp from '@volar/vscode/node';
-import { activate as commonActivate, deactivate as commonDeactivate } from './common';
+import { activate as commonActivate, deactivate as commonDeactivate, currentHybridModeStatus } from './common';
 import { config } from './config';
 import { middleware } from './middleware';
 
@@ -133,7 +133,6 @@ try {
 	const tsExtension = vscode.extensions.getExtension('vscode.typescript-language-features')!;
 	const readFileSync = fs.readFileSync;
 	const extensionJsPath = require.resolve('./dist/extension.js', { paths: [tsExtension.extensionPath] });
-	const { hybridMode } = config.server;
 
 	// @ts-expect-error
 	fs.readFileSync = (...args) => {
@@ -141,7 +140,7 @@ try {
 			// @ts-expect-error
 			let text = readFileSync(...args) as string;
 
-			if (!hybridMode) {
+			if (!currentHybridModeStatus) {
 				// patch readPlugins
 				text = text.replace(
 					'languages:Array.isArray(e.languages)',


### PR DESCRIPTION
Closes #4131

This introduces the default value of `"auto"` for `vue.server.hybridMode`, which automatically enables it based on the compatibility of installed TS plugin extensions with Hybrid Mode.

The following TS plugin extensions are currently known to be compatible:

- unifiedjs.vscode-mdx
- astro-build.astro-vscode
- ije.esm-vscode
- johnsoncodehk.vscode-tsslint
- VisualStudioExptTeam.vscodeintellicode

The following TS plugin extensions are currently known to be incompatible:

- styled-components.vscode-styled-components
- svelte.svelte-vscode
- Divlo.vscode-styled-jsx-languageserver

If you know of any other compatible TS plugin extensions, please report them here so that we can update the whitelist.

To verify compatibility, simply set `"vue.server.hybridMode": true` in your VSCode settings and reload VSCode to check if TS support in .vue files is working as expected.