### PR TITLE
Neovim vls initializer BUG FIX PROPOSAL

### DIFF
--- a/packages/language-server/lib/initialize.ts
+++ b/packages/language-server/lib/initialize.ts
@@ -70,7 +70,11 @@ export function initialize(
 				watchingExtensions.add(ext);
 			}
 			fileWatcher?.then(dispose => dispose.dispose());
-			fileWatcher = server.fileWatcher.watchFiles(['**/*.{' + [...watchingExtensions].join(',') + '}']);
+      if (server.watchFiles) {
+          fileWatcher = server.watchFiles(['**/*.{' + [...watchingExtensions].join(',') + '}']);
+      } else {
+          console.warn("server.watchFiles is not a function");
+      }
 		}
 	}
 }


### PR DESCRIPTION
## BUG: Neovim Usage of vue-language-server

Bug: 
When you attempt to open a vue file using vue-language-server, I get this message and logs:

error message: 
```
Client quit with exit code 1 and signal 0
```

log:
```
[ERROR][2024-08-20 23:11:28] .../vim/lsp/rpc.lua:770	"rpc"	"/Users/{user}/.local/share/nvim/mason/bin/vue-language-server"	"stderr"	"/Users/{user}/.local/share/nvim/mason/packages/vue-language-server/node_modules/@vue/language-server/lib/initialize.js:48\n            fileWatcher = server.watchFiles(['**/*.{' + [...watchingExtensions].join(',') + '}']);\n                                          ^\n\nTypeError: server.watchFiles is not a function\n    at updateFileWatcher (/Users/{user}/.local/share/nvim/mason/packages/vue-language-server/node_modules/@vue/language-server/lib/initialize.js:48:43)\n    at /Users/{user}/.local/share/nvim/mason/packages/vue-language-server/node_modules/@vue/language-server/lib/initialize.js:29:9\n    at createTypeScriptLS (/Users/{user}/.local/share/nvim/mason/packages/vue-language-server/node_modules/@vue/language-server/node_modules/@volar/language-server/lib/project/typescriptProjectLs.js:31:46)\n    at /Users/{user}/.local/share/nvim/mason/packages/vue-language-server/node_modules/@vue/language-server/node_modules/@volar/language-server/lib/project/typescriptProject.js:205:69\n    at async getOrCreateInferredProject (/Users/{user}/.local/share/nvim/mason/packages/vue-language-server/node_modules/@vue/language-server/node_modules/@volar/language-server/lib/project/typescriptProject.js:208:25)\n    at async Object.getLanguageService (/Users/{user}/.local/share/nvim/mason/packages/vue-language-server/node_modules/@vue/language-server/node_modules/@volar/language-server/lib/project/typescriptProject.js:54:29)\n    at async Timeout._onTimeout (/Users/{user}/.local/share/nvim/mason/packages/vue-language-server/node_modules/@vue/language-server/node_modules/@volar/language-server/lib/features/languageFeatures.js:695:42)\n\nNode.js v21.7.3\n"
```

So, the problem seems to be: 
_The server.watchFile function is unrecognized in the initialize.js file_

I don't fully know what this function is doing, but when i made the change I have suggested here where I just allow for that function to be undefined and just throw a warning in response, it works for me no problem. 

I figured I would open up this suggestion and if I am thinking about this incorrectly, happy to have a discussion about it. Thanks! 