### PR TITLE
chore: add 'expected' and 'actually happening' to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,6 +60,18 @@ body:
       placeholder: Steps to reproduce
     validations:
       required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What is expected?
+    validations:
+      required: true
+  - type: textarea
+    id: actually-happening
+    attributes:
+      label: What is actually happening?
+    validations:
+      required: true
   - type: input
     id: reproduction-link
     attributes:


### PR DESCRIPTION
Some issues don't provide enough information on what is expected vs happening.