### PR TITLE
feat(vscode): support for disabling typescript plugin

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -224,8 +224,15 @@
 					"default": "auto",
 					"enum": [
 						"auto",
+						"typeScriptPluginOnly",
 						true,
 						false
+					],
+					"enumDescriptions": [
+						"Automatically detect and enable TypeScript Plugin/Hybrid Mode in a safe environment.",
+						"Only enable Vue TypeScript Plugin but disable Hybrid Mode.",
+						"Enable TypeScript Plugin/Hybrid Mode.",
+						"Disable TypeScript Plugin/Hybrid Mode."
 					],
 					"description": "Vue language server only handles CSS and HTML language support, and tsserver takes over TS language support via TS plugin."
 				},

--- a/extensions/vscode/src/config.ts
+++ b/extensions/vscode/src/config.ts
@@ -16,7 +16,7 @@ export const config = {
 		return _config().get('doctor')!;
 	},
 	get server(): Readonly<{
-		hybridMode: 'auto' | boolean;
+		hybridMode: 'auto' | 'typeScriptPluginOnly' | boolean;
 		maxOldSpaceSize: number;
 		maxFileSize: number;
 		diagnosticModel: 'push' | 'pull';

--- a/extensions/vscode/src/nodeClientMain.ts
+++ b/extensions/vscode/src/nodeClientMain.ts
@@ -3,7 +3,7 @@ import * as serverLib from '@vue/language-server';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as lsp from '@volar/vscode/node';
-import { activate as commonActivate, deactivate as commonDeactivate, currentHybridModeStatus } from './common';
+import { activate as commonActivate, deactivate as commonDeactivate, enabledHybridMode, enabledTypeScriptPlugin } from './common';
 import { config } from './config';
 import { middleware } from './middleware';
 
@@ -140,7 +140,13 @@ try {
 			// @ts-expect-error
 			let text = readFileSync(...args) as string;
 
-			if (!currentHybridModeStatus) {
+			if (!enabledTypeScriptPlugin) {
+				text = text.replace(
+					'for(const e of n.contributes.typescriptServerPlugins',
+					s => s + `.filter(p=>p.name!=='typescript-vue-plugin-bundle')`
+				);
+			}
+			else if (!enabledHybridMode) {
 				// patch readPlugins
 				text = text.replace(
 					'languages:Array.isArray(e.languages)',


### PR DESCRIPTION
## Changes

When Hybrid Mode is explicitly or automatically disabled, `@vue/typescript-plugin` will no longer be effective by default to avoid potential crashes of tsserver.

A new option `"vue.server.hybridMode": "typeScriptPluginOnly"` is introduced, to address which allows users to still enable `@vue/typescript-plugin` when Hybrid Mode is disabled.

For explanations of all states, please refer to:

https://github.com/vuejs/language-tools/pull/4226/files#diff-288f1ebddf6afc6081e2ca910029e86e55c9cd7871b425c2a97a82a2cd77ac9eR231-R236