### PR TITLE
chore: fix nvim config snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ lspconfig.tsserver.setup {
       },
     },
   },
+}
 
 lspconfig.volar.setup {
   init_options = {
@@ -104,7 +105,7 @@ lspconfig.volar.setup {
       hybridMode = false,
     },
   },
-},
+}
 ```
 
 ### nvim-cmp integration


### PR DESCRIPTION
I noticed a mistake in the snippet for nvim, there was a missing `}` and a trailing.