### PR TITLE
📝 correct location string in tsserver plugin initializationOptions

### DIFF
--- a/packages/typescript-plugin/README.md
+++ b/packages/typescript-plugin/README.md
@@ -11,7 +11,7 @@ The LSP client must be configured to explicitly enable this plug-in. This is don
     "plugins": [
         {
           "name": "@vue/typescript-plugin",
-          "location": "/usr/local/lib/node_modules/@vue/language-server",
+          "location": "/usr/local/lib/node_modules/@vue/typescript-plugin",
           "languages": ["vue"],
         },
     ],


### PR DESCRIPTION
This broke during the revert in https://github.com/vuejs/language-tools/commit/1f543969c31c23a44bdfae0a7d57c99cdfce0a2b.