### PR TITLE
fix(language-service): initialize scope with null prototype object

### DIFF
--- a/packages/language-server/tests/inlayHints.spec.ts
+++ b/packages/language-server/tests/inlayHints.spec.ts
@@ -186,6 +186,28 @@ describe('Definitions', async () => {
 		`);
 	});
 
+	it('#4855', async () => {
+		expect(
+			await requestInlayHintsResult('fixture.vue', 'vue', `
+				<script setup lang="ts">
+				import { toString } from './utils';
+
+				const { foo } = defineProps<{ foo: string }>();
+				console.log(foo);
+				</script>
+			`)
+		).toMatchInlineSnapshot(`
+			"
+							<script setup lang="ts">
+							import { toString } from './utils';
+
+							const { foo } = defineProps<{ foo: string }>();
+							console.log(/* props. */foo);
+							</script>
+						"
+		`);
+	});
+
 	const openedDocuments: TextDocument[] = [];
 
 	afterEach(async () => {

--- a/packages/language-service/lib/plugins/vue-inlayhints.ts
+++ b/packages/language-service/lib/plugins/vue-inlayhints.ts
@@ -107,7 +107,7 @@ export function findDestructuredProps(
 	ast: ts.SourceFile,
 	props: Set<string>
 ) {
-	const rootScope: Scope = {};
+	const rootScope: Scope = Object.create(null);
 	const scopeStack: Scope[] = [rootScope];
 	let currentScope: Scope = rootScope;
 	const excludedIds = new WeakSet<ts.Identifier>();


### PR DESCRIPTION
Prevent mistakenly identifying properties such as `toString` inherited from `Object` as props.