### PR TITLE
fix(language-core): generate `value` instead of model name into tuple

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -438,7 +438,7 @@ function* generateModelEmits(
 		const generateDefineModels = function* () {
 			for (const defineModel of defineModels) {
 				const [propName, localName] = getPropAndLocalName(scriptSetup, defineModel);
-				yield `'update:${propName}': [${propName}:`;
+				yield `'update:${propName}': [value: `;
 				yield* generateDefinePropType(scriptSetup, propName, localName, defineModel);
 				yield `]${endOfLine}`;
 			}

--- a/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -93,10 +93,10 @@ type __VLS_PrettifyLocal<T> = {
 exports[`vue-tsc-dts > Input: generic/component.vue, Output: generic/component.vue.d.ts 1`] = `
 "declare const _default: <T>(__VLS_props: NonNullable<Awaited<typeof __VLS_setup>>["props"], __VLS_ctx?: __VLS_PrettifyLocal<Pick<NonNullable<Awaited<typeof __VLS_setup>>, "attrs" | "emit" | "slots">>, __VLS_expose?: NonNullable<Awaited<typeof __VLS_setup>>["expose"], __VLS_setup?: Promise<{
     props: __VLS_PrettifyLocal<Pick<Partial<{}> & Omit<{
-        readonly "onUpdate:title"?: (title: string) => any;
+        readonly "onUpdate:title"?: (value: string) => any;
         readonly onBar?: (data: number) => any;
     } & import("vue").VNodeProps & import("vue").AllowedComponentProps & import("vue").ComponentCustomProps & Readonly<{}> & Readonly<{
-        "onUpdate:title"?: (title: string) => any;
+        "onUpdate:title"?: (value: string) => any;
         onBar?: (data: number) => any;
     }>, never>, "onUpdate:title" | "onBar"> & ({
         title?: string;
@@ -116,7 +116,7 @@ exports[`vue-tsc-dts > Input: generic/component.vue, Output: generic/component.v
             foo: number;
         }): any;
     };
-    emit: ((e: "bar", data: number) => void) & ((evt: "update:title", title: string) => void);
+    emit: ((e: "bar", data: number) => void) & ((evt: "update:title", value: string) => void);
 }>) => import("vue").VNode<import("vue").RendererNode, import("vue").RendererElement, {
     [key: string]: any;
 }> & {
@@ -132,10 +132,10 @@ type __VLS_PrettifyLocal<T> = {
 exports[`vue-tsc-dts > Input: generic/custom-extension-component.cext, Output: generic/custom-extension-component.cext.d.ts 1`] = `
 "declare const _default: <T>(__VLS_props: NonNullable<Awaited<typeof __VLS_setup>>["props"], __VLS_ctx?: __VLS_PrettifyLocal<Pick<NonNullable<Awaited<typeof __VLS_setup>>, "attrs" | "emit" | "slots">>, __VLS_expose?: NonNullable<Awaited<typeof __VLS_setup>>["expose"], __VLS_setup?: Promise<{
     props: __VLS_PrettifyLocal<Pick<Partial<{}> & Omit<{
-        readonly "onUpdate:title"?: (title: string) => any;
+        readonly "onUpdate:title"?: (value: string) => any;
         readonly onBar?: (data: number) => any;
     } & import("vue").VNodeProps & import("vue").AllowedComponentProps & import("vue").ComponentCustomProps & Readonly<{}> & Readonly<{
-        "onUpdate:title"?: (title: string) => any;
+        "onUpdate:title"?: (value: string) => any;
         onBar?: (data: number) => any;
     }>, never>, "onUpdate:title" | "onBar"> & ({
         title?: string;
@@ -155,7 +155,7 @@ exports[`vue-tsc-dts > Input: generic/custom-extension-component.cext, Output: g
             foo: number;
         }): any;
     };
-    emit: ((e: "bar", data: number) => void) & ((evt: "update:title", title: string) => void);
+    emit: ((e: "bar", data: number) => void) & ((evt: "update:title", value: string) => void);
 }>) => import("vue").VNode<import("vue").RendererNode, import("vue").RendererElement, {
     [key: string]: any;
 }> & {
@@ -329,13 +329,13 @@ exports[`vue-tsc-dts > Input: reference-type-model/component.vue, Output: refere
     quxModifiers?: Record<'lazy' | 'trim', true>;
 };
 declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<__VLS_PublicProps>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {
-    "update:foo": (foo: number) => void;
-    "update:bar": (bar: string[]) => void;
-    "update:qux": (qux: string) => void;
+    "update:foo": (value: number) => void;
+    "update:bar": (value: string[]) => void;
+    "update:qux": (value: string) => void;
 }, string, import("vue").PublicProps, Readonly<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<__VLS_PublicProps>>> & Readonly<{
-    "onUpdate:foo"?: (foo: number) => any;
-    "onUpdate:bar"?: (bar: string[]) => any;
-    "onUpdate:qux"?: (qux: string) => any;
+    "onUpdate:foo"?: (value: number) => any;
+    "onUpdate:bar"?: (value: string[]) => any;
+    "onUpdate:qux"?: (value: string) => any;
 }>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
 export default _default;
 type __VLS_NonUndefinedable<T> = T extends undefined ? never : T;

--- a/test-workspace/tsc/passedFixtures/vue3/#4890/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#4890/main.vue
@@ -1,0 +1,3 @@
+<script setup lang="ts" generic="T">
+defineModel('hello-world');
+</script>


### PR DESCRIPTION
fix #4890 