### PR TITLE
chore: remove side effects

### DIFF
--- a/packages/component-meta/package.json
+++ b/packages/component-meta/package.json
@@ -6,6 +6,7 @@
 		"**/*.js",
 		"**/*.d.ts"
 	],
+	"sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/vuejs/language-tools.git",

--- a/packages/component-type-helpers/package.json
+++ b/packages/component-type-helpers/package.json
@@ -6,6 +6,7 @@
 		"**/*.js",
 		"**/*.d.ts"
 	],
+	"sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/vuejs/language-tools.git",

--- a/packages/language-core/package.json
+++ b/packages/language-core/package.json
@@ -6,6 +6,7 @@
 		"**/*.js",
 		"**/*.d.ts"
 	],
+	"sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/vuejs/language-tools.git",

--- a/packages/language-plugin-pug/package.json
+++ b/packages/language-plugin-pug/package.json
@@ -6,6 +6,7 @@
 		"**/*.js",
 		"**/*.d.ts"
 	],
+	"sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/vuejs/language-tools.git",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -9,6 +9,7 @@
 	"bin": {
 		"vue-language-server": "./bin/vue-language-server.js"
 	},
+	"sideEffects": true,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/vuejs/language-tools.git",

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -7,6 +7,7 @@
 		"**/*.js",
 		"**/*.d.ts"
 	],
+	"sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/vuejs/language-tools.git",

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -7,6 +7,7 @@
 		"**/*.js",
 		"**/*.d.ts"
 	],
+	"sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/vuejs/language-tools.git",

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -6,6 +6,7 @@
 		"**/*.js",
 		"**/*.d.ts"
 	],
+	"sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/vuejs/language-tools.git",


### PR DESCRIPTION
This would allow bundlers to tree shake the module code when imports are not done via `import type`.

E.g., 

```ts
import { ComponentProps } from 'vue-component-type-helpers';
```

Also, I would like to know why the `code` needs to be default exported as a string containing the same TS code again. Is it maybe some artifact from the past and or only relevant to Vue2?
