### PR TITLE
Feature: add feature about custom options to use own tsconfig.json

### DIFF
--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -1,11 +1,14 @@
 import { runTsc } from '@volar/typescript/lib/quickstart/runTsc';
 import * as vue from '@vue/language-core';
+import { createCliOptions } from './options';
 
 const windowsPathReg = /\\/g;
 
 export function run() {
 
 	let runExtensions = ['.vue'];
+
+	const customOptions = createCliOptions();
 
 	const extensionsChangedException = new Error('extensions changed');
 	const main = () => runTsc(
@@ -14,7 +17,7 @@ export function run() {
 		(ts, options) => {
 			const { configFilePath } = options.options;
 			const vueOptions = typeof configFilePath === 'string'
-				? vue.createParsedCommandLine(ts, ts.sys, configFilePath.replace(windowsPathReg, '/')).vueOptions
+				? vue.createParsedCommandLine(ts, ts.sys, (customOptions?.project || configFilePath).replace(windowsPathReg, '/')).vueOptions
 				: vue.resolveVueCompilerOptions({});
 			const allExtensions = [
 				...vueOptions.extensions,

--- a/packages/tsc/options.ts
+++ b/packages/tsc/options.ts
@@ -25,12 +25,11 @@ export function createCliOptions(): CustomOptions | undefined {
 		if (findIndex !== -1 && !!options[findIndex]) {
 			parsedOptions = {
 				...(parsedOptions ?? {}),
-				[options[findIndex]]: arg[i + 1],
+				[options[findIndex]]: args.slice(ARGS_ACCESS_NUM)[findIndex + 1],
 			};
 			// required to remove custom options and value for executing runTsc()
 			process.argv = process.argv.filter((_, j) => j !== i + ARGS_ACCESS_NUM && j !== i + ARGS_ACCESS_NUM + 1);
 		}
-		args.slice(1);
 	});
 	return parsedOptions;
 };

--- a/packages/tsc/options.ts
+++ b/packages/tsc/options.ts
@@ -1,0 +1,36 @@
+interface Options {
+	Project: 'project',
+};
+interface CustomOptions extends Record<Options[keyof Options], string> {};
+
+const ARGS_ACCESS_NUM = 2;
+const OPTIONS = {
+	Project: 'project',
+} as const satisfies Options;
+const OPTIONS_PREFIX = '--';
+
+export function createCliOptions(): CustomOptions | undefined {
+	const args = structuredClone(process.argv);
+	let parsedOptions: CustomOptions | undefined
+	args.slice(ARGS_ACCESS_NUM).forEach((arg, i) => {
+		const options = Object.values(OPTIONS)
+		const optionStrings = options.map(t => `${OPTIONS_PREFIX}${t}`);
+		if (!optionStrings.includes(arg)) {
+			return;
+		}
+		if (args[i + 1] == null) {
+			return;
+		}
+		const findIndex = optionStrings.findIndex(s => s === arg);
+		if (findIndex !== -1 && !!options[findIndex]) {
+			parsedOptions = {
+				...(parsedOptions ?? {}),
+				[options[findIndex]]: arg[i + 1],
+			};
+			// required to remove custom options and value for executing runTsc()
+			process.argv = process.argv.filter((_, j) => j !== i + ARGS_ACCESS_NUM && j !== i + ARGS_ACCESS_NUM + 1);
+		}
+		args.slice(1);
+	});
+	return parsedOptions;
+};


### PR DESCRIPTION
## Abstract
I created pull request about this discussions https://github.com/vuejs/language-tools/discussions/4466

## About Test
- vue file
```index.vue
<script setup lang="ts">
	const a: number = ''
</script>

<template></template>
```
- tsconfig.json
```json
{
	"compilerOptions": {
		"strict": true,
	}
}
```
- command
```sh
./packages/tsc/bin/vue-tsc.js --project ./packages/tsc/playground/tsconfig.json ./packages/tsc/playground/index.vue
```
- logs
![スクリーンショット 2024-06-14 13 50 01](https://github.com/vuejs/language-tools/assets/11657877/fffb1608-48a8-4835-bbfe-bbb5be18f46f)


