### PR TITLE
fix: directive syntax highlighting

### DIFF
--- a/extensions/vscode/syntaxes/vue.tmLanguage.json
+++ b/extensions/vscode/syntaxes/vue.tmLanguage.json
@@ -985,37 +985,48 @@
 			]
 		},
 		"vue-directives-original": {
-			"begin": "(?:\\b(v-)|([:\\.])|(@)|(#))(\\[?)([\\w\\-]*)(\\]?)(?:\\.([\\w\\-]*))*",
+			"begin": "(?:(?:(v-[\\w-]+)(:)?)|([:\\.])|(@)|(#))(?:(?:(\\[)([^\\]]*)(\\]))|([\\w-]+))?(?:(\\.)([\\w-]*))*",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.other.attribute-name.html.vue"
 				},
 				"2": {
-					"name": "punctuation.attribute-shorthand.bind.html.vue"
+					"name": "punctuation.separator.key-value.html.vue"
 				},
 				"3": {
-					"name": "punctuation.attribute-shorthand.event.html.vue"
+					"name": "punctuation.attribute-shorthand.bind.html.vue"
 				},
 				"4": {
-					"name": "punctuation.attribute-shorthand.slot.html.vue"
+					"name": "punctuation.attribute-shorthand.event.html.vue"
 				},
 				"5": {
-					"name": "punctuation.separator.key-value.html.vue"
+					"name": "punctuation.attribute-shorthand.slot.html.vue"
 				},
 				"6": {
-					"name": "entity.other.attribute-name.html.vue"
+					"name": "punctuation.separator.key-value.html.vue"
 				},
 				"7": {
-					"name": "punctuation.separator.key-value.html.vue"
+					"name": "source.ts.embedded.html.vue",
+					"patterns": [
+						{
+							"include": "source.ts#expression"
+						}
+					]
 				},
 				"8": {
-					"name": "entity.other.attribute-name.html.vue"
+					"name": "punctuation.separator.key-value.html.vue"
 				},
 				"9": {
+					"name": "entity.other.attribute-name.html.vue"
+				},
+				"10": {
 					"name": "punctuation.separator.key-value.html.vue"
+				},
+				"11": {
+					"name": "entity.other.attribute-name.html.vue"
 				}
 			},
-			"end": "(?=\\s*+[^=\\s])",
+			"end": "(?=\\s*[^=\\s])",
 			"endCaptures": {
 				"1": {
 					"name": "punctuation.definition.string.end.html.vue"

--- a/extensions/vscode/syntaxes/vue.tmLanguage.json
+++ b/extensions/vscode/syntaxes/vue.tmLanguage.json
@@ -985,7 +985,7 @@
 			]
 		},
 		"vue-directives-original": {
-			"begin": "(?:(?:(v-[\\w-]+)(:)?)|([:\\.])|(@)|(#))(?:(?:(\\[)([^\\]]*)(\\]))|([\\w-]+))?(?:(\\.)([\\w-]*))*",
+			"begin": "(?:(?:(v-[\\w-]+)(:)?)|([:\\.])|(@)|(#))(?:(?:(\\[)([^\\]]*)(\\]))|([\\w-]+))?",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.other.attribute-name.html.vue"
@@ -1018,12 +1018,6 @@
 				},
 				"9": {
 					"name": "entity.other.attribute-name.html.vue"
-				},
-				"10": {
-					"name": "punctuation.separator.key-value.html.vue"
-				},
-				"11": {
-					"name": "entity.other.attribute-name.html.vue"
 				}
 			},
 			"end": "(?=\\s*[^=\\s])",
@@ -1034,6 +1028,15 @@
 			},
 			"name": "meta.attribute.directive.vue",
 			"patterns": [
+			  {
+					"match": "(\\.)([\\w-]*)",
+					"1": {
+						"name": "punctuation.separator.key-value.html.vue"
+					},
+					"2": {
+						"name": "entity.other.attribute-name.html.vue"
+					}
+				},
 				{
 					"include": "#vue-directives-expression"
 				}

--- a/test-workspace/language-service/syntax/directives.vue
+++ b/test-workspace/language-service/syntax/directives.vue
@@ -16,6 +16,13 @@
 	<div :foo="':foo=123'"></div>
 	<div :foo="[{ bar: []}]"></div>
 	<div .prop="[1, 2]"></div>
+	<div v-a:[({a:1}).a]="1"></div>
+	<div v-a:[c]></div>
+	<div v-a:[({a:1}).a].d="[1, 2]"></div>
+	<div @[({a:1}).a].d="[1, 2]" v-d:[2]="3"></div>
+	<div :[1]="value"></div>
+	<div v-bind="{ id: someProp, 'other-attr': otherProp }"></div>
+	<div :xlink:special.d="3"></div>
 </template>
 
 <template lang="pug">

--- a/test-workspace/language-service/syntax/directives.vue
+++ b/test-workspace/language-service/syntax/directives.vue
@@ -23,6 +23,7 @@
 	<div :[1]="value"></div>
 	<div v-bind="{ id: someProp, 'other-attr': otherProp }"></div>
 	<div :xlink:special.d="3"></div>
+	<div v-a.c.d="3"></div>
 </template>
 
 <template lang="pug">


### PR DESCRIPTION
fix #2550.

| Before | After |
| - | - |
| ![image](https://github.com/vuejs/language-tools/assets/63178754/daaf53a6-38e0-4718-9b3f-5606244108cb) | ![image](https://github.com/vuejs/language-tools/assets/63178754/c23d8e19-f53e-4efa-9294-75394e48ba5a) |

About the regex

```txt
(?:(?:(v-[\w-]+)(:)?)|([:\.])|(@)|(#))(?:(?:(\[)([^\]]*)(\]))|([\w-]+))?
                  |                         \
(?:(?:(v-[\w-]+)(:)?)|([:\.])|(@)|(#))   (?:(?:(\[)([^\]]*)(\]))|([\w-]+))?
   v-a                                      <omit>                      Then, modifiers or expression
   v-a:                                     [expr]
   #                                        attr-name
   :
   .
   @
```
