### PR TITLE
fix(language-service): ignore css rename when use typescript-semanitc rename

### DIFF
--- a/packages/language-service/lib/plugins/css.ts
+++ b/packages/language-service/lib/plugins/css.ts
@@ -9,6 +9,9 @@ export function create(): LanguageServicePlugin {
 			const baseInstance = base.create(context);
 			return {
 				...baseInstance,
+				async provideRenameEdits() {
+					return undefined;
+				},
 				async provideDiagnostics(document, token) {
 					let diagnostics = await baseInstance.provideDiagnostics?.(document, token) ?? [];
 					if (document.languageId === 'postcss') {

--- a/test-workspace/language-service/rename/#4677/input/entry.vue
+++ b/test-workspace/language-service/rename/#4677/input/entry.vue
@@ -1,0 +1,8 @@
+<template>
+	<div class="foo classname"></div>
+</template>
+
+<style scoped>
+  .foo { }
+/* ^^^rename: foo1 */
+</style>

--- a/test-workspace/language-service/rename/#4677/output/entry.vue
+++ b/test-workspace/language-service/rename/#4677/output/entry.vue
@@ -1,0 +1,8 @@
+<template>
+	<div class="foo1 classname"></div>
+</template>
+
+<style scoped>
+  .foo1 { }
+/* ^^^rename: foo1 */
+</style>


### PR DESCRIPTION
fix https://github.com/vuejs/language-tools/issues/4677

When performing a rename, if the rename action is done on the name itself rather than on the . (dot), it triggers both the typescript-semantic and css plugins. However, if the rename is performed on the . (dot),  only the css plugin's rename operation is triggered.

1. When both typescript-semantic and css plugins are triggered:

The typescript-semantic plugin correctly generates the modification based on the TypeScript files generated by Vue.

On the other hand, the css plugin analyzes the CSS block and extracts the range including the . for the rename operation. When we trigger the rename, the content we input does not include the ., but the target range for replacement does include it, leading to a misalignment issue.

```vue

  .foo
// typescript-semantic
->.foo1

// css
      ! This is the leftover content from the TypeScript plugin above
->foo11
  ^^^^
   Generated by the CSS plugin
```

2. When only the css plugin is triggered:

In this case, the input needs to include the entire selector, including the .. However, triggering the rename only for the CSS part does not update the class names in the template area, so the desired effect is not achieved.
