### PR TITLE
fix: should try casting dynamic slot name into constant

### DIFF
--- a/packages/language-core/lib/codegen/script/globalTypes.ts
+++ b/packages/language-core/lib/codegen/script/globalTypes.ts
@@ -100,6 +100,7 @@ declare global {
 		: false;
 
 	function __VLS_normalizeSlot<S>(s: S): S extends () => infer R ? (props: {}) => R : S;
+	function __VLS_tryAsConstant<const T>(t: T): T;
 
 	/**
 	 * emit

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -444,7 +444,9 @@ function* generateComponentSlot(
 			slotDir.arg.loc.source,
 			slotDir.arg.loc.start.offset,
 			slotDir.arg.isStatic ? ctx.codeFeatures.withoutHighlight : ctx.codeFeatures.all,
-			slotDir.arg.loc
+			slotDir.arg.loc,
+			false,
+			true,
 		);
 		yield ': __VLS_thisSlot';
 	}

--- a/packages/language-core/lib/codegen/template/objectProperty.ts
+++ b/packages/language-core/lib/codegen/template/objectProperty.ts
@@ -15,19 +15,24 @@ export function* generateObjectProperty(
 	features: VueCodeInformation,
 	astHolder?: any,
 	shouldCamelize = false,
-	shouldBeConstant = false,
+	shouldBeConstant = false
 ): Generator<Code> {
 	if (code.startsWith('[') && code.endsWith(']') && astHolder) {
-		yield* generateInterpolation(
-			options,
-			ctx,
-			code.slice(1, -1),
-			astHolder,
-			offset + 1,
-			features,
-			shouldBeConstant ? '[__VLS_tryAsConstant(' : '[',
-			shouldBeConstant ? ')]' : ']',
-		);
+		if (shouldBeConstant) {
+			yield* generateInterpolation(
+				options,
+				ctx,
+				code.slice(1, -1),
+				astHolder,
+				offset + 1,
+				features,
+				'[__VLS_tryAsConstant(',
+				')]',
+			);
+		}
+		else {
+			yield* generateInterpolation(options, ctx, code, astHolder, offset, features, '', '');
+		}
 	}
 	else if (shouldCamelize) {
 		if (variableNameRegex.test(camelize(code))) {

--- a/packages/language-core/lib/codegen/template/objectProperty.ts
+++ b/packages/language-core/lib/codegen/template/objectProperty.ts
@@ -14,10 +14,20 @@ export function* generateObjectProperty(
 	offset: number,
 	features: VueCodeInformation,
 	astHolder?: any,
-	shouldCamelize = false
+	shouldCamelize = false,
+	shouldBeConstant = false,
 ): Generator<Code> {
 	if (code.startsWith('[') && code.endsWith(']') && astHolder) {
-		yield* generateInterpolation(options, ctx, code, astHolder, offset, features, '', '');
+		yield* generateInterpolation(
+			options,
+			ctx,
+			code.slice(1, -1),
+			astHolder,
+			offset + 1,
+			features,
+			shouldBeConstant ? '[__VLS_tryAsConstant(' : '[',
+			shouldBeConstant ? ')]' : ']',
+		);
 	}
 	else if (shouldCamelize) {
 		if (variableNameRegex.test(camelize(code))) {

--- a/test-workspace/tsc/vue3/#4668/child.vue
+++ b/test-workspace/tsc/vue3/#4668/child.vue
@@ -1,0 +1,8 @@
+<template></template>
+
+<script lang="ts" setup>
+defineSlots<{
+  action1: (props: { a: string }) => void
+  action2: (props: { a: string }) => void
+}>()
+</script>

--- a/test-workspace/tsc/vue3/#4668/main.vue
+++ b/test-workspace/tsc/vue3/#4668/main.vue
@@ -1,0 +1,16 @@
+<template>
+  <Child>
+    <template #[`action${n}`]="data">
+      {{ exactType(data.a, {} as string) }}
+    </template>
+    <template #action2="data">
+      {{ exactType(data.a, {} as string) }}
+    </template>
+  </Child>
+</template>
+<script lang="ts" setup>
+import { exactType } from 'tsc/shared'
+import Child from './child.vue'
+
+const n = 1 as const
+</script>


### PR DESCRIPTION
fix #4668.

Introduced a new helper:

```ts
function __VLS_tryAsConstant<const T>(t: T): T;
```

which is used to infer the type of an arbitrary expression like `as const`, but not throwing errors when this can't be done. For example, `("1" + "2") as const` will be an error, but `__VLS_tryAsConstant("1" + "2")` will just be of type `string`.

btw, I think `__VLS_tryAsConstant` can be used in other places to provide more precise type info - but it may cause performance issues.