### PR TITLE
fix(tsc): log catched errors to console

### DIFF
--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -52,6 +52,8 @@ export function run() {
 	} catch (err) {
 		if (err === extensionsChangedException) {
 			main();
+		} else {
+			console.error(err);
 		}
 	}
 }


### PR DESCRIPTION
This prevents that the output of a successful vue-tsc run looks the same like one finished with an unexpected error.