### PR TITLE
feat(typescript-plugin): add emit JSDoc support

### DIFF
--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -34,6 +34,7 @@ export function* generateComponent(
 	const var_originalComponent = matchImportName ?? ctx.getInternalVariable();
 	const var_functionalComponent = ctx.getInternalVariable();
 	const var_componentInstance = ctx.getInternalVariable();
+	const var_componentEmit = ctx.getInternalVariable();
 	const var_componentEvents = ctx.getInternalVariable();
 	const var_defineComponentCtx = ctx.getInternalVariable();
 	const isComponentTag = node.tag.toLowerCase() === 'component';
@@ -238,7 +239,7 @@ export function* generateComponent(
 	yield* generateVScope(options, ctx, node, props);
 
 	ctx.usedComponentCtxVars.add(componentCtxVar);
-	yield* generateElementEvents(options, ctx, node, var_functionalComponent, var_componentInstance, var_componentEvents, () => usedComponentEventsVar = true);
+	yield* generateElementEvents(options, ctx, node, var_functionalComponent, var_componentInstance, var_componentEmit, var_componentEvents, () => usedComponentEventsVar = true);
 
 	const slotDir = node.props.find(p => p.type === CompilerDOM.NodeTypes.DIRECTIVE && p.name === 'slot') as CompilerDOM.DirectiveNode;
 	if (slotDir) {
@@ -252,7 +253,8 @@ export function* generateComponent(
 		yield `const ${componentCtxVar} = __VLS_pickFunctionalComponentCtx(${var_originalComponent}, ${var_componentInstance})!${endOfLine}`;
 	}
 	if (usedComponentEventsVar) {
-		yield `let ${var_componentEvents}!: __VLS_NormalizeEmits<typeof ${componentCtxVar}.emit>${endOfLine}`;
+		yield `let ${var_componentEmit}!: typeof ${componentCtxVar}.emit${endOfLine}`;
+		yield `let ${var_componentEvents}!: __VLS_NormalizeEmits<typeof ${var_componentEmit}>${endOfLine}`;
 	}
 }
 

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -16,6 +16,7 @@ export function* generateElementEvents(
 	node: CompilerDOM.ElementNode,
 	componentVar: string,
 	componentInstanceVar: string,
+	emitVar: string,
 	eventsVar: string,
 	used: () => void,
 ): Generator<Code> {
@@ -27,7 +28,9 @@ export function* generateElementEvents(
 		) {
 			used();
 			const eventVar = ctx.getInternalVariable();
-			yield `let ${eventVar} = { '${prop.arg.loc.source}': __VLS_pickEvent(`;
+			yield `let ${eventVar} = {${newLine}`;
+			yield `/**__VLS_emit,${emitVar},${prop.arg.loc.source}*/${newLine}`;
+			yield `'${prop.arg.loc.source}': __VLS_pickEvent(`;
 			yield `${eventsVar}['${prop.arg.loc.source}'], `;
 			yield `({} as __VLS_FunctionalComponentProps<typeof ${componentVar}, typeof ${componentInstanceVar}>)`;
 			yield* generateEventArg(options, ctx, prop.arg, true, false);
@@ -59,7 +62,8 @@ export function* generateElementEvents(
 			}
 			yield `: `;
 			yield* generateEventExpression(options, ctx, prop);
-			yield ` }${endOfLine}`;
+			yield newLine;
+			yield `}${endOfLine}`;
 		}
 		else if (
 			prop.type === CompilerDOM.NodeTypes.DIRECTIVE


### PR DESCRIPTION
Close #1894

It is not possible to generate virtual code that can display emit JSDoc. As an alternative, JSDoc is now calculated from the original type through TypeChecker and attach to the hover message via proxy getQuickInfoAtPosition.