### PR TITLE
fix: write globalTypes into `dist` for correct export

### DIFF
--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -51,7 +51,7 @@ export interface ScriptCodegenOptions {
 export function* generateScript(options: ScriptCodegenOptions): Generator<Code, ScriptCodegenContext> {
 	const ctx = createScriptCodegenContext(options);
 
-	yield `/// <reference types="${options.vueCompilerOptions.lib}/__globalTypes_${options.vueCompilerOptions.target}_${options.vueCompilerOptions.strictTemplates}" />${newLine}`;
+	yield `/// <reference types="${options.vueCompilerOptions.lib}/dist/__globalTypes_${options.vueCompilerOptions.target}_${options.vueCompilerOptions.strictTemplates}.d.ts" />${newLine}`;
 
 	if (options.sfc.script?.src) {
 		yield* generateSrc(options.sfc.script, options.sfc.script.src);

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -27,7 +27,7 @@ export function run(tscPath = require.resolve('typescript/lib/tsc')) {
 						: options.host?.getCurrentDirectory() ?? ts.sys.getCurrentDirectory();
 					const libDir = require.resolve(`${vueOptions.lib}/package.json`, { paths: [rootDir] })
 						.slice(0, -'package.json'.length);
-					const globalTypesPath = `${libDir}__globalTypes_${vueOptions.target}_${vueOptions.strictTemplates}.d.ts`;
+					const globalTypesPath = `${libDir}dist/__globalTypes_${vueOptions.target}_${vueOptions.strictTemplates}.d.ts`;
 					const globalTypesContents = vue.generateGlobalTypes(vueOptions.lib, vueOptions.target, vueOptions.strictTemplates);
 					ts.sys.writeFile(globalTypesPath, globalTypesContents);
 				} catch { }

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -37,7 +37,7 @@ describe('vue-tsc-dts', () => {
 				: options.host?.getCurrentDirectory() ?? ts.sys.getCurrentDirectory();
 			const libDir = require.resolve(`${vueOptions.lib}/package.json`, { paths: [rootDir] })
 				.slice(0, -'package.json'.length);
-			const globalTypesPath = `${libDir}__globalTypes_${vueOptions.target}_${vueOptions.strictTemplates}.d.ts`;
+			const globalTypesPath = `${libDir}dist/__globalTypes_${vueOptions.target}_${vueOptions.strictTemplates}.d.ts`;
 			const globalTypesContents = vue.generateGlobalTypes(vueOptions.lib, vueOptions.target, vueOptions.strictTemplates);
 			ts.sys.writeFile(globalTypesPath, globalTypesContents);
 		} catch { }

--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -63,7 +63,7 @@ const plugin: ts.server.PluginModuleFactory = mods => {
 				try {
 					const libDir = require.resolve(`${options.lib}/package.json`, { paths: [proj.getCurrentDirectory()] })
 						.slice(0, -'package.json'.length);
-					const globalTypesPath = `${libDir}__globalTypes_${options.target}_${options.strictTemplates}.d.ts`;
+					const globalTypesPath = `${libDir}dist/__globalTypes_${options.target}_${options.strictTemplates}.d.ts`;
 					const globalTypesContents = vue.generateGlobalTypes(options.lib, options.target, options.strictTemplates);
 					proj.writeFile(globalTypesPath, globalTypesContents);
 				} catch { }


### PR DESCRIPTION
fix #4737, fix #4738, fix #4739

https://github.com/vuejs/core/blob/8c3fdd1a7d4060680f8379fac8848d9f5f6e5620/packages/vue/package.json#L69