### PR TITLE
Removed possibly redundant duplicate reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 - [Vue Language Features](https://github.com/vuejs/language-tools/tree/master/extensions/vscode) \
 *Vue, Vitepress, petite-vue language support extension for VSCode*
-- [TypeScript Vue Plugin](https://github.com/vuejs/language-tools/tree/master/packages/typescript-plugin) \
-*VSCode extension to support Vue in TS server*
 - [vue-tsc](https://github.com/vuejs/language-tools/tree/master/packages/tsc) \
 *Type-check and dts build command line tool*
 - [vue-component-meta](https://github.com/vuejs/language-tools/tree/master/packages/component-meta) \


### PR DESCRIPTION
Dear Developers and Community,

Sincere gratitude for the magic and work you do...

# Changes

## 1. Removed possibly redundant duplicate reference.

Reason: The identical reference is already stated in the list in:

```md
[`@vue/language-server`](/packages/language-server/) // ...
```

---

Best and kind regards :sparkles: 