### PR TITLE
fix(vscode): partial fix "as"/"instanceof" expressions syntax highlight

### DIFF
--- a/extensions/vscode/syntaxes/vue.tmLanguage.json
+++ b/extensions/vscode/syntaxes/vue.tmLanguage.json
@@ -1071,7 +1071,7 @@
 							"name": "source.ts.embedded.html.vue",
 							"patterns": [
 								{
-									"include": "source.ts"
+									"include": "source.ts#expression"
 								}
 							]
 						}
@@ -1092,7 +1092,7 @@
 							"name": "source.ts.embedded.html.vue",
 							"patterns": [
 								{
-									"include": "source.ts"
+									"include": "source.ts#expression"
 								}
 							]
 						}
@@ -1257,7 +1257,7 @@
 							"name": "source.ts.embedded.html.vue",
 							"patterns": [
 								{
-									"include": "source.ts"
+									"include": "source.ts#expression"
 								}
 							]
 						}

--- a/test-workspace/language-service/syntax/directives.vue
+++ b/test-workspace/language-service/syntax/directives.vue
@@ -1,6 +1,7 @@
 <template>
 	<div @click></div>
 	<div @click="{}"></div>
+	<div @click="log('hello'); log('world');"></div>
 	<div #default></div>
 	<div #default="args"></div>
 	<div #></div>
@@ -15,12 +16,12 @@
 	<div :foo="':foo=123'"></div>
 	<div :foo="[{ bar: []}]"></div>
 	<div .prop="[1, 2]"></div>
-	<div style="width: 100%; height: auto;"></div>
 </template>
 
 <template lang="pug">
 div(@click)
 div(@click="{}")
+div(@click="log('hello'); log('world');")
 div(#default)
 div(#default="args")
 div(#)
@@ -35,7 +36,6 @@ div(v-if="true" v-else-if="true" v-else)
 div(:foo="':foo=123'")
 div(:foo="[{ bar: []}]")
 div(.prop="[1, 2]")
-div(style="width: 100%; height: auto;")
 </template>
 
 <template lang="pug">
@@ -48,6 +48,7 @@ h1#myId(class="text-right") hello
 <template lang="html">
 	<div @click></div>
 	<div @click="{}"></div>
+	<div @click="log('hello'); log('world');"></div>
 	<div #default></div>
 	<div #default="args"></div>
 	<div #></div>
@@ -62,5 +63,4 @@ h1#myId(class="text-right") hello
 	<div :foo="':foo=123'"></div>
 	<div :foo="[{ bar: []}]"></div>
 	<div .prop="[1, 2]"></div>
-	<div style="width: 100%; height: auto;"></div>
 </template>

--- a/test-workspace/language-service/syntax/generic.vue
+++ b/test-workspace/language-service/syntax/generic.vue
@@ -1,0 +1,1 @@
+<script setup generic="T"></script>

--- a/test-workspace/language-service/syntax/inline-style.vue
+++ b/test-workspace/language-service/syntax/inline-style.vue
@@ -1,0 +1,7 @@
+<template>
+	<div style="width: 100%; height: auto;"></div>
+</template>
+
+<template lang="pug">
+div(style="width: 100%; height: auto;")
+</template>

--- a/test-workspace/language-service/syntax/template-expression.vue
+++ b/test-workspace/language-service/syntax/template-expression.vue
@@ -1,0 +1,7 @@
+<template>
+	<div v-if="var as XXX"></div>
+	<div v-if="var instanceof XXX"></div>
+	<div v-if="typeof xxx"></div>
+	<div v-if="typeof XXX"></div>
+	<div v-if="''.toString('xxx')"></div>
+</template>


### PR DESCRIPTION
Partial fix #520.

Before PR:

<img width="383" alt="image" src="https://github.com/vuejs/language-tools/assets/16279759/61664e85-cae9-4672-987c-b69e3ff64450">

After PR:

<img width="402" alt="image" src="https://github.com/vuejs/language-tools/assets/16279759/a355590e-3f4a-49d4-803d-a99a42f9764a">

[An upstream fix](https://github.com/microsoft/TypeScript-TmLanguage/issues/985#issuecomment-2127996567) is ​​still required to fully resolve the issue.