### PR TITLE
fix(language-core): use defineEmits calls instead of type infer

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -383,10 +383,10 @@ function* generateModelEmits(
 	scriptSetup: NonNullable<Sfc['scriptSetup']>,
 	scriptSetupRanges: ScriptSetupRanges,
 ): Generator<Code> {
-	yield `let __VLS_modelEmitsType!: {}`;
+	yield `const __VLS_modelEmitsType = `;
 
 	if (scriptSetupRanges.defineProp.length) {
-		yield ` & ReturnType<typeof import('${options.vueCompilerOptions.lib}').defineEmits<{${newLine}`;
+		yield `(await import('${options.vueCompilerOptions.lib}')).defineEmits<{${newLine}`;
 		for (const defineProp of scriptSetupRanges.defineProp) {
 			if (!defineProp.isModel) {
 				continue;
@@ -406,7 +406,9 @@ function* generateModelEmits(
 			}
 			yield `]${endOfLine}`;
 		}
-		yield `}>>`;
+		yield `}>()`;
+	} else {
+		yield `{}`;
 	}
 	yield endOfLine;
 }

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -385,7 +385,7 @@ function* generateModelEmits(
 ): Generator<Code> {
 	yield `const __VLS_modelEmitsType = `;
 
-	if (scriptSetupRanges.defineProp.length) {
+	if (scriptSetupRanges.defineProp.filter(p => p.isModel).length) {
 		yield `(await import('${options.vueCompilerOptions.lib}')).defineEmits<{${newLine}`;
 		for (const defineProp of scriptSetupRanges.defineProp) {
 			if (!defineProp.isModel) {


### PR DESCRIPTION
## It will be a type error when I pass the compiled ts file to twoslash.
<img width="841" alt="image" src="https://github.com/vuejs/language-tools/assets/32807958/9f0ff85f-8583-4bec-8744-4ac3272ab076">
