### PR TITLE
feat(vscode): add empty pattern to codeblock attributes scope

### DIFF
--- a/extensions/vscode/syntaxes/markdown-vue.json
+++ b/extensions/vscode/syntaxes/markdown-vue.json
@@ -20,7 +20,8 @@
 					"name": "fenced_code.block.language.markdown"
 				},
 				"5": {
-					"name": "fenced_code.block.language.attributes.markdown"
+					"name": "fenced_code.block.language.attributes.markdown",
+					"patterns": []
 				}
 			},
 			"endCaptures": {


### PR DESCRIPTION
Motivation: https://github.com/slidevjs/slidev/pull/1743 needs to inject to `fenced_code.block.language.attributes.markdown` to support highlighting special code block attributes like 
<img src="https://github.com/user-attachments/assets/9966e2b0-634b-4534-996b-3caddb2a4820" width="400" >


Due to https://github.com/microsoft/vscode/issues/221682, grammar can't be injected into scopes without `patterns` and `begin`/`end`. However, only code blocks defined in [VSCode's Markdown grammar file](https://github.com/microsoft/vscode/blob/main/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json) can be overridden by injecting the same code block rules with the desired `patterns: []` into `text.html.markdown` (which has been done in [this commit](https://github.com/slidevjs/slidev/pull/1743/commits/6a20591047fb7f2ddd341e0e5e6c834cce51ff84)), so it seems that the only way to support Vue's code block is adding `patterns: []` to Vue's grammar file.