### PR TITLE
chore: Add optional "dependencies" textarea to issue template [ci skip]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,6 +48,18 @@ body:
       render: shell
       placeholder: System, Binaries, Browsers
   - type: textarea
+    id: dependencies
+    attributes:
+      label: package.json dependencies
+      description: You may add your list of dependencies here as it helps us to investigate your report.
+      render: json
+      placeholder: ```json
+      {
+      "dependencies": {},
+      "devDependencies": {},
+      }
+      ```
+  - type: textarea
     id: steps-to-reproduce
     attributes:
       label: Steps to reproduce

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,7 +53,8 @@ body:
       label: package.json dependencies
       description: You may add your list of dependencies here as it helps us to investigate your report.
       render: json
-      placeholder: ```json
+      placeholder: |
+      ```json
       {
       "dependencies": {},
       "devDependencies": {},

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,10 +54,10 @@ body:
       description: You may add your list of dependencies here as it helps us to investigate your report.
       render: json
       placeholder: |
-      {
-      "dependencies": {},
-      "devDependencies": {},
-      }
+      \{
+      "dependencies": \{\},
+      "devDependencies": \{\},
+      \}
   - type: textarea
     id: steps-to-reproduce
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,10 +54,10 @@ body:
       description: You may add your list of dependencies here as it helps us to investigate your report.
       render: json
       placeholder: |
-      \{
-      "dependencies": \{\},
-      "devDependencies": \{\},
-      \}
+        {
+          "dependencies": {},
+          "devDependencies": {},
+        }
   - type: textarea
     id: steps-to-reproduce
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,12 +54,10 @@ body:
       description: You may add your list of dependencies here as it helps us to investigate your report.
       render: json
       placeholder: |
-      ```json
       {
       "dependencies": {},
       "devDependencies": {},
       }
-      ```
   - type: textarea
     id: steps-to-reproduce
     attributes:


### PR DESCRIPTION
Many issues are caused by third-party extensions. It might be good to let our users post their list of dependencies. Optional for now (?)