### PR TITLE
fix(typescript-plugin): TS not working in template when tsconfig missing

### DIFF
--- a/packages/component-meta/lib/base.ts
+++ b/packages/component-meta/lib/base.ts
@@ -151,9 +151,14 @@ export function baseCreate(
 	const vueLanguagePlugin = vue.createVueLanguagePlugin<string>(
 		ts,
 		id => id,
-		ts.sys.useCaseSensitiveFileNames,
 		() => projectHost.getProjectVersion?.() ?? '',
-		() => projectHost.getScriptFileNames(),
+		fileName => {
+			const fileMap = new vue.FileMap(ts.sys.useCaseSensitiveFileNames);
+			for (const vueFileName of projectHost.getScriptFileNames()) {
+				fileMap.set(vueFileName, undefined);
+			}
+			return fileMap.has(fileName);
+		},
 		projectHost.getCompilationSettings(),
 		vueCompilerOptions
 	);

--- a/packages/language-server/node.ts
+++ b/packages/language-server/node.ts
@@ -1,6 +1,6 @@
 import type { Connection } from '@volar/language-server';
 import { createConnection, createServer, createTypeScriptProject, loadTsdkByPath } from '@volar/language-server/node';
-import { ParsedCommandLine, VueCompilerOptions, createParsedCommandLine, createVueLanguagePlugin, parse, resolveVueCompilerOptions } from '@vue/language-core';
+import { FileMap, ParsedCommandLine, VueCompilerOptions, createParsedCommandLine, createVueLanguagePlugin, parse, resolveVueCompilerOptions } from '@vue/language-core';
 import { LanguageServiceEnvironment, convertAttrName, convertTagName, createDefaultGetTsPluginClient, detect, getVueLanguageServicePlugins } from '@vue/language-service';
 import * as tsPluginClient from '@vue/typescript-plugin/lib/client';
 import { searchNamedPipeServerForFile } from '@vue/typescript-plugin/lib/utils';
@@ -26,9 +26,14 @@ export const getLanguagePlugins: GetLanguagePlugin<URI> = async ({ serviceEnv, c
 	const vueLanguagePlugin = createVueLanguagePlugin(
 		tsdk.typescript,
 		asFileName,
-		sys?.useCaseSensitiveFileNames ?? false,
 		() => projectHost?.getProjectVersion?.() ?? '',
-		() => projectHost?.getScriptFileNames() ?? [],
+		fileName => {
+			const fileMap = new FileMap(sys?.useCaseSensitiveFileNames ?? false);
+			for (const vueFileName of projectHost?.getScriptFileNames() ?? []) {
+				fileMap.set(vueFileName, undefined);
+			}
+			return fileMap.has(fileName);
+		},
 		commandLine?.options ?? {},
 		vueOptions
 	);

--- a/packages/language-service/tests/utils/format.ts
+++ b/packages/language-service/tests/utils/format.ts
@@ -8,9 +8,8 @@ const resolvedVueOptions = resolveVueCompilerOptions({});
 const vueLanguagePlugin = createVueLanguagePlugin<URI>(
 	ts,
 	() => '',
-	false,
 	() => '',
-	() => [],
+	() => false,
 	{},
 	resolvedVueOptions,
 );

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -32,9 +32,14 @@ export function run() {
 				const vueLanguagePlugin = vue.createVueLanguagePlugin<string>(
 					ts,
 					id => id,
-					options.host?.useCaseSensitiveFileNames?.() ?? false,
 					() => '',
-					() => options.rootNames.map(rootName => rootName.replace(windowsPathReg, '/')),
+					fileName => {
+						const fileMap = new vue.FileMap(options.host?.useCaseSensitiveFileNames?.() ?? false);
+						for (const vueFileName of options.rootNames.map(rootName => rootName.replace(windowsPathReg, '/'))) {
+							fileMap.set(vueFileName, undefined);
+						}
+						return fileMap.has(fileName);
+					},
 					options.options,
 					vueOptions
 				);

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -34,11 +34,16 @@ describe('vue-tsc-dts', () => {
 		const vueLanguagePlugin = vue.createVueLanguagePlugin<string>(
 			ts,
 			id => id,
-			options.host?.useCaseSensitiveFileNames?.() ?? false,
 			() => '',
-			() => options.rootNames.map(rootName => rootName.replace(windowsPathReg, '/')),
+			fileName => {
+				const fileMap = new vue.FileMap(options.host?.useCaseSensitiveFileNames?.() ?? false);
+				for (const vueFileName of options.rootNames.map(rootName => rootName.replace(windowsPathReg, '/'))) {
+					fileMap.set(vueFileName, undefined);
+				}
+				return fileMap.has(fileName);
+			},
 			options.options,
-			vueOptions,
+			vueOptions
 		);
 		return [vueLanguagePlugin];
 	});
@@ -62,7 +67,7 @@ describe('vue-tsc-dts', () => {
 					outputText = text;
 				},
 				undefined,
-				true,
+				true
 			);
 			expect(outputText ? normalizeNewline(outputText) : undefined).toMatchSnapshot();
 		});

--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -11,9 +11,16 @@ const plugin = createLanguageServicePlugin(
 		const languagePlugin = vue.createVueLanguagePlugin<string>(
 			ts,
 			id => id,
-			info.languageServiceHost.useCaseSensitiveFileNames?.() ?? false,
 			() => info.languageServiceHost.getProjectVersion?.() ?? '',
-			() => externalFiles.get(info.project) ?? [],
+			info.project.projectKind === ts.server.ProjectKind.Inferred
+				? () => true
+				: fileName => {
+					const fileMap = new vue.FileMap(info.languageServiceHost.useCaseSensitiveFileNames?.() ?? false);
+					for (const vueFileName of externalFiles.get(info.project) ?? []) {
+						fileMap.set(vueFileName, undefined);
+					}
+					return fileMap.has(fileName);
+				},
 			info.languageServiceHost.getCompilationSettings(),
 			vueOptions
 		);


### PR DESCRIPTION
When the project does not have tsconfig, since global types will never be generated, all types in the template will be any.