### PR TITLE
chore: specify `packageManager`

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: latest
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/update-html-data.yml
+++ b/.github/workflows/update-html-data.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"private": true,
+	"packageManager": "pnpm@9.1.0",
 	"scripts": {
 		"build": "tsc -b",
 		"watch": "npm run build && (npm run watch:base & npm run watch:vue)",


### PR DESCRIPTION
Not sure why my local environment always uses pnpm v8 for volar, and it causes pnpm-lock.yaml to be changed.