### PR TITLE
fix(language-core): generate correct reference for `v-on` on `<slot>`

### DIFF
--- a/packages/language-core/lib/codegen/template/elementProps.ts
+++ b/packages/language-core/lib/codegen/template/elementProps.ts
@@ -24,8 +24,7 @@ export function* generateElementProps(
 		suffix: string;
 	}[]
 ): Generator<Code> {
-	const isIntrinsicElement = node.tagType === CompilerDOM.ElementTypes.ELEMENT || node.tagType === CompilerDOM.ElementTypes.TEMPLATE;
-	const canCamelize = node.tagType === CompilerDOM.ElementTypes.COMPONENT;
+	const isComponent = node.tagType === CompilerDOM.ElementTypes.COMPONENT;
 
 	for (const prop of props) {
 		if (
@@ -37,7 +36,7 @@ export function* generateElementProps(
 				&& !prop.arg.loc.source.startsWith('[')
 				&& !prop.arg.loc.source.endsWith(']')
 			) {
-				if (isIntrinsicElement) {
+				if (!isComponent) {
 					yield `...{ `;
 					yield* generateEventArg(ctx, prop.arg, true);
 					yield `: `;
@@ -101,7 +100,7 @@ export function* generateElementProps(
 			}
 
 			const shouldSpread = propName === 'style' || propName === 'class';
-			const shouldCamelize = canCamelize
+			const shouldCamelize = isComponent
 				&& (!prop.arg || (prop.arg.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION && prop.arg.isStatic)) // isStatic
 				&& hyphenateAttr(propName) === propName
 				&& !options.vueCompilerOptions.htmlAttributes.some(pattern => minimatch(propName, pattern));
@@ -189,7 +188,7 @@ export function* generateElementProps(
 			}
 
 			const shouldSpread = prop.name === 'style' || prop.name === 'class';
-			const shouldCamelize = canCamelize
+			const shouldCamelize = isComponent
 				&& hyphenateAttr(prop.name) === prop.name
 				&& !options.vueCompilerOptions.htmlAttributes.some(pattern => minimatch(prop.name, pattern));
 

--- a/test-workspace/tsc/passedFixtures/vue3/#4862/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#4862/main.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+const bar = () => {}
+</script>
+
+<template>
+    <slot @bar="bar"></slot>
+</template>


### PR DESCRIPTION
fix #4862 