### PR TITLE
feat(language-server): create project with tsconfig on hybrid mode

### DIFF
--- a/packages/language-server/lib/hybridModeProject.ts
+++ b/packages/language-server/lib/hybridModeProject.ts
@@ -1,0 +1,126 @@
+import type { LanguagePlugin, LanguageServicePlugin, ServerProject, ServerProjectProviderFactory } from '@volar/language-server';
+import { createSimpleServerProject } from '@volar/language-server/lib/project/simpleProject';
+import { createServiceEnvironment, getWorkspaceFolder } from '@volar/language-server/lib/project/simpleProjectProvider';
+import type { ServerContext } from '@volar/language-server/lib/server';
+import { FileMap, createLanguage } from '@vue/language-core';
+import { LanguageService, ServiceEnvironment, createLanguageService } from '@vue/language-service';
+import { searchNamedPipeServerForFile } from '@vue/typescript-plugin/lib/utils';
+import type * as ts from 'typescript';
+
+export function createHybridModeProjectProviderFactory(sys: ts.System): ServerProjectProviderFactory {
+	return (context, servicePlugins, getLanguagePlugins) => {
+		const serviceEnvs = new FileMap<ServiceEnvironment>(sys.useCaseSensitiveFileNames);
+		const tsconfigProjects = new FileMap<Promise<ServerProject>>(sys.useCaseSensitiveFileNames);
+		const simpleProjects = new FileMap<Promise<ServerProject>>(sys.useCaseSensitiveFileNames);
+		context.onDidChangeWatchedFiles(({ changes }) => {
+			for (const change of changes) {
+				if (tsconfigProjects.has(change.uri)) {
+					tsconfigProjects.get(change.uri)?.then(project => project.dispose());
+					tsconfigProjects.delete(change.uri);
+					context.reloadDiagnostics();
+				}
+			}
+		});
+		return {
+			async getProject(uri): Promise<ServerProject> {
+				const workspaceFolder = getWorkspaceFolder(uri, context.workspaceFolders);
+				let serviceEnv = serviceEnvs.get(workspaceFolder);
+				if (!serviceEnv) {
+					serviceEnv = createServiceEnvironment(context, workspaceFolder);
+					serviceEnvs.set(workspaceFolder, serviceEnv);
+				}
+				const fileName = serviceEnv.typescript!.uriToFileName(uri);
+				const projectInfo = (await searchNamedPipeServerForFile(fileName))?.projectInfo;
+				if (projectInfo?.kind === 1) {
+					const tsconfig = projectInfo.name;
+					const tsconfigUri = serviceEnv.typescript!.fileNameToUri(tsconfig);
+					if (!tsconfigProjects.has(tsconfigUri)) {
+						tsconfigProjects.set(tsconfigUri, (async () => {
+							const languagePlugins = await getLanguagePlugins(serviceEnv, {
+								typescript: {
+									configFileName: tsconfig,
+									host: {
+										getScriptFileNames() {
+											return [];
+										},
+									} as any,
+									sys: {
+										...sys,
+										version: 0,
+										async sync() {
+											return 0;
+										},
+										dispose() { },
+									},
+								},
+							});
+							return createTSConfigProject(context, serviceEnv, languagePlugins, servicePlugins);
+						})());
+					}
+					return await tsconfigProjects.get(tsconfigUri)!;
+				}
+				else {
+					if (!simpleProjects.has(workspaceFolder)) {
+						simpleProjects.set(workspaceFolder, (() => {
+							return createSimpleServerProject(context, serviceEnv, servicePlugins, getLanguagePlugins);
+						})());
+					}
+					return await simpleProjects.get(workspaceFolder)!;
+				}
+			},
+			async getProjects() {
+				return Promise.all([
+					...tsconfigProjects.values(),
+					...simpleProjects.values(),
+				]);
+			},
+			async reloadProjects() {
+				for (const project of [
+					...tsconfigProjects.values(),
+					...simpleProjects.values(),
+				]) {
+					(await project).dispose();
+				}
+				tsconfigProjects.clear();
+			},
+		};
+
+		function createTSConfigProject(
+			context: ServerContext,
+			serviceEnv: ServiceEnvironment,
+			languagePlugins: LanguagePlugin[],
+			servicePlugins: LanguageServicePlugin[],
+		): ServerProject {
+
+			let languageService: LanguageService | undefined;
+
+			return {
+				getLanguageService,
+				getLanguageServiceDontCreate: () => languageService,
+				dispose() {
+					languageService?.dispose();
+				},
+			};
+
+			function getLanguageService() {
+				if (!languageService) {
+					const language = createLanguage(languagePlugins, false, uri => {
+						const script = context.documents.get(uri);
+						if (script) {
+							language.scripts.set(uri, script.languageId, script.getSnapshot());
+						}
+						else {
+							language.scripts.delete(uri);
+						}
+					});
+					languageService = createLanguageService(
+						language,
+						servicePlugins,
+						serviceEnv,
+					);
+				}
+				return languageService;
+			}
+		}
+	};
+}

--- a/packages/typescript-plugin/lib/client.ts
+++ b/packages/typescript-plugin/lib/client.ts
@@ -85,7 +85,7 @@ export function getElementAttrs(
 }
 
 async function sendRequest<T>(request: Request) {
-	const server = await searchNamedPipeServerForFile(request.args[0]);
+	const server = (await searchNamedPipeServerForFile(request.args[0]))?.server;
 	if (!server) {
 		console.warn('[Vue Named Pipe Client] No server found for', request.args[0]);
 		return;

--- a/packages/typescript-plugin/lib/server.ts
+++ b/packages/typescript-plugin/lib/server.ts
@@ -10,7 +10,7 @@ import { NamedPipeServer, connect, readPipeTable, updatePipeTable } from './util
 import type { Language, VueCompilerOptions } from '@vue/language-core';
 
 export interface Request {
-	type: 'containsFile'
+	type: 'projectInfoForFile'
 	| 'collectExtractProps'
 	| 'getImportPathForFile'
 	| 'getPropertiesAtLocation'
@@ -45,8 +45,14 @@ export function startNamedPipeServer(
 			const request: Request = JSON.parse(text);
 			const fileName = request.args[0];
 			const project = getProject(fileName);
-			if (request.type === 'containsFile') {
-				connection.write(JSON.stringify(!!project));
+			if (request.type === 'projectInfoForFile') {
+				connection.write(JSON.stringify(project
+					? {
+						name: project.info.project.getProjectName(),
+						kind: project.info.project.projectKind,
+					}
+					: undefined
+				));
 			}
 			else if (project) {
 				const requestContext = {

--- a/packages/typescript-plugin/lib/utils.ts
+++ b/packages/typescript-plugin/lib/utils.ts
@@ -59,9 +59,12 @@ export async function searchNamedPipeServerForFile(fileName: string) {
 	for (const server of configuredServers) {
 		const client = await connect(server.path);
 		if (client) {
-			const response = await sendRequestWorker<boolean>({ type: 'containsFile', args: [fileName] }, client);
-			if (response) {
-				return server;
+			const projectInfo = await sendRequestWorker<{ name: string; kind: ts.server.ProjectKind; }>({ type: 'projectInfoForFile', args: [fileName] }, client);
+			if (projectInfo) {
+				return {
+					server,
+					projectInfo,
+				};
 			}
 		}
 	}
@@ -69,7 +72,10 @@ export async function searchNamedPipeServerForFile(fileName: string) {
 		if (!path.relative(server.currentDirectory, fileName).startsWith('..')) {
 			const client = await connect(server.path);
 			if (client) {
-				return server;
+				return {
+					server,
+					projectInfo: undefined,
+				};
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #3959

Even if Hybrid Mode is enabled, the project should still be created based on tsconfig. This is to ensure that the template compiler/codegen can use the `compilerOptions` and `vueCompilerOptions` in tsconfig.

To ensure tsconfig options consistency with the tsconfig path displayed in the status bar, it is necessary to communicate with the tsserver to obtain a matching tsconfig instead of searching in LSP server.