### PR TITLE
fix(language-core): avoid using `__typeProps` with runtime props

### DIFF
--- a/packages/language-core/lib/codegen/script/component.ts
+++ b/packages/language-core/lib/codegen/script/component.ts
@@ -158,8 +158,8 @@ export function* generatePropsOption(
 		typeOptionExpCodes.unshift(`{} as ${attrsType}`);
 	}
 
-	const useTypeOption = options.vueCompilerOptions.target >= 3.5 && typeOptionExpCodes.length;
-	const useOption = (!useTypeOption || scriptSetupRanges.props.withDefaults) && optionExpCodes.length;
+	const useTypeOption = typeOptionExpCodes.length && options.vueCompilerOptions.target >= 3.5 && !scriptSetupRanges.props.define?.arg;
+	const useOption = optionExpCodes.length && (!useTypeOption || scriptSetupRanges.props.withDefaults);
 
 	if (useTypeOption) {
 		if (typeOptionExpCodes.length === 1) {

--- a/test-workspace/tsc/passedFixtures/vue3.5/#4799/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3.5/#4799/main.vue
@@ -1,0 +1,13 @@
+<script lang="ts" setup>
+import { exactType } from '../../shared';
+
+defineProps({
+    foo: String
+});
+
+defineModel();
+</script>
+
+<template>
+    {{ exactType(foo, {} as string | undefined) }}
+</template>


### PR DESCRIPTION
fix #4799 