### PR TITLE
fix(tsc): improve regexp performance for global type removal

### DIFF
--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -1,6 +1,5 @@
 import { runTsc } from '@volar/typescript/lib/quickstart/runTsc';
 import * as vue from '@vue/language-core';
-import * as path from 'path';
 
 const windowsPathReg = /\\/g;
 
@@ -23,13 +22,7 @@ export function run() {
 			) {
 				const writeFile = options.host!.writeFile.bind(options.host);
 				options.host!.writeFile = (fileName, contents, ...args) => {
-					if (!vueLanguagePlugin.pluginContext.globalTypesHolder) {
-						return writeFile(fileName, contents, ...args);
-					}
-
-					const writeFileName = path.basename(vueLanguagePlugin.getCanonicalFileName(fileName));
-					const globalTypesFileName = path.basename(vueLanguagePlugin.getCanonicalFileName(vueLanguagePlugin.pluginContext.globalTypesHolder));
-					return writeFile(fileName, writeFileName.startsWith(globalTypesFileName) ? removeEmitGlobalTypes(contents) : contents, ...args);
+				   return writeFile(fileName, removeEmitGlobalTypes(contents), ...args);
 				};
 				const vueLanguagePlugin = vue.createVueLanguagePlugin(
 					ts,
@@ -65,7 +58,7 @@ export function run() {
 	}
 }
 
-const removeEmitGlobalTypesRegexp = /[^\n]*__VLS_globalTypesStart[\w\W]*__VLS_globalTypesEnd[^\n]*\n/g;
+const removeEmitGlobalTypesRegexp = /^[^\n]*__VLS_globalTypesStart[\w\W]*__VLS_globalTypesEnd[^\n]*\n?$/mg;
 
 export function removeEmitGlobalTypes(dts: string) {
 	return dts.replace(removeEmitGlobalTypesRegexp, '');


### PR DESCRIPTION
The issue with the removal of global types was the RegExp, for certain files written like `.tsbuildinfo` which is a single line long contents file it would scan the whole line scanning for the characters.

By specifying `m` flag it causes `^` and `$` to match the begin/end of each line (not only begin/end of string).

This removes the need for the check of the filename to do the replacement check.