### PR TITLE
fix(language-core): correct logic for defineSlots destructuring

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -163,15 +163,14 @@ function* generateSetupFunction(
 		}
 	}
 	if (scriptSetupRanges.slots.define) {
-		if (!scriptSetupRanges.slots.name) {
-			setupCodeModifies.push([[`const __VLS_slots = `], scriptSetupRanges.slots.define.start, scriptSetupRanges.slots.define.start]);
-		}
-		else if (scriptSetupRanges.slots.isObjectBindingPattern) {
+		if (scriptSetupRanges.slots.isObjectBindingPattern) {
 			setupCodeModifies.push([
 				[`__VLS_slots;\nconst __VLS_slots = `],
 				scriptSetupRanges.slots.define.start,
 				scriptSetupRanges.slots.define.start,
 			]);
+		} else if (!scriptSetupRanges.slots.name) {
+			setupCodeModifies.push([[`const __VLS_slots = `], scriptSetupRanges.slots.define.start, scriptSetupRanges.slots.define.start]);
 		}
 	}
 	if (scriptSetupRanges.emits.define && !scriptSetupRanges.emits.name) {

--- a/test-workspace/tsc/vue3/#4326/main.vue
+++ b/test-workspace/tsc/vue3/#4326/main.vue
@@ -2,10 +2,10 @@
 import { exactType } from 'tsc/shared';
 
 const { bottom } = defineSlots<{
-	bottom: (props: { num: number }) => any[],
-}>()
+	bottom: (props: { num: number; }) => any[],
+}>();
 
 exactType(bottom, {} as (props: {
-    num: number;
-}) => any[])
+	num: number;
+}) => any[]);
 </script>

--- a/test-workspace/tsc/vue3/#4326/main.vue
+++ b/test-workspace/tsc/vue3/#4326/main.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { exactType } from 'tsc/shared';
+
+const { bottom } = defineSlots<{
+	bottom: (props: { num: number }) => any[],
+}>()
+
+exactType(bottom, {} as (props: {
+    num: number;
+}) => any[])
+</script>


### PR DESCRIPTION
## Before:

<img width="841" alt="image" src="https://github.com/vuejs/language-tools/assets/32807958/f006d35b-b4e8-4783-bd61-437c8a8a8d48">

## After: 
```ts
const { bottom } = __VLS_slots; 
const __VLS_slots = defineSlots<{
	bottom: (props: { num: number }) => any[],
}>()
```
