### PR TITLE
fix: semantic highlight of the end tag of namespaced elements

### DIFF
--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -112,8 +112,8 @@ export function* generateComponent(
 			dynamicTagInfo.astHolder,
 			dynamicTagInfo.offsets[0],
 			ctx.codeFeatures.all,
-			'',
-			''
+			'(',
+			')'
 		);
 		if (dynamicTagInfo.offsets[1] !== undefined) {
 			yield `,`;
@@ -127,8 +127,8 @@ export function* generateComponent(
 					...ctx.codeFeatures.all,
 					completion: false,
 				},
-				'',
-				''
+				'(',
+				')'
 			);
 		}
 		yield `)${endOfLine}`;

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -47,7 +47,7 @@ export function* generateComponent(
 	let props = node.props;
 	let dynamicTagInfo: {
 		exp: string;
-		offset: number;
+		offsets: [number, number | undefined];
 		astHolder: any;
 	} | undefined;
 
@@ -56,7 +56,7 @@ export function* generateComponent(
 			if (prop.type === CompilerDOM.NodeTypes.DIRECTIVE && prop.name === 'bind' && prop.arg?.loc.source === 'is' && prop.exp) {
 				dynamicTagInfo = {
 					exp: prop.exp.loc.source,
-					offset: prop.exp.loc.start.offset,
+					offsets: [prop.exp.loc.start.offset, undefined],
 					astHolder: prop.exp.loc,
 				};
 				props = props.filter(p => p !== prop);
@@ -69,7 +69,7 @@ export function* generateComponent(
 		dynamicTagInfo = {
 			exp: node.tag,
 			astHolder: node.loc,
-			offset: startTagOffset,
+			offsets: [startTagOffset, endTagOffset],
 		};
 	}
 
@@ -104,18 +104,34 @@ export function* generateComponent(
 		yield `]${endOfLine}`;
 	}
 	else if (dynamicTagInfo) {
-		yield `const ${var_originalComponent} = `;
+		yield `const ${var_originalComponent} = (`;
 		yield* generateInterpolation(
 			options,
 			ctx,
 			dynamicTagInfo.exp,
 			dynamicTagInfo.astHolder,
-			dynamicTagInfo.offset,
+			dynamicTagInfo.offsets[0],
 			ctx.codeFeatures.all,
-			'(',
-			')'
+			'',
+			''
 		);
-		yield endOfLine;
+		if (dynamicTagInfo.offsets[1] !== undefined) {
+			yield `,`;
+			yield* generateInterpolation(
+				options,
+				ctx,
+				dynamicTagInfo.exp,
+				dynamicTagInfo.astHolder,
+				dynamicTagInfo.offsets[1],
+				{
+					...ctx.codeFeatures.all,
+					completion: false,
+				},
+				'',
+				''
+			);
+		}
+		yield `)${endOfLine}`;
 	}
 	else if (!isComponentTag) {
 		yield `// @ts-ignore${newLine}`;

--- a/test-workspace/language-service/syntax/namespaced.vue
+++ b/test-workspace/language-service/syntax/namespaced.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Component } from "vue";
+import { defineComponent } from "vue";
+const A = {
+  B: {
+    C: defineComponent({
+      setup() {
+        return () => "";
+      },
+    }),
+  },
+};
+const C: Component & {
+  D: Component;
+} = null!;
+</script>
+
+<template>
+  <A.B.C> {{ A.B.C }} </A.B.C>
+  <A.B.C />
+  <C>
+    <C.D> 222 </C.D>
+    <C.D />
+  </C>
+</template>

--- a/test-workspace/language-service/tsconfig.json
+++ b/test-workspace/language-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../tsconfig.json",
+	"exclude": "../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
 			"__COMPLETE_ROOT__/*": [

--- a/test-workspace/language-service/tsconfig.json
+++ b/test-workspace/language-service/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"exclude": "../tsconfig.json",
+	"extends": "../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
 			"__COMPLETE_ROOT__/*": [


### PR DESCRIPTION
fix #3341

| Previous | Now |
| - | - |
| ![image](https://github.com/user-attachments/assets/e58a37c5-81e4-45a1-a739-038f0472371b) | ![image](https://github.com/user-attachments/assets/2aba4b95-cc31-4a69-b9b2-c381af891e5f) |

The remaining problem is that renaming doesn't work. If you rename `C` in the script block, everything is fine. However, if `C` in `<A.B.C` is renamed to `C123`, it will become `<C123123`; if it's renamed to `D`, an error message "Rename failed to apply edits" will show.
