### PR TITLE
fix: Whitelist ms-dynamics-smb.al extension for Vue Hybrid Mode.

### DIFF
--- a/extensions/vscode/src/common.ts
+++ b/extensions/vscode/src/common.ts
@@ -63,6 +63,7 @@ function isExtensionCompatibleWithHybridMode(extension: vscode.Extension<any>) {
 		|| extension.id === 'Divlo.vscode-styled-jsx-languageserver'
 		|| extension.id === 'nrwl.angular-console'
 		|| extension.id === 'ShenQingchuan.vue-vine-extension'
+		|| extension.id === 'ms-dynamics-smb.al'
 	) {
 		return true;
 	}


### PR DESCRIPTION
The Microsoft AL Language Extension for Microsoft Dynamics 365 Business shows up as potentially incompatible when starting VS Code and opening .vue files. These are unrelated to to the AL language plugin. 

Changing hybrid mode to true does not cause any interference with Vue files as far as I can tell. 

![image](https://github.com/user-attachments/assets/5af45cf6-e00c-45ee-85d0-f25665709742)
