### PR TITLE
feat: redesign additional extensions, VitePress, PetiteVue support

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -90,10 +90,7 @@
 			{
 				"name": "typescript-vue-plugin-bundle",
 				"enableForWorkspaceTypeScriptVersions": true,
-				"configNamespace": "typescript",
-				"languages": [
-					"vue"
-				]
+				"configNamespace": "typescript"
 			}
 		],
 		"grammars": [
@@ -236,31 +233,19 @@
 					],
 					"description": "Vue language server only handles CSS and HTML language support, and tsserver takes over TS language support via TS plugin."
 				},
+				"vue.server.includeLanguages": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"vue"
+					]
+				},
 				"vue.server.maxFileSize": {
 					"type": "number",
 					"default": 20971520,
 					"description": "Maximum file size for Vue Language Server to load. (default: 20MB)"
-				},
-				"vue.server.petiteVue.supportHtmlFile": {
-					"type": "boolean",
-					"default": false
-				},
-				"vue.server.vitePress.supportMdFile": {
-					"type": "boolean",
-					"default": false
-				},
-				"vue.server.diagnosticModel": {
-					"type": "string",
-					"default": "push",
-					"enum": [
-						"push",
-						"pull"
-					],
-					"enumDescriptions": [
-						"Diagnostic push by language server.",
-						"Diagnostic pull by language client."
-					],
-					"description": "Diagnostic update model."
 				},
 				"vue.server.maxOldSpaceSize": {
 					"type": [
@@ -269,14 +254,6 @@
 					],
 					"default": null,
 					"description": "Set --max-old-space-size option on server process. If you have problem on frequently \"Request textDocument/** failed.\" error, try setting higher memory(MB) on it."
-				},
-				"vue.server.additionalExtensions": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					},
-					"default": [],
-					"description": "List any additional file extensions that should be processed as Vue files (requires restart)."
 				},
 				"vue.doctor.status": {
 					"type": "boolean",
@@ -290,6 +267,9 @@
 				},
 				"vue.splitEditors.layout.left": {
 					"type": "array",
+					"items": {
+						"type": "string"
+					},
 					"default": [
 						"script",
 						"scriptSetup",
@@ -298,6 +278,9 @@
 				},
 				"vue.splitEditors.layout.right": {
 					"type": "array",
+					"items": {
+						"type": "string"
+					},
 					"default": [
 						"template",
 						"customBlocks"

--- a/extensions/vscode/src/config.ts
+++ b/extensions/vscode/src/config.ts
@@ -16,17 +16,10 @@ export const config = {
 		return _config().get('doctor')!;
 	},
 	get server(): Readonly<{
+		includeLanguages: string[];
 		hybridMode: 'auto' | 'typeScriptPluginOnly' | boolean;
 		maxOldSpaceSize: number;
 		maxFileSize: number;
-		diagnosticModel: 'push' | 'pull';
-		additionalExtensions: string[];
-		vitePress: {
-			supportMdFile: boolean;
-		};
-		petiteVue: {
-			supportHtmlFile: boolean;
-		};
 	}> {
 		return _config().get('server')!;
 	},

--- a/extensions/vscode/src/features/doctor.ts
+++ b/extensions/vscode/src/features/doctor.ts
@@ -231,9 +231,20 @@ export async function register(context: vscode.ExtensionContext, client: BaseLan
 			});
 		}
 
-		// check outdated vue language plugins
-		// check node_modules has more than one vue versions
-		// check ESLint, Prettier...
+		if (
+			vscode.workspace.getConfiguration('vue').has('server.additionalExtensions')
+			|| vscode.workspace.getConfiguration('vue').has('server.petiteVue.supportHtmlFile')
+			|| vscode.workspace.getConfiguration('vue').has('server.vitePress.supportMdFile')
+		) {
+			problems.push({
+				title: 'Deprecated configuration',
+				message: [
+					'`vue.server.additionalExtensions`, `vue.server.petiteVue.supportHtmlFile`, and `vue.server.vitePress.supportMdFile` are deprecated. Please remove them from your settings.',
+					'',
+					'- PR: https://github.com/vuejs/language-tools/pull/4321',
+				].join('\n'),
+			});
+		}
 
 		return problems;
 	}

--- a/extensions/vscode/src/features/nameCasing.ts
+++ b/extensions/vscode/src/features/nameCasing.ts
@@ -136,11 +136,7 @@ export async function activate(_context: vscode.ExtensionContext, client: BaseLa
 	}
 
 	async function update(document: vscode.TextDocument | undefined) {
-		if (
-			document?.languageId === 'vue'
-			|| (config.server.vitePress.supportMdFile && document?.languageId === 'markdown')
-			|| (config.server.petiteVue.supportHtmlFile && document?.languageId === 'html')
-		) {
+		if (document && vscode.languages.match(selector, document)) {
 			let detected: Awaited<ReturnType<typeof detect>> | undefined;
 			let attrNameCasing = attrNameCasings.get(document.uri.toString());
 			let tagNameCasing = tagNameCasings.get(document.uri.toString());

--- a/extensions/vscode/src/nodeClientMain.ts
+++ b/extensions/vscode/src/nodeClientMain.ts
@@ -35,7 +35,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			runOptions.execArgv.push("--max-old-space-size=" + config.server.maxOldSpaceSize);
 		}
 		const debugOptions: lsp.ForkOptions = { execArgv: ['--nolazy', '--inspect=' + port] };
-		let serverOptions: lsp.ServerOptions = {
+		const serverOptions: lsp.ServerOptions = {
 			run: {
 				module: serverModule.fsPath,
 				transport: lsp.TransportKind.ipc,
@@ -55,7 +55,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				isTrusted: true,
 				supportHtml: true,
 			},
-			outputChannel
+			outputChannel,
 		};
 		const client = new _LanguageClient(
 			id,
@@ -145,18 +145,17 @@ try {
 					s => s + `.filter(p=>p.name!=='typescript-vue-plugin-bundle')`
 				);
 			}
-			else if (!enabledHybridMode) {
+			else if (enabledHybridMode) {
 				// patch readPlugins
 				text = text.replace(
 					'languages:Array.isArray(e.languages)',
 					[
 						'languages:',
-						`e.name==='typescript-vue-plugin-bundle'?[]:`,
-						'Array.isArray(e.languages)',
+						`e.name==='typescript-vue-plugin-bundle'?[${config.server.includeLanguages.map(lang => `"${lang}"`).join(',')}]`,
+						':Array.isArray(e.languages)',
 					].join(''),
 				);
-			}
-			else {
+
 				// VSCode < 1.87.0
 				text = text.replace('t.$u=[t.$r,t.$s,t.$p,t.$q]', s => s + '.concat("vue")'); // patch jsTsLanguageModes
 				text = text.replace('.languages.match([t.$p,t.$q,t.$r,t.$s]', s => s + '.concat("vue")'); // patch isSupportedLanguageMode

--- a/packages/component-meta/lib/base.ts
+++ b/packages/component-meta/lib/base.ts
@@ -92,6 +92,12 @@ function createCheckerWorker(
 			if (parsedCommandLine.vueOptions.extensions.some(ext => fileName.endsWith(ext))) {
 				return 'vue';
 			}
+			if (parsedCommandLine.vueOptions.vitePressExtensions.some(ext => fileName.endsWith(ext))) {
+				return 'markdown';
+			}
+			if (parsedCommandLine.vueOptions.petiteVueExtensions.some(ext => fileName.endsWith(ext))) {
+				return 'html';
+			}
 			return vue.resolveCommonLanguageId(fileName);
 		},
 		scriptIdToFileName: id => id,

--- a/packages/language-core/lib/plugins.ts
+++ b/packages/language-core/lib/plugins.ts
@@ -1,6 +1,3 @@
-import useHtmlFilePlugin from './plugins/file-html';
-import useMdFilePlugin from './plugins/file-md';
-import useVueFilePlugin from './plugins/file-vue';
 import useVueSfcCustomBlocks from './plugins/vue-sfc-customblocks';
 import useVueSfcScriptsFormat from './plugins/vue-sfc-scripts';
 import useVueSfcStyles from './plugins/vue-sfc-styles';
@@ -11,12 +8,9 @@ import useVueTemplateInlineTsPlugin from './plugins/vue-template-inline-ts';
 import useVueTsx from './plugins/vue-tsx';
 import { pluginVersion, type VueLanguagePlugin } from './types';
 
-export function getDefaultVueLanguagePlugins(pluginContext: Parameters<VueLanguagePlugin>[0]) {
+export function getBasePlugins(pluginContext: Parameters<VueLanguagePlugin>[0]) {
 
 	const plugins: VueLanguagePlugin[] = [
-		useMdFilePlugin, // .md for VitePress
-		useHtmlFilePlugin, // .html for PetiteVue
-		useVueFilePlugin, // .vue and others for Vue
 		useVueTemplateHtmlPlugin,
 		useVueTemplateInlineCssPlugin,
 		useVueTemplateInlineTsPlugin,

--- a/packages/language-core/lib/plugins/file-html.ts
+++ b/packages/language-core/lib/plugins/file-html.ts
@@ -12,81 +12,78 @@ const plugin: VueLanguagePlugin = () => {
 
 		parseSFC(fileName, content) {
 
-			if (fileName.endsWith('.html')) {
+			let sfc: SFCParseResult = {
+				descriptor: {
+					filename: fileName,
+					source: content,
+					template: null,
+					script: null,
+					scriptSetup: null,
+					styles: [],
+					customBlocks: [],
+					cssVars: [],
+					shouldForceReload: () => false,
+					slotted: false,
+				},
+				errors: [],
+			};
 
-				let sfc: SFCParseResult = {
-					descriptor: {
-						filename: fileName,
-						source: content,
-						template: null,
-						script: null,
-						scriptSetup: null,
-						styles: [],
-						customBlocks: [],
-						cssVars: [],
-						shouldForceReload: () => false,
-						slotted: false,
-					},
-					errors: [],
-				};
+			let templateContent = content;
 
-				let templateContent = content;
+			for (const match of content.matchAll(sfcBlockReg)) {
 
-				for (const match of content.matchAll(sfcBlockReg)) {
+				const matchText = match[0];
+				const tag = match[1];
+				const attrs = match[2];
+				const lang = attrs.match(langReg)?.[2];
+				const content = match[3];
+				const contentStart = match.index + matchText.indexOf(content);
 
-					const matchText = match[0];
-					const tag = match[1];
-					const attrs = match[2];
-					const lang = attrs.match(langReg)?.[2];
-					const content = match[3];
-					const contentStart = match.index + matchText.indexOf(content);
-
-					if (tag === 'style') {
-						sfc.descriptor.styles.push({
-							attrs: {},
-							content,
-							loc: {
-								start: { column: -1, line: -1, offset: contentStart },
-								end: { column: -1, line: -1, offset: contentStart + content.length },
-								source: content,
-							},
-							type: 'style',
-							lang,
-						});
-					}
-					// ignore `<script src="...">`
-					else if (tag === 'script' && attrs.indexOf('src=') === -1) {
-						let type: 'script' | 'scriptSetup' = attrs.indexOf('type=') >= 0 ? 'scriptSetup' : 'script';
-						sfc.descriptor[type] = {
-							attrs: {},
-							content,
-							loc: {
-								start: { column: -1, line: -1, offset: contentStart },
-								end: { column: -1, line: -1, offset: contentStart + content.length },
-								source: content,
-							},
-							type: 'script',
-							lang,
-						};
-					}
-
-					templateContent = templateContent.substring(0, match.index) + ' '.repeat(matchText.length) + templateContent.substring(match.index + matchText.length);
+				if (tag === 'style') {
+					sfc.descriptor.styles.push({
+						attrs: {},
+						content,
+						loc: {
+							start: { column: -1, line: -1, offset: contentStart },
+							end: { column: -1, line: -1, offset: contentStart + content.length },
+							source: content,
+						},
+						type: 'style',
+						lang,
+					});
+				}
+				// ignore `<script src="...">`
+				else if (tag === 'script' && attrs.indexOf('src=') === -1) {
+					let type: 'script' | 'scriptSetup' = attrs.indexOf('type=') >= 0 ? 'scriptSetup' : 'script';
+					sfc.descriptor[type] = {
+						attrs: {},
+						content,
+						loc: {
+							start: { column: -1, line: -1, offset: contentStart },
+							end: { column: -1, line: -1, offset: contentStart + content.length },
+							source: content,
+						},
+						type: 'script',
+						lang,
+					};
 				}
 
-				sfc.descriptor.template = {
-					attrs: {},
-					content: templateContent,
-					loc: {
-						start: { column: -1, line: -1, offset: 0 },
-						end: { column: -1, line: -1, offset: templateContent.length },
-						source: templateContent,
-					},
-					type: 'template',
-					ast: {} as any,
-				};
+				templateContent = templateContent.substring(0, match.index) + ' '.repeat(matchText.length) + templateContent.substring(match.index + matchText.length);
+			}
 
-				return sfc;
+			sfc.descriptor.template = {
+				attrs: {},
+				content: templateContent,
+				loc: {
+					start: { column: -1, line: -1, offset: 0 },
+					end: { column: -1, line: -1, offset: templateContent.length },
+					source: templateContent,
+				},
+				type: 'template',
+				ast: {} as any,
 			};
+
+			return sfc;
 		}
 	};
 };

--- a/packages/language-core/lib/plugins/file-md.ts
+++ b/packages/language-core/lib/plugins/file-md.ts
@@ -17,67 +17,64 @@ const plugin: VueLanguagePlugin = () => {
 
 		version: 2,
 
-		parseSFC(fileName, content) {
+		parseSFC(_fileName, content) {
 
-			if (fileName.endsWith('.md')) {
+			content = content
+				// code block
+				.replace(codeblockReg, (match, quotes) => quotes + ' '.repeat(match.length - quotes.length * 2) + quotes)
+				// inline code block
+				.replace(inlineCodeblockReg, match => `\`${' '.repeat(match.length - 2)}\``)
+				// # \<script setup>
+				.replace(scriptSetupReg, match => ' '.repeat(match.length))
+				// <<< https://vitepress.dev/guide/markdown#import-code-snippets
+				.replace(codeSnippetImportReg, match => ' '.repeat(match.length));
 
-				content = content
-					// code block
-					.replace(codeblockReg, (match, quotes) => quotes + ' '.repeat(match.length - quotes.length * 2) + quotes)
-					// inline code block
-					.replace(inlineCodeblockReg, match => `\`${' '.repeat(match.length - 2)}\``)
-					// # \<script setup>
-					.replace(scriptSetupReg, match => ' '.repeat(match.length))
-					// <<< https://vitepress.dev/guide/markdown#import-code-snippets
-					.replace(codeSnippetImportReg, match => ' '.repeat(match.length));
+			const codes: Segment[] = [];
 
-				const codes: Segment[] = [];
-
-				for (const match of content.matchAll(sfcBlockReg)) {
-					if (match.index !== undefined) {
-						const matchText = match[0];
-						codes.push([matchText, undefined, match.index]);
-						codes.push('\n\n');
-						content = content.substring(0, match.index) + ' '.repeat(matchText.length) + content.substring(match.index + matchText.length);
-					}
+			for (const match of content.matchAll(sfcBlockReg)) {
+				if (match.index !== undefined) {
+					const matchText = match[0];
+					codes.push([matchText, undefined, match.index]);
+					codes.push('\n\n');
+					content = content.substring(0, match.index) + ' '.repeat(matchText.length) + content.substring(match.index + matchText.length);
 				}
+			}
 
-				content = content
-					// angle bracket: <http://foo.com>
-					.replace(angleBracketReg, match => ' '.repeat(match.length))
-					// [foo](http://foo.com)
-					.replace(linkReg, match => ' '.repeat(match.length));
+			content = content
+				// angle bracket: <http://foo.com>
+				.replace(angleBracketReg, match => ' '.repeat(match.length))
+				// [foo](http://foo.com)
+				.replace(linkReg, match => ' '.repeat(match.length));
 
-				codes.push('<template>\n');
-				codes.push([content, undefined, 0]);
-				codes.push('\n</template>');
+			codes.push('<template>\n');
+			codes.push([content, undefined, 0]);
+			codes.push('\n</template>');
 
-				const file2VueSourceMap = new SourceMap(buildMappings(codes));
-				const sfc = parse(toString(codes));
+			const file2VueSourceMap = new SourceMap(buildMappings(codes));
+			const sfc = parse(toString(codes));
 
-				if (sfc.descriptor.template) {
-					transformRange(sfc.descriptor.template);
-				}
-				if (sfc.descriptor.script) {
-					transformRange(sfc.descriptor.script);
-				}
-				if (sfc.descriptor.scriptSetup) {
-					transformRange(sfc.descriptor.scriptSetup);
-				}
-				for (const style of sfc.descriptor.styles) {
-					transformRange(style);
-				}
-				for (const customBlock of sfc.descriptor.customBlocks) {
-					transformRange(customBlock);
-				}
+			if (sfc.descriptor.template) {
+				transformRange(sfc.descriptor.template);
+			}
+			if (sfc.descriptor.script) {
+				transformRange(sfc.descriptor.script);
+			}
+			if (sfc.descriptor.scriptSetup) {
+				transformRange(sfc.descriptor.scriptSetup);
+			}
+			for (const style of sfc.descriptor.styles) {
+				transformRange(style);
+			}
+			for (const customBlock of sfc.descriptor.customBlocks) {
+				transformRange(customBlock);
+			}
 
-				return sfc;
+			return sfc;
 
-				function transformRange(block: SFCBlock) {
-					block.loc.start.offset = file2VueSourceMap.getSourceOffset(block.loc.start.offset)?.[0] ?? -1;
-					block.loc.end.offset = file2VueSourceMap.getSourceOffset(block.loc.end.offset)?.[0] ?? -1;
-				}
-			};
+			function transformRange(block: SFCBlock) {
+				block.loc.start.offset = file2VueSourceMap.getSourceOffset(block.loc.start.offset)?.[0] ?? -1;
+				block.loc.end.offset = file2VueSourceMap.getSourceOffset(block.loc.end.offset)?.[0] ?? -1;
+			}
 		}
 	};
 };

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -31,6 +31,8 @@ export interface VueCompilerOptions {
 	target: number;
 	lib: string;
 	extensions: string[];
+	vitePressExtensions: string[];
+	petiteVueExtensions: string[];
 	jsxSlots: boolean;
 	strictTemplates: boolean;
 	skipTemplateCodegen: boolean;

--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -36,7 +36,11 @@ export function createParsedCommandLineByJson(
 		{},
 		configFileName,
 		undefined,
-		resolvedVueOptions.extensions.map(extension => ({
+		[
+			...resolvedVueOptions.extensions,
+			...resolvedVueOptions.vitePressExtensions,
+			...resolvedVueOptions.petiteVueExtensions,
+		].map(extension => ({
 			extension: extension.slice(1),
 			isMixedContent: true,
 			scriptKind: ts.ScriptKind.Deferred,
@@ -83,7 +87,11 @@ export function createParsedCommandLine(
 			{},
 			tsConfigPath,
 			undefined,
-			resolvedVueOptions.extensions.map(extension => ({
+			[
+				...resolvedVueOptions.extensions,
+				...resolvedVueOptions.vitePressExtensions,
+				...resolvedVueOptions.petiteVueExtensions,
+			].map(extension => ({
 				extension: extension.slice(1),
 				isMixedContent: true,
 				scriptKind: ts.ScriptKind.Deferred,

--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -207,6 +207,8 @@ export function resolveVueCompilerOptions(vueOptions: Partial<VueCompilerOptions
 		...vueOptions,
 		target,
 		extensions: vueOptions.extensions ?? ['.vue'],
+		vitePressExtensions: vueOptions.vitePressExtensions ?? [],
+		petiteVueExtensions: vueOptions.petiteVueExtensions ?? [],
 		lib,
 		jsxSlots: vueOptions.jsxSlots ?? false,
 		strictTemplates: vueOptions.strictTemplates ?? false,

--- a/packages/language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/language-core/schemas/vue-tsconfig.schema.json
@@ -21,6 +21,16 @@
 					"default": [ ".vue" ],
 					"markdownDescription": "Valid file extensions that should be considered as regular Vue SFC, please note that you should not use this option separately for additional file extensions IDE support, see https://github.com/vuejs/language-tools/tree/master/extensions/vscode/README.md#custom-file-extensions."
 				},
+				"vitePressExtensions": {
+					"type": "array",
+					"default": [ ".md" ],
+					"markdownDescription": "Valid file extensions that should be considered as regular VitePress SFC."
+				},
+				"petiteVueExtensions": {
+					"type": "array",
+					"default": [ ".html" ],
+					"markdownDescription": "Valid file extensions that should be considered as regular PetiteVue SFC."
+				},
 				"lib": {
 					"default": "",
 					"markdownDescription": "Specify module name for import regular types. (If empty, will use `@vue/runtime-dom` for target < 2.7, `vue` for target >= 2.7)"
@@ -38,15 +48,6 @@
 				"skipTemplateCodegen": {
 					"type": "boolean",
 					"markdownDescription": "https://github.com/vuejs/language-tools/issues/577"
-				},
-				"nativeTags": {
-					"type": "array",
-					"default": [
-						"div",
-						"img",
-						"..."
-					],
-					"markdownDescription": "List of valid intrinsic elements."
 				},
 				"dataAttributes": {
 					"type": "array",

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -6,9 +6,5 @@ export type VueInitializationOptions = InitializationOptions & {
 	};
 	vue?: {
 		hybridMode?: boolean;
-		/**
-		 * @example ['vue1', 'vue2']
-		 */
-		additionalExtensions?: string[];
 	};
 };

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -16,9 +16,14 @@ export function run() {
 			const vueOptions = typeof configFilePath === 'string'
 				? vue.createParsedCommandLine(ts, ts.sys, configFilePath.replace(windowsPathReg, '/')).vueOptions
 				: vue.resolveVueCompilerOptions({});
+			const allExtensions = [
+				...vueOptions.extensions,
+				...vueOptions.vitePressExtensions,
+				...vueOptions.petiteVueExtensions,
+			];
 			if (
-				runExtensions.length === vueOptions.extensions.length
-				&& runExtensions.every(ext => vueOptions.extensions.includes(ext))
+				runExtensions.length === allExtensions.length
+				&& runExtensions.every(ext => allExtensions.includes(ext))
 			) {
 				const writeFile = options.host!.writeFile.bind(options.host);
 				options.host!.writeFile = (fileName, contents, ...args) => {
@@ -36,11 +41,7 @@ export function run() {
 				return [vueLanguagePlugin];
 			}
 			else {
-				runExtensions = [
-					...vueOptions.extensions,
-					...vueOptions.vitePressExtensions,
-					...vueOptions.petiteVueExtensions,
-				];
+				runExtensions = allExtensions;
 				throw extensionsChangedException;
 			}
 		},

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -36,7 +36,11 @@ export function run() {
 				return [vueLanguagePlugin];
 			}
 			else {
-				runExtensions = vueOptions.extensions;
+				runExtensions = [
+					...vueOptions.extensions,
+					...vueOptions.vitePressExtensions,
+					...vueOptions.petiteVueExtensions,
+				];
 				throw extensionsChangedException;
 			}
 		},

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -25,13 +25,12 @@ describe('vue-tsc-dts', () => {
 		options: compilerOptions
 	};
 
-	let vueExts: string[] = [];
+	let vueOptions: vue.VueCompilerOptions;
 	const createProgram = proxyCreateProgram(ts, ts.createProgram, (ts, options) => {
 		const { configFilePath } = options.options;
-		const vueOptions = typeof configFilePath === 'string'
+		vueOptions = typeof configFilePath === 'string'
 			? vue.createParsedCommandLine(ts, ts.sys, configFilePath.replace(windowsPathReg, '/')).vueOptions
 			: vue.resolveVueCompilerOptions({ extensions: ['.vue', '.cext'] });
-		vueExts = vueOptions.extensions;
 		const vueLanguagePlugin = vue.createVueLanguagePlugin(
 			ts,
 			id => id,
@@ -43,8 +42,14 @@ describe('vue-tsc-dts', () => {
 		);
 		return [vueLanguagePlugin];
 	}, fileName => {
-		if (vueExts.some(ext => fileName.endsWith(ext))) {
+		if (vueOptions.extensions.some(ext => fileName.endsWith(ext))) {
 			return 'vue';
+		}
+		if (vueOptions.vitePressExtensions.some(ext => fileName.endsWith(ext))) {
+			return 'markdown';
+		}
+		if (vueOptions.petiteVueExtensions.some(ext => fileName.endsWith(ext))) {
+			return 'html';
 		}
 		return vue.resolveCommonLanguageId(fileName);
 	});

--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -1,7 +1,7 @@
 import { decorateLanguageService } from '@volar/typescript/lib/node/decorateLanguageService';
 import { decorateLanguageServiceHost, searchExternalFiles } from '@volar/typescript/lib/node/decorateLanguageServiceHost';
 import * as vue from '@vue/language-core';
-import { createLanguage, resolveCommonLanguageId } from '@vue/language-core';
+import { createLanguage } from '@vue/language-core';
 import type * as ts from 'typescript';
 import { decorateLanguageServiceForVue } from './lib/common';
 import { startNamedPipeServer, projects } from './lib/server';
@@ -38,19 +38,14 @@ function createLanguageServicePlugin(): ts.server.PluginModuleFactory {
 					);
 					const extensions = languagePlugin.typescript?.extraFileExtensions.map(ext => '.' + ext.extension) ?? [];
 					const getScriptSnapshot = info.languageServiceHost.getScriptSnapshot.bind(info.languageServiceHost);
-					const getLanguageId = (fileName: string) => {
-						if (extensions.some(ext => fileName.endsWith(ext))) {
-							return 'vue';
-						}
-						return resolveCommonLanguageId(fileName);
-					};
 					const language = createLanguage(
 						[languagePlugin],
 						ts.sys.useCaseSensitiveFileNames,
 						fileName => {
 							const snapshot = getScriptSnapshot(fileName);
 							if (snapshot) {
-								language.scripts.set(fileName, getLanguageId(fileName), snapshot);
+								// @ts-expect-error
+								language.scripts.set(fileName, undefined, snapshot);
 							}
 							else {
 								language.scripts.delete(fileName);

--- a/packages/typescript-plugin/lib/common.ts
+++ b/packages/typescript-plugin/lib/common.ts
@@ -29,9 +29,9 @@ export function decorateLanguageServiceForVue(
 			for (const item of result.entries) {
 				if (item.source) {
 					const originalName = item.name;
-					for (const ext of vueOptions.extensions) {
-						const suffix = capitalize(ext.substring('.'.length)); // .vue -> Vue
-						if (item.source.endsWith(ext) && item.name.endsWith(suffix)) {
+					for (const vueExt of vueOptions.extensions) {
+						const suffix = capitalize(vueExt.slice(1)); // .vue -> Vue
+						if (item.source.endsWith(vueExt) && item.name.endsWith(suffix)) {
 							item.name = capitalize(item.name.slice(0, -suffix.length));
 							if (item.insertText) {
 								// #2286
@@ -40,7 +40,7 @@ export function decorateLanguageServiceForVue(
 							if (item.data) {
 								// @ts-expect-error
 								item.data.__isComponentAutoImport = {
-									ext,
+									ext: vueExt,
 									suffix,
 									originalName,
 									newName: item.insertText,


### PR DESCRIPTION
Fixes #4251

## Motivation

In the past, the behavior of configuring additional extensions, VitePress and PetiteVue was inconsistent between IDEs and `vue-tsc` is inconsistent.

For example, when `"vue.server.additionalExtensions": ["nvue"]` is configured, but `vueCompilerOptions` is set to default:

- `.nvue` files become project files for the Vue language server.
- `.nvue` files do not become project files for `vue-tsc`.
- The Vue language server can monitor `.nvue` files.

When `vueCompilerOptions: { "extensions": [".vue", ".nvue"] }` is configured, but `vue.server.additionalExtensions` is set to default:

- `.nvue` files become project files for the Vue language server.
- `.nvue` files become project files for `vue-tsc`.
- The Vue language server cannot monitor `.nvue` files.

This PR is to address this inconsistency. `vue.server.additionalExtensions` is actually not needed, and we can achieve the above 3 points by only configuring `vueCompilerOptions: { "extensions": [".vue", ".nvue"] }`.

## Changes

- Removed editor settings:
	- `vue.server.additionalExtensions`
	- `vue.server.petiteVue.supportHtmlFile`
	- `vue.server.vitePress.supportMdFile`
- Added editor setting:
	- `vue.server.includeLanguages`
- Added `vueCompilerOptions`:
	- `vitePressExtensions`
	- `petiteVueExtensions`

## Usage

### Additional Extensions Support

Using `.nvue` extension in uni-app as an example.

1. Add `.nvue` to the tsconfig/jsconfig include option:
	 ```diff
	 // tsconfig.json/jsconfig.json
	 {
		 "include": [
			 "src/**/*.ts",
			 "src/**/*.vue",
	 +    "src/**/*.nvue",
		 ],
	 }
	 ```
2. Add `.nvue` to the tsconfig/jsconfig `vueCompilerOptions.extensions` option:
	 ```diff
	 // tsconfig.json/jsconfig.json
	 {
		 "include": [
			 "src/**/*.ts",
			 "src/**/*.vue",
			 "src/**/*.nvue",
		 ],
		 "vueCompilerOptions": {
	 +    "extensions": [".vue", ".nvue"],
		 },
	 }
	 ```
3. For VSCode support, add `.nvue` to the VSCode `files.associations` setting:
	 ```diff
	 // .vscode/settings.json
	 {
		 "files.associations": {
	 +    "*.nvue": "vue"
		 },
	 }
	 ```

### VitePress Support

1. Add `.md` to the tsconfig/jsconfig include option:
	 ```diff
	 // tsconfig.json/jsconfig.json
	 {
		 "include": [
			 "src/**/*.ts",
			 "src/**/*.vue",
	 +    "src/**/*.md",
		 ],
	 }
	 ```
2. Add `.md` to the tsconfig/jsconfig `vueCompilerOptions.vitePressExtensions` option:
	 ```diff
	 // tsconfig.json/jsconfig.json
	 {
		 "include": [
			 "src/**/*.ts",
			 "src/**/*.vue",
			 "src/**/*.md",
		 ],
		 "vueCompilerOptions": {
	 +    "vitePressExtensions": [".md"],
		 },
	 }
	 ```
3. For VSCode support, add `markdown` to the VSCode `vue.server.includeLanguages` setting:
	 ```diff
	 // .vscode/settings.json
	 {
		 "vue.server.includeLanguages": [
			 "vue",
	 +    "markdown",
		 ],
	 }
	 ```

### PetiteVue Support

1. Add `.html` to the tsconfig/jsconfig include option:
	 ```diff
	 // tsconfig.json/jsconfig.json
	 {
		 "include": [
			 "src/**/*.ts",
			 "src/**/*.vue",
	 +    "src/**/*.html",
		 ],
	 }
	 ```
2. Add `.html` to the tsconfig/jsconfig `vueCompilerOptions.petiteVueExtensions` option:
	 ```diff
	 // tsconfig.json/jsconfig.json
	 {
		 "include": [
			 "src/**/*.ts",
			 "src/**/*.vue",
			 "src/**/*.html",
		 ],
		 "vueCompilerOptions": {
	 +    "petiteVueExtensions": [".html"],
		 },
	 }
	 ```
3. For VSCode support, add `html` to the VSCode `vue.server.includeLanguages` setting:
	 ```diff
	 // .vscode/settings.json
	 {
		 "vue.server.includeLanguages": [
			 "vue",
	 +    "html",
		 ],
	 }
	 ```

## Notes

Vue language server is currently unable to watch additional extensions, we need to wait for the next release of `@volar/language-server` to expose the API for dynamically registering file watchers.