### PR TITLE
fix(language-core): infer define model type from options type

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -323,15 +323,15 @@ function* generateComponentProps(
 				? `: `
 				: `?: `;
 			if (defineProp.type) {
+				// Infer from defineProp<T>
 				yield scriptSetup.content.substring(defineProp.type.start, defineProp.type.end);
 			}
-			else if (defineProp.name && defineProp.nameIsString) {
-				yield `NonNullable<typeof ${propName}['value']>`;
-			}
-			else if (!defineProp.nameIsString) {
+			else if ((defineProp.name && defineProp.nameIsString) || !defineProp.nameIsString) {
+				// Infer from actual prop declaration code 
 				yield `NonNullable<typeof ${propName}['value']>`;
 			}
 			else if (defineProp.defaultValue) {
+				// Infer from defineProp({default: T})
 				yield `typeof __VLS_defaults['${propName}']`;
 			}
 			else {

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -308,6 +308,8 @@ function* generateComponentProps(
 			if (defineProp.name && defineProp.nameIsString) {
 				// renaming support
 				yield generateSfcBlockSection(scriptSetup, defineProp.name.start, defineProp.name.end, codeFeatures.navigation);
+				propName = scriptSetup.content.substring(defineProp.name.start, defineProp.name.end);
+				propName = propName.replace(/['"]+/g, '');
 			}
 			else if (defineProp.name) {
 				propName = scriptSetup.content.substring(defineProp.name.start, defineProp.name.end);
@@ -322,6 +324,9 @@ function* generateComponentProps(
 				: `?: `;
 			if (defineProp.type) {
 				yield scriptSetup.content.substring(defineProp.type.start, defineProp.type.end);
+			}
+			else if (defineProp.name && defineProp.nameIsString) {
+				yield `NonNullable<typeof ${propName}['value']>`;
 			}
 			else if (!defineProp.nameIsString) {
 				yield `NonNullable<typeof ${propName}['value']>`;

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -322,21 +322,7 @@ function* generateComponentProps(
 			yield defineProp.required
 				? `: `
 				: `?: `;
-			if (defineProp.type) {
-				// Infer from defineProp<T>
-				yield scriptSetup.content.substring(defineProp.type.start, defineProp.type.end);
-			}
-			else if ((defineProp.name && defineProp.nameIsString) || !defineProp.nameIsString) {
-				// Infer from actual prop declaration code 
-				yield `NonNullable<typeof ${propName}['value']>`;
-			}
-			else if (defineProp.defaultValue) {
-				// Infer from defineProp({default: T})
-				yield `typeof __VLS_defaults['${propName}']`;
-			}
-			else {
-				yield `any`;
-			}
+			yield* generateDefinePropType(scriptSetup, propName, defineProp);
 			yield `,${newLine}`;
 
 			if (defineProp.modifierType) {
@@ -387,12 +373,7 @@ function* generateModelEmits(
 				propName = propName.replace(/['"]+/g, '');
 			}
 			yield `'update:${propName}': [${propName}:`;
-			if (defineProp.type) {
-				yield scriptSetup.content.substring(defineProp.type.start, defineProp.type.end);
-			}
-			else {
-				yield `any`;
-			}
+			yield* generateDefinePropType(scriptSetup, propName, defineProp);
 			yield `]${endOfLine}`;
 		}
 		yield `}`;
@@ -403,4 +384,22 @@ function* generateModelEmits(
 		yield `{}`;
 	}
 	yield endOfLine;
+}
+
+function* generateDefinePropType(scriptSetup: NonNullable<Sfc['scriptSetup']>, propName: string, defineProp: ScriptSetupRanges['defineProp'][number]) {
+	if (defineProp.type) {
+		// Infer from defineProp<T>
+		yield scriptSetup.content.substring(defineProp.type.start, defineProp.type.end);
+	}
+	else if ((defineProp.name && defineProp.nameIsString) || !defineProp.nameIsString) {
+		// Infer from actual prop declaration code 
+		yield `NonNullable<typeof ${propName}['value']>`;
+	}
+	else if (defineProp.defaultValue) {
+		// Infer from defineProp({default: T})
+		yield `typeof __VLS_defaults['${propName}']`;
+	}
+	else {
+		yield `any`;
+	}
 }

--- a/test-workspace/tsc/vue2/tsconfig.json
+++ b/test-workspace/tsc/vue2/tsconfig.json
@@ -19,6 +19,7 @@
 		"../vue3/#3672",
 		"../vue3/#3782",
 		"../vue3/#4327",
+		"../vue3/#4512",
 		"../vue3/components",
 		"../vue3/defineEmits",
 		"../vue3/defineModel",

--- a/test-workspace/tsc/vue3/#4512/main.vue
+++ b/test-workspace/tsc/vue3/#4512/main.vue
@@ -8,6 +8,9 @@
 	<!-- @vue-expect-error -->
 	<Test3 v-model:opened="test"></Test3>
 	<Test3 v-model:opened="test3ok"></Test3>
+
+	<Test1 :opened="true" v-on:update:opened="v => exactType(v, {} as boolean)"></Test1>
+	<Test2 :opened="true" v-on:update:opened="v => exactType(v, {} as boolean)"></Test2>
 </template>
 
 <script setup lang="ts">
@@ -15,6 +18,7 @@ import {ref} from 'vue'
 import Test1 from './test1.vue'
 import Test2 from './test2.vue'
 import Test3 from './test3.vue'
+import { exactType } from '../../shared';
 
 const test3ok = ref({
 	asdf: 1,

--- a/test-workspace/tsc/vue3/#4512/main.vue
+++ b/test-workspace/tsc/vue3/#4512/main.vue
@@ -1,0 +1,23 @@
+<template>
+	<!-- @vue-expect-error -->
+	<Test1 v-model:opened="test"></Test1>
+
+	<!-- @vue-expect-error -->
+	<Test2 v-model:opened="test"></Test2>
+
+	<!-- @vue-expect-error -->
+	<Test3 v-model:opened="test"></Test3>
+	<Test3 v-model:opened="test3ok"></Test3>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+import Test1 from './test1.vue'
+import Test2 from './test2.vue'
+import Test3 from './test3.vue'
+
+const test3ok = ref({
+	asdf: 1,
+})
+const test = ref(0)
+</script>

--- a/test-workspace/tsc/vue3/#4512/test1.vue
+++ b/test-workspace/tsc/vue3/#4512/test1.vue
@@ -1,0 +1,9 @@
+<template>
+	<div>{{ opened }}</div>
+</template>
+
+<script setup lang="ts">
+const opened = defineModel<boolean>('opened', {
+	required: true,
+})
+</script>

--- a/test-workspace/tsc/vue3/#4512/test2.vue
+++ b/test-workspace/tsc/vue3/#4512/test2.vue
@@ -1,0 +1,10 @@
+<template>
+	<div>{{ opened }}</div>
+</template>
+
+<script setup lang="ts">
+const opened = defineModel('opened', {
+	type: Boolean,
+	required: true,
+})
+</script>

--- a/test-workspace/tsc/vue3/#4512/test3.vue
+++ b/test-workspace/tsc/vue3/#4512/test3.vue
@@ -1,0 +1,16 @@
+<template>
+	<div>{{ opened }}</div>
+</template>
+
+<script setup lang="ts">
+import {PropType} from 'vue'
+
+interface O {
+	asdf: number
+}
+
+const opened = defineModel('opened', {
+	type: Object as PropType<O>,
+	required: true,
+})
+</script>


### PR DESCRIPTION
If `T` in `defineModel<T>` is not defined, try to infer from user's code.