### PR TITLE
docs(nvim): add nvim-cmp integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,28 @@ sources = cmp.config.sources({
         return true
       end
 
+      -- If you want to be more accurate and have nvim-treesitter installed, you can check if the cursor is in a start tag
+      -- This would be helpful for the following code
+      -- type ExampleType = '@a' | '@b' | '@c' | '1@c'
+      -- const v: ExampleType = ''
+
+      -- local ts_utils = require('nvim-treesitter.ts_utils')
+      -- local function is_in_start_tag()
+      --   local node = ts_utils.get_node_at_cursor()
+      --   while node do
+      --     if node:type() == 'start_tag' then
+      --       return true
+      --     end
+      --     node = node:parent()
+      --   end
+      --   return false
+      -- end
+      --
+      -- -- If not in start tag, return true
+      -- if not is_in_start_tag() then
+      --   return true
+      -- end
+
       local cursor_before_line = ctx.cursor_before_line
       -- For events
       if cursor_before_line:sub(-1) == '@' then

--- a/README.md
+++ b/README.md
@@ -107,6 +107,32 @@ lspconfig.volar.setup {
 },
 ```
 
+### nvim-cmp integration
+
+Inspired by [this tweet](https://twitter.com/youyuxi/status/1799701740000035136) by Evan You, in neovim you can achieve the same behavior with [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
+
+```lua
+-- To see more information :h cmp-config.sources
+sources = cmp.config.sources({
+  {
+    name = 'nvim_lsp',
+    ---@param entry cmp.Entry
+    ---@param ctx cmp.Context
+    entry_filter = function(entry, ctx)
+      local cursor_before_line = ctx.cursor_before_line
+      -- For events
+      if cursor_before_line:sub(-1) == '@' then
+        return entry.completion_item.label:match('^@')
+      -- For props also exclude events with `:on-` prefix
+      elseif cursor_before_line:sub(-1) == ':' then
+        return entry.completion_item.label:match('^:') and not entry.completion_item.label:match('^:on-')
+      else
+        return true
+      end
+  },
+})
+
+```
 </details>
 
 [mattn/vim-lsp-settings](https://github.com/mattn/vim-lsp-settings) ⚡ \

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ sources = cmp.config.sources({
     ---@param entry cmp.Entry
     ---@param ctx cmp.Context
     entry_filter = function(entry, ctx)
+      -- Check if the buffer type is 'vue'
+      local filetype = vim.bo.filetype
+      if filetype ~= 'vue' then
+        return true
+      end
+
       local cursor_before_line = ctx.cursor_before_line
       -- For events
       if cursor_before_line:sub(-1) == '@' then

--- a/README.md
+++ b/README.md
@@ -132,15 +132,12 @@ sources = cmp.config.sources({
       -- local ts_utils = require('nvim-treesitter.ts_utils')
       -- local function is_in_start_tag()
       --   local node = ts_utils.get_node_at_cursor()
-      --   while node do
-      --     if node:type() == 'start_tag' then
-      --       return true
-      --     end
-      --     node = node:parent()
+      --   if not node then
+      --    return false
       --   end
-      --   return false
+      --   return node:type() == 'start_tag'
       -- end
-      --
+
       -- -- If not in start tag, return true
       -- if not is_in_start_tag() then
       --   return true

--- a/README.md
+++ b/README.md
@@ -109,72 +109,8 @@ lspconfig.volar.setup {
 
 ### nvim-cmp integration
 
-Inspired by [this tweet](https://twitter.com/youyuxi/status/1799701740000035136) by Evan You, in neovim you can achieve the same behavior with [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
+Check out this [discussion](https://github.com/vuejs/language-tools/discussions/4495)
 
-```lua
--- To see more information :h cmp-config.sources
-sources = cmp.config.sources({
-  {
-    name = 'nvim_lsp',
-    ---@param entry cmp.Entry
-    ---@param ctx cmp.Context
-    entry_filter = function(entry, ctx)
-      -- Check if the buffer type is 'vue'
-      if ctx.filetype ~= 'vue' then
-        return true
-      end
-
-      local cursor_before_line = ctx.cursor_before_line
-      -- For events
-      if cursor_before_line:sub(-1) == '@' then
-        return entry.completion_item.label:match('^@')
-      -- For props also exclude events with `:on-` prefix
-      elseif cursor_before_line:sub(-1) == ':' then
-        return entry.completion_item.label:match('^:') and not entry.completion_item.label:match('^:on-')
-      else
-        return true
-      end
-  },
-})
-
-```
-The regex performance is quite good since it only checks the beginning characters. However, this approach can still lead to issues such as a string union.
-
-For example, with this TypeScript type:
-
-```ts
-type EmailAddresses = 'a@b.c' | 'd@e.f'
-
-```
-You will lose the items in nvim-cmp if you only type `@`. To address this, you can add Treesitter to check if the cursor is in a starting tag.
-
-To use a local buffer variable to cache the result of the Treesitter is recommended to avoid performance issues as the function will call for every single entry. Here is an example of how to do it:
-
-```lua
-entry_filter = function(entry, ctx)
-  -- Use a buffer-local variable to cache the result of the Treesitter check
-  local bufnr = ctx.bufnr
-  local cached_is_in_start_tag = vim.b[bufnr]._vue_ts_cached_is_in_start_tag
-  if cached_is_in_start_tag == nil then
-    vim.b[bufnr]._vue_ts_cached_is_in_start_tag = is_in_start_tag()
-  end
-  -- If not in start tag, return true
-  if vim.b[bufnr]._vue_ts_cached_is_in_start_tag == false then
-    return true
-  end
-  -- rest of the code
-end
-
-```
-
-In your cmp configuration, register an event to clear the cache when the menu is closed:
-
-```lua
-cmp.event:on('menu_closed', function()
-  local bufnr = vim.api.nvim_get_current_buf()
-  vim.b[bufnr]._vue_ts_cached_is_in_start_tag = nil
-end)
-```
 </details>
 
 [mattn/vim-lsp-settings](https://github.com/mattn/vim-lsp-settings) ⚡ \

--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ sources = cmp.config.sources({
     ---@param ctx cmp.Context
     entry_filter = function(entry, ctx)
       -- Check if the buffer type is 'vue'
-      local filetype = vim.bo.filetype
-      if filetype ~= 'vue' then
+      if ctx.filetype ~= 'vue' then
         return true
       end
 

--- a/README.md
+++ b/README.md
@@ -124,25 +124,6 @@ sources = cmp.config.sources({
         return true
       end
 
-      -- If you want to be more accurate and have nvim-treesitter installed, you can check if the cursor is in a start tag
-      -- This would be helpful for the following code
-      -- type ExampleType = '@a' | '@b' | '@c' | '1@c'
-      -- const v: ExampleType = ''
-
-      -- local ts_utils = require('nvim-treesitter.ts_utils')
-      -- local function is_in_start_tag()
-      --   local node = ts_utils.get_node_at_cursor()
-      --   if not node then
-      --    return false
-      --   end
-      --   return node:type() == 'start_tag'
-      -- end
-
-      -- -- If not in start tag, return true
-      -- if not is_in_start_tag() then
-      --   return true
-      -- end
-
       local cursor_before_line = ctx.cursor_before_line
       -- For events
       if cursor_before_line:sub(-1) == '@' then
@@ -156,6 +137,43 @@ sources = cmp.config.sources({
   },
 })
 
+```
+The regex performance is quite good since it only checks the beginning characters. However, this approach can still lead to issues such as a string union.
+
+For example, with this TypeScript type:
+
+```ts
+type EmailAddresses = 'a@b.c' | 'd@e.f'
+
+```
+You will lose the items in nvim-cmp if you only type `@`. To address this, you can add Treesitter to check if the cursor is in a starting tag.
+
+To use a local buffer variable to cache the result of the Treesitter is recommended to avoid performance issues as the function will call for every single entry. Here is an example of how to do it:
+
+```lua
+entry_filter = function(entry, ctx)
+  -- Use a buffer-local variable to cache the result of the Treesitter check
+  local bufnr = ctx.bufnr
+  local cached_is_in_start_tag = vim.b[bufnr]._vue_ts_cached_is_in_start_tag
+  if cached_is_in_start_tag == nil then
+    vim.b[bufnr]._vue_ts_cached_is_in_start_tag = is_in_start_tag()
+  end
+  -- If not in start tag, return true
+  if vim.b[bufnr]._vue_ts_cached_is_in_start_tag == false then
+    return true
+  end
+  -- rest of the code
+end
+
+```
+
+In your cmp configuration, register an event to clear the cache when the menu is closed:
+
+```lua
+cmp.event:on('menu_closed', function()
+  local bufnr = vim.api.nvim_get_current_buf()
+  vim.b[bufnr]._vue_ts_cached_is_in_start_tag = nil
+end)
 ```
 </details>
 


### PR DESCRIPTION
Hi 👋

This is a documentation update for neovim user, `nvim-cmp` is a popular neovim plugin used for auto complete code, I know this might be a little bit off topic but I hope this can help some neovim users. 

As mentioned in the content, I was inspired by [this post](https://twitter.com/youyuxi/status/1799701740000035136).

Basically this changes:

![image](https://github.com/vuejs/language-tools/assets/33137074/d5486a58-85ca-431f-b53c-298ed9622e3f)
![image](https://github.com/vuejs/language-tools/assets/33137074/71b65836-e3cb-4970-9ef7-3640f24394d5)

to:

![image](https://github.com/vuejs/language-tools/assets/33137074/13256ddb-1b85-4787-8380-99a5f2f95542)
![image](https://github.com/vuejs/language-tools/assets/33137074/92ade4e7-9839-4ded-ba00-ec7e81905786)
