### PR TITLE
fix(language-core): drop duplicate hints on incomplete tag

### DIFF
--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -26,9 +26,10 @@ export function* generateComponent(
 ): Generator<Code> {
 	const startTagOffset = node.loc.start.offset + options.template.content.substring(node.loc.start.offset).indexOf(node.tag);
 	const endTagOffset = !node.isSelfClosing && options.template.lang === 'html' ? node.loc.start.offset + node.loc.source.lastIndexOf(node.tag) : undefined;
-	const tagOffsets = endTagOffset !== undefined
-		? [startTagOffset, endTagOffset]
-		: [startTagOffset];
+	const tagOffsets =
+		endTagOffset !== undefined && endTagOffset > startTagOffset
+			? [startTagOffset, endTagOffset]
+			: [startTagOffset];
 	const propsFailedExps: {
 		node: CompilerDOM.SimpleExpressionNode;
 		prefix: string;


### PR DESCRIPTION
fix #4695 