### PR TITLE
fix(language-core): set __VLS_template as an asynchronous function

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -57,7 +57,7 @@ export function* generateScriptSetup(
 			+ `			props: ${ctx.helperTypes.Prettify.name}<typeof __VLS_functionalComponentProps & __VLS_PublicProps> & __VLS_BuiltInPublicProps,${newLine}`
 			+ `			expose(exposed: import('${options.vueCompilerOptions.lib}').ShallowUnwrapRef<${scriptSetupRanges.expose.define ? 'typeof __VLS_exposed' : '{}'}>): void,${newLine}`
 			+ `			attrs: any,${newLine}`
-			+ `			slots: ReturnType<typeof __VLS_template>,${newLine}`
+			+ `			slots: Awaited<ReturnType<typeof __VLS_template>>,${newLine}`
 			+ `			emit: ${emitTypes.join(' & ')},${newLine}`
 			+ `		}${endOfLine}`;
 		yield `	})(),${newLine}`; // __VLS_setup = (async () => {
@@ -253,7 +253,7 @@ function* generateSetupFunction(
 			yield* generateComponent(options, ctx, scriptSetup, scriptSetupRanges);
 			yield endOfLine;
 			yield `${syntax} `;
-			yield `{} as ${ctx.helperTypes.WithTemplateSlots.name}<typeof __VLS_component, ReturnType<typeof __VLS_template>>${endOfLine}`;
+			yield `{} as ${ctx.helperTypes.WithTemplateSlots.name}<typeof __VLS_component, Awaited<ReturnType<typeof __VLS_template>>>${endOfLine}`;
 		}
 		else {
 			yield `${syntax} `;

--- a/packages/language-core/lib/codegen/script/template.ts
+++ b/packages/language-core/lib/codegen/script/template.ts
@@ -17,10 +17,10 @@ export function* generateTemplate(
 
 	if (!options.vueCompilerOptions.skipTemplateCodegen) {
 		if (isClassComponent) {
-			yield `__VLS_template() {${newLine}`;
+			yield `async __VLS_template() {${newLine}`;
 		}
 		else {
-			yield `function __VLS_template() {${newLine}`;
+			yield `async function __VLS_template() {${newLine}`;
 		}
 		const templateCodegenCtx = createTemplateCodegenContext(new Set());
 		yield* generateCtx(options, ctx, isClassComponent);


### PR DESCRIPTION
### `__VLS_template` should be an asynchronous function.
Prevent the compile error:
```text
 'await' expressions are only allowed within async functions and at the top levels of modules.
```
<img width="779" alt="image" src="https://github.com/vuejs/language-tools/assets/32807958/ea5ea937-8af9-4d95-902f-3af798f6bb52">
