### PR TITLE
fix(language-core): reduce unnecessary props mapping

### DIFF
--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -118,7 +118,7 @@ export function* generateElement(
 	}
 	else {
 		yield `const ${var_functionalComponent} = __VLS_asFunctionalComponent(${var_originalComponent}, new ${var_originalComponent}({`;
-		yield* generateElementProps(options, ctx, node, props, 'navigationOnly');
+		yield* generateElementProps(options, ctx, node, props, false);
 		yield `}))${endOfLine}`;
 	}
 
@@ -146,7 +146,7 @@ export function* generateElement(
 			startTagOffset + tag.length,
 			ctx.codeFeatures.verification,
 			`{`,
-			...generateElementProps(options, ctx, node, props, 'normal', propsFailedExps),
+			...generateElementProps(options, ctx, node, props, true, propsFailedExps),
 			`}`,
 		);
 		yield `, ...__VLS_functionalComponentArgsRest(${var_functionalComponent}))${endOfLine}`;
@@ -154,7 +154,7 @@ export function* generateElement(
 	else {
 		// without strictTemplates, this only for instacne type
 		yield `const ${var_componentInstance} = ${var_functionalComponent}({`;
-		yield* generateElementProps(options, ctx, node, props, 'navigationOnly');
+		yield* generateElementProps(options, ctx, node, props, false);
 		yield `}, ...__VLS_functionalComponentArgsRest(${var_functionalComponent}))${endOfLine}`;
 		// and this for props type-checking
 		yield `({} as (props: __VLS_FunctionalComponentProps<typeof ${var_originalComponent}, typeof ${var_componentInstance}> & Record<string, unknown>) => void)(`;
@@ -163,7 +163,7 @@ export function* generateElement(
 			startTagOffset + tag.length,
 			ctx.codeFeatures.verification,
 			`{`,
-			...generateElementProps(options, ctx, node, props, 'normal', propsFailedExps),
+			...generateElementProps(options, ctx, node, props, true, propsFailedExps),
 			`}`,
 		);
 		yield `)${endOfLine}`;

--- a/packages/language-core/lib/codegen/template/slotOutlet.ts
+++ b/packages/language-core/lib/codegen/template/slotOutlet.ts
@@ -54,7 +54,7 @@ export function* generateSlotOutlet(
 			startTagOffset + node.tag.length,
 			ctx.codeFeatures.verification,
 			`{${newLine}`,
-			...generateElementProps(options, ctx, node, node.props.filter(prop => prop !== nameProp), 'normal'),
+			...generateElementProps(options, ctx, node, node.props.filter(prop => prop !== nameProp), true),
 			`}`,
 		);
 		yield `)${endOfLine}`;
@@ -62,7 +62,7 @@ export function* generateSlotOutlet(
 	}
 	else {
 		yield `var ${varSlot} = {${newLine}`;
-		yield* generateElementProps(options, ctx, node, node.props.filter(prop => prop !== nameProp), 'normal');
+		yield* generateElementProps(options, ctx, node, node.props.filter(prop => prop !== nameProp), true);
 		yield `}${endOfLine}`;
 	}
 


### PR DESCRIPTION
When executing go to definition on component prop, it should jump directly to the prop definition instead of popping up a peek window.

<img width="670" alt="image" src="https://github.com/vuejs/language-tools/assets/16279759/f440a60c-16ec-41bf-bf9e-63347d010a6f">