### PR TITLE
fix(language-core): fallthrough attributes break component type when root tag type is unknown

### DIFF
--- a/packages/language-core/lib/codegen/script/component.ts
+++ b/packages/language-core/lib/codegen/script/component.ts
@@ -128,10 +128,6 @@ export function* generatePropsOption(
 	const optionExpCodes: Code[] = [];
 	const typeOptionExpCodes: Code[] = [];
 
-	if (inheritAttrs && options.templateCodegen?.inheritedAttrVars.size && !hasEmitsOption) {
-		optionExpCodes.push(`{} as ${ctx.helperTypes.TypePropsToOption.name}<__VLS_PickNotAny<${ctx.helperTypes.OmitIndexSignature.name}<ReturnType<typeof __VLS_template>['attrs']>, {}>>`);
-		typeOptionExpCodes.push(`{} as ReturnType<typeof __VLS_template>['attrs']`);
-	}
 	if (ctx.generatedPropsType) {
 		optionExpCodes.push([
 			`{} as `,
@@ -141,10 +137,21 @@ export function* generatePropsOption(
 		].join(''));
 		typeOptionExpCodes.push(`{} as __VLS_PublicProps`);
 	}
-
 	if (scriptSetupRanges.props.define?.arg) {
 		const { arg } = scriptSetupRanges.props.define;
 		optionExpCodes.push(generateSfcBlockSection(scriptSetup, arg.start, arg.end, codeFeatures.navigation));
+	}
+	if (inheritAttrs && options.templateCodegen?.inheritedAttrVars.size && !hasEmitsOption) {
+		const attrsType = `ReturnType<typeof __VLS_template>['attrs']`;
+		const optionType = `${ctx.helperTypes.TypePropsToOption.name}<__VLS_PickNotAny<${ctx.helperTypes.OmitIndexSignature.name}<${attrsType}>, {}>>`;
+		if (optionExpCodes.length) {
+			optionExpCodes.unshift(`{} as ${optionType}`);
+		}
+		else {
+			// workaround for https://github.com/vuejs/core/pull/7419
+			optionExpCodes.unshift(`{} as keyof ${attrsType} extends never ? never: ${optionType}`);
+		}
+		typeOptionExpCodes.unshift(`{} as ${attrsType}`);
 	}
 
 	const useTypeOption = options.vueCompilerOptions.target >= 3.5 && typeOptionExpCodes.length;

--- a/test-workspace/tsc/passedFixtures/vue3_strictTemplate/inheritAttrs_unknownTag/basic.vue
+++ b/test-workspace/tsc/passedFixtures/vue3_strictTemplate/inheritAttrs_unknownTag/basic.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+declare const child: unknown;
+</script>
+
+<template>
+	<child />
+</template>

--- a/test-workspace/tsc/passedFixtures/vue3_strictTemplate/inheritAttrs_unknownTag/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3_strictTemplate/inheritAttrs_unknownTag/main.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import basic from './basic.vue';
+</script>
+
+<template>
+	<basic />
+</template>


### PR DESCRIPTION
When the root tag type is unknown and the component missing props define, the component type is corrupted. This is actually defineComponent's bug and trying to avoid it on our side.

Related: https://github.com/vuejs/core/pull/7419