### PR TITLE
fix(language-core): ignore type error for possible component name

### DIFF
--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -124,7 +124,7 @@ export function* generateComponent(
 			yield* generatePropertyAccess(options, ctx, componentName);
 			yield ` }: `;
 		}
-		yield `typeof __VLS_resolvedLocalAndGlobalComponents)`;
+		yield `typeof __VLS_resolvedLocalAndGlobalComponents)${newLine}`;
 		yield* generatePropertyAccess(
 			options,
 			ctx,

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -117,6 +117,7 @@ export function* generateComponent(
 		yield endOfLine;
 	}
 	else if (!isComponentTag) {
+		yield `// @ts-ignore${newLine}`;
 		yield `const ${var_originalComponent} = ({} as `;
 		for (const componentName of possibleOriginalNames) {
 			yield `'${componentName}' extends keyof typeof __VLS_ctx ? { '${getCanonicalComponentName(node.tag)}': typeof __VLS_ctx`;


### PR DESCRIPTION
Relevant test cases: 
https://github.com/vuejs/language-tools/blob/f3f528adb0247c91ede66ae83c7add0c46db6cec/test-workspace/tsc/vue3/%233374/main.vue#L3

<img width="828" alt="image" src="https://github.com/vuejs/language-tools/assets/32807958/d89e7755-ad11-4de3-b9b4-9eb584ced718">