### PR TITLE
feat: better sfc-level tag name completion

### DIFF
--- a/packages/language-service/lib/plugins/vue-sfc.ts
+++ b/packages/language-service/lib/plugins/vue-sfc.ts
@@ -172,6 +172,17 @@ export function create(): LanguageServicePlugin {
 						return result;
 					});
 				},
+
+				async provideCompletionItems(document, position, context, token) {
+					const result = await htmlPluginInstance.provideCompletionItems?.(document, position, context, token)
+					if (!result) return;
+					result.items = [
+						...result.items.filter(item => item.label !== '!DOCTYPE' && item.label !== 'Custom Blocks'),
+						createCompletionItemWithTs(result.items.find(item => item.label === 'script')!),
+						createCompletionItemWithTs(result.items.find(item => item.label === 'script setup')!),
+					]
+					return result;
+				},
 			};
 		},
 	};
@@ -184,4 +195,15 @@ export function create(): LanguageServicePlugin {
 			return callback(virtualCode);
 		}
 	}
+}
+
+function createCompletionItemWithTs(base: vscode.CompletionItem): vscode.CompletionItem {
+	return {
+		...base,
+		label: base.label + ' lang="ts"',
+		textEdit: {
+			...base.textEdit!,
+			newText: base.textEdit!.newText + ' lang="ts"',
+		}
+	};
 }


### PR DESCRIPTION
Typing `lang="ts"` every time when start writing a new SFC is very annoying. This PR adds completion for that.

| **Before** | ![image](https://github.com/vuejs/language-tools/assets/63178754/b29bf79d-d921-4563-9f8d-8e0ce74a6480) |
| -- | -- |
| **After** | ![image](https://github.com/vuejs/language-tools/assets/63178754/1a591b1e-23e9-47aa-b5cb-0745e0f93d80) |


**Improvements**
- Removed `!DOCTYPE` and `Custom Blocks`
- Add `script lang="ts"` and `script setup lang="ts"`

**Notes**
- The description of `script lang="ts"` is the same as `script`, and the description of `script setup lang="ts"` is the same as `script setup`. I am not sure how to update this.
- Exact matching is used in this PR. I don't know if a looser matching method should be used.
- Should the order of the completion items be changed?