### PR TITLE
fix(language-core): handle `v-for` with `v-once` correctly

### DIFF
--- a/packages/language-core/lib/codegen/template/templateChild.ts
+++ b/packages/language-core/lib/codegen/template/templateChild.ts
@@ -49,6 +49,11 @@ export function* generateTemplateChild(
 
 	const shouldInheritRootNodeAttrs = options.inheritAttrs;
 
+	const cur = node as CompilerDOM.ElementNode | CompilerDOM.IfNode | CompilerDOM.ForNode;
+	if (cur.codegenNode?.type === CompilerDOM.NodeTypes.JS_CACHE_EXPRESSION) {
+		cur.codegenNode = cur.codegenNode.value as any;
+	}
+
 	if (node.type === CompilerDOM.NodeTypes.ROOT) {
 		let prev: CompilerDOM.TemplateChildNode | undefined;
 		if (shouldInheritRootNodeAttrs && node.children.length === 1 && node.children[0].type === CompilerDOM.NodeTypes.ELEMENT) {

--- a/packages/language-core/lib/codegen/template/vFor.ts
+++ b/packages/language-core/lib/codegen/template/vFor.ts
@@ -51,8 +51,7 @@ export function* generateVFor(
 		ctx.addLocalVariable(varName);
 	}
 	let isFragment = true;
-	// children is undefined with v-once (#4827)
-	for (const argument of (node.codegenNode?.children as CompilerDOM.ForRenderListExpression | undefined)?.arguments ?? []) {
+	for (const argument of node.codegenNode?.children.arguments ?? []) {
 		if (
 			argument.type === CompilerDOM.NodeTypes.JS_FUNCTION_EXPRESSION
 			&& argument.returns?.type === CompilerDOM.NodeTypes.VNODE_CALL

--- a/packages/language-core/lib/codegen/template/vFor.ts
+++ b/packages/language-core/lib/codegen/template/vFor.ts
@@ -51,7 +51,8 @@ export function* generateVFor(
 		ctx.addLocalVariable(varName);
 	}
 	let isFragment = true;
-	for (const argument of node.codegenNode?.children.arguments ?? []) {
+	// children is undefined with v-once (#4827)
+	for (const argument of node.codegenNode?.children?.arguments ?? []) {
 		if (
 			argument.type === CompilerDOM.NodeTypes.JS_FUNCTION_EXPRESSION
 			&& argument.returns?.type === CompilerDOM.NodeTypes.VNODE_CALL

--- a/packages/language-core/lib/codegen/template/vFor.ts
+++ b/packages/language-core/lib/codegen/template/vFor.ts
@@ -52,7 +52,7 @@ export function* generateVFor(
 	}
 	let isFragment = true;
 	// children is undefined with v-once (#4827)
-	for (const argument of node.codegenNode?.children?.arguments ?? []) {
+	for (const argument of (node.codegenNode?.children as CompilerDOM.ForRenderListExpression | undefined)?.arguments ?? []) {
 		if (
 			argument.type === CompilerDOM.NodeTypes.JS_FUNCTION_EXPRESSION
 			&& argument.returns?.type === CompilerDOM.NodeTypes.VNODE_CALL

--- a/test-workspace/tsc/passedFixtures/vue3/#4827/child.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#4827/child.vue
@@ -1,0 +1,3 @@
+<template>
+	<pre v-for="_ in []" v-once></pre>
+</template>

--- a/test-workspace/tsc/passedFixtures/vue3/#4827/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#4827/main.vue
@@ -1,0 +1,3 @@
+<template>
+	<pre v-for="_ in []" v-once></pre>
+</template>

--- a/test-workspace/tsc/passedFixtures/vue3/#4827/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#4827/main.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import Main from './child.vue'
+</script>
+
 <template>
-	<pre v-for="_ in []" v-once></pre>
+  <Main />
 </template>


### PR DESCRIPTION
fix #4827 