### PR TITLE
feat(language-core): proper support for class component

### DIFF
--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -64,7 +64,7 @@ export function* generateScript(options: ScriptCodegenOptions): Generator<Code> 
 		yield* generateSrc(options.sfc.script, options.sfc.script.src);
 	}
 	if (options.sfc.script && options.scriptRanges) {
-		const { exportDefault } = options.scriptRanges;
+		const { exportDefault, classBlockEnd } = options.scriptRanges;
 		const isExportRawObject = exportDefault
 			&& options.sfc.script.content[exportDefault.expression.start] === '{';
 		if (options.sfc.scriptSetup && options.scriptSetupRanges) {
@@ -117,6 +117,11 @@ export function* generateScript(options: ScriptCodegenOptions): Generator<Code> 
 			yield options.vueCompilerOptions.optionsWrapper[1];
 			yield generateSfcBlockSection(options.sfc.script, exportDefault.expression.end, options.sfc.script.content.length, codeFeatures.all);
 		}
+		else if (classBlockEnd !== undefined) {
+			yield generateSfcBlockSection(options.sfc.script, 0, classBlockEnd, codeFeatures.all);
+			yield* generateTemplate(options, ctx, true);
+			yield generateSfcBlockSection(options.sfc.script, classBlockEnd, options.sfc.script.content.length, codeFeatures.all);
+		}
 		else {
 			yield generateSfcBlockSection(options.sfc.script, 0, options.sfc.script.content.length, codeFeatures.all);
 		}
@@ -132,7 +137,7 @@ export function* generateScript(options: ScriptCodegenOptions): Generator<Code> 
 	yield `\ntype __VLS_IntrinsicElementsCompletion = __VLS_IntrinsicElements${endOfLine}`;
 
 	if (!ctx.generatedTemplate) {
-		yield* generateTemplate(options, ctx);
+		yield* generateTemplate(options, ctx, false);
 	}
 
 	if (options.sfc.scriptSetup) {

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -238,7 +238,7 @@ function* generateSetupFunction(
 
 	yield* generateComponentProps(options, ctx, scriptSetup, scriptSetupRanges, definePropMirrors);
 	yield* generateModelEmits(options, scriptSetup, scriptSetupRanges);
-	yield* generateTemplate(options, ctx);
+	yield* generateTemplate(options, ctx, false);
 
 	if (syntax) {
 		if (!options.vueCompilerOptions.skipTemplateCodegen && (options.templateCodegen?.hasSlot || scriptSetupRanges?.slots.define)) {

--- a/packages/language-core/lib/parsers/scriptRanges.ts
+++ b/packages/language-core/lib/parsers/scriptRanges.ts
@@ -14,6 +14,7 @@ export function parseScriptRanges(ts: typeof import('typescript'), ast: ts.Sourc
 		componentsOptionNode: ts.ObjectLiteralExpression | undefined,
 		nameOption: TextRange | undefined,
 	}) | undefined;
+	let classBlockEnd: number | undefined;
 
 	const bindings = hasScriptSetup ? parseBindingRanges(ts, ast) : [];
 
@@ -61,10 +62,19 @@ export function parseScriptRanges(ts: typeof import('typescript'), ast: ts.Sourc
 				};
 			}
 		}
+
+		if (
+			ts.isClassDeclaration(raw)
+			&& raw.modifiers?.some(mod => mod.kind === ts.SyntaxKind.ExportKeyword)
+			&& raw.modifiers?.some(mod => mod.kind === ts.SyntaxKind.DefaultKeyword)
+		) {
+			classBlockEnd = raw.end - 1;
+		}
 	});
 
 	return {
 		exportDefault,
+		classBlockEnd,
 		bindings,
 	};
 

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -56,7 +56,6 @@ export interface VueCompilerOptions {
 	experimentalDefinePropProposal: 'kevinEdition' | 'johnsonEdition' | false;
 	experimentalResolveStyleCssClasses: 'scoped' | 'always' | 'never';
 	experimentalModelPropName: Record<string, Record<string, boolean | Record<string, string> | Record<string, string>[]>>;
-	experimentalUseElementAccessInTemplate: boolean;
 }
 
 export const pluginVersion = 2;

--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -262,6 +262,5 @@ export function resolveVueCompilerOptions(vueOptions: Partial<VueCompilerOptions
 				select: true
 			}
 		},
-		experimentalUseElementAccessInTemplate: vueOptions.experimentalUseElementAccessInTemplate ?? false,
 	};
 }

--- a/packages/language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/language-core/schemas/vue-tsconfig.schema.json
@@ -90,11 +90,6 @@
 					],
 					"markdownDescription": "https://github.com/vuejs/language-tools/issues/1038, https://github.com/vuejs/language-tools/issues/1121"
 				},
-				"experimentalUseElementAccessInTemplate": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "https://github.com/vuejs/language-tools/issues/997"
-				},
 				"experimentalModelPropName": {
 					"type": "object",
 					"default": {

--- a/test-workspace/tsc/vue3/#997/main.vue
+++ b/test-workspace/tsc/vue3/#997/main.vue
@@ -1,0 +1,9 @@
+<template>
+	{{ count }}
+</template>
+
+<script lang="ts">
+export default class Counter {
+	private count = 0
+}
+</script>


### PR DESCRIPTION
Re-fix #997, `vueCompilerOptions.experimentalUseElementAccessInTemplate` is now deprecated.