### PR TITLE
fix(language-core): refer absolute path of global types file

### DIFF
--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -56,9 +56,9 @@ export function* generateScript(options: ScriptCodegenOptions): Generator<Code, 
 	const ctx = createScriptCodegenContext(options);
 
 	if (options.vueCompilerOptions.__setupedGlobalTypes) {
-		const { absolutePath } = options.vueCompilerOptions.__setupedGlobalTypes;
-		if (absolutePath) {
-			yield `/// <reference types="${absolutePath}" />${newLine}`;
+		const globalTypes = options.vueCompilerOptions.__setupedGlobalTypes;
+		if (typeof globalTypes === 'object') {
+			yield `/// <reference types="${globalTypes.absolutePath}" />${newLine}`;
 		}
 		else {
 			yield `/// <reference types=".vue-global-types/${options.vueCompilerOptions.lib}_${options.vueCompilerOptions.target}_${options.vueCompilerOptions.strictTemplates}.d.ts" />${newLine}`;

--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -56,7 +56,11 @@ export function* generateScript(options: ScriptCodegenOptions): Generator<Code, 
 	const ctx = createScriptCodegenContext(options);
 
 	if (options.vueCompilerOptions.__setupedGlobalTypes) {
-		yield `/// <reference types=".vue-global-types/${options.vueCompilerOptions.lib}_${options.vueCompilerOptions.target}_${options.vueCompilerOptions.strictTemplates}.d.ts" />${newLine}`;
+		if (options.vueCompilerOptions.__setupedGlobalTypesAbsolutePath) {
+			yield `/// <reference types="${options.vueCompilerOptions.__setupedGlobalTypesAbsolutePath}" />${newLine}`;
+		} else {
+			yield `/// <reference types=".vue-global-types/${options.vueCompilerOptions.lib}_${options.vueCompilerOptions.target}_${options.vueCompilerOptions.strictTemplates}.d.ts" />${newLine}`;
+		}
 	}
 	else {
 		yield `/* placeholder */`;

--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -56,9 +56,11 @@ export function* generateScript(options: ScriptCodegenOptions): Generator<Code, 
 	const ctx = createScriptCodegenContext(options);
 
 	if (options.vueCompilerOptions.__setupedGlobalTypes) {
-		if (options.vueCompilerOptions.__setupedGlobalTypesAbsolutePath) {
-			yield `/// <reference types="${options.vueCompilerOptions.__setupedGlobalTypesAbsolutePath}" />${newLine}`;
-		} else {
+		const { absolutePath } = options.vueCompilerOptions.__setupedGlobalTypes;
+		if (absolutePath) {
+			yield `/// <reference types="${absolutePath}" />${newLine}`;
+		}
+		else {
 			yield `/// <reference types=".vue-global-types/${options.vueCompilerOptions.lib}_${options.vueCompilerOptions.target}_${options.vueCompilerOptions.strictTemplates}.d.ts" />${newLine}`;
 		}
 	}

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -55,8 +55,8 @@ export interface VueCompilerOptions {
 	experimentalModelPropName: Record<string, Record<string, boolean | Record<string, string> | Record<string, string>[]>>;
 
 	// internal
-	__setupedGlobalTypes?: {
-		absolutePath?: string;
+	__setupedGlobalTypes?: true | {
+		absolutePath: string;
 	};
 	__test?: boolean;
 }

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -56,6 +56,7 @@ export interface VueCompilerOptions {
 
 	// internal
 	__setupedGlobalTypes?: boolean;
+	__setupedGlobalTypesAbsolutePath?: string;
 	__test?: boolean;
 }
 

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -55,8 +55,9 @@ export interface VueCompilerOptions {
 	experimentalModelPropName: Record<string, Record<string, boolean | Record<string, string> | Record<string, string>[]>>;
 
 	// internal
-	__setupedGlobalTypes?: boolean;
-	__setupedGlobalTypesAbsolutePath?: string;
+	__setupedGlobalTypes?: {
+		absolutePath?: string;
+	};
 	__test?: boolean;
 }
 

--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -281,7 +281,7 @@ export function resolveVueCompilerOptions(vueOptions: Partial<VueCompilerOptions
 export function setupGlobalTypes(rootDir: string, vueOptions: VueCompilerOptions, host: {
 	fileExists(path: string): boolean;
 	writeFile?(path: string, data: string): void;
-}): { absolutePath: string; } | undefined {
+}): VueCompilerOptions['__setupedGlobalTypes'] {
 	if (!host.writeFile) {
 		return;
 	}

--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -36,13 +36,10 @@ export function createParsedCommandLineByJson(
 
 	const resolvedVueOptions = resolveVueCompilerOptions(vueOptions);
 	if (skipGlobalTypesSetup) {
-		resolvedVueOptions.__setupedGlobalTypes = {};
+		resolvedVueOptions.__setupedGlobalTypes = true;
 	}
 	else {
-		const absolutePath = setupGlobalTypes(rootDir, resolvedVueOptions, parseConfigHost);
-		if (absolutePath) {
-			resolvedVueOptions.__setupedGlobalTypes = { absolutePath };
-		}
+		resolvedVueOptions.__setupedGlobalTypes = setupGlobalTypes(rootDir, resolvedVueOptions, parseConfigHost);
 	}
 	const parsed = ts.parseJsonConfigFileContent(
 		json,
@@ -94,13 +91,10 @@ export function createParsedCommandLine(
 
 		const resolvedVueOptions = resolveVueCompilerOptions(vueOptions);
 		if (skipGlobalTypesSetup) {
-			resolvedVueOptions.__setupedGlobalTypes = {};
+			resolvedVueOptions.__setupedGlobalTypes = true;
 		}
 		else {
-			const absolutePath = setupGlobalTypes(path.dirname(tsConfigPath), resolvedVueOptions, parseConfigHost);
-			if (absolutePath) {
-				resolvedVueOptions.__setupedGlobalTypes = { absolutePath };
-			}
+			resolvedVueOptions.__setupedGlobalTypes = setupGlobalTypes(path.dirname(tsConfigPath), resolvedVueOptions, parseConfigHost);
 		}
 		const parsed = ts.parseJsonSourceFileConfigFileContent(
 			config,
@@ -287,7 +281,7 @@ export function resolveVueCompilerOptions(vueOptions: Partial<VueCompilerOptions
 export function setupGlobalTypes(rootDir: string, vueOptions: VueCompilerOptions, host: {
 	fileExists(path: string): boolean;
 	writeFile?(path: string, data: string): void;
-}) {
+}): { absolutePath: string; } | undefined {
 	if (!host.writeFile) {
 		return;
 	}
@@ -303,6 +297,6 @@ export function setupGlobalTypes(rootDir: string, vueOptions: VueCompilerOptions
 		const globalTypesPath = path.join(dir, 'node_modules', '.vue-global-types', `${vueOptions.lib}_${vueOptions.target}_${vueOptions.strictTemplates}.d.ts`);
 		const globalTypesContents = `// @ts-nocheck\nexport {};\n` + generateGlobalTypes(vueOptions.lib, vueOptions.target, vueOptions.strictTemplates);
 		host.writeFile(globalTypesPath, globalTypesContents);
-		return globalTypesPath;
+		return { absolutePath: globalTypesPath };
 	} catch { }
 }

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -33,7 +33,9 @@ describe('vue-tsc-dts', () => {
 		}
 		else {
 			vueOptions = vue.resolveVueCompilerOptions({ extensions: ['.vue', '.cext'] });
-			vueOptions.__setupedGlobalTypes = vue.setupGlobalTypes(workspace.replace(windowsPathReg, '/'), vueOptions, ts.sys);
+			const globalTypesInfo = vue.setupGlobalTypes(workspace.replace(windowsPathReg, '/'), vueOptions, ts.sys);
+			vueOptions.__setupedGlobalTypes = globalTypesInfo.done;
+			vueOptions.__setupedGlobalTypesAbsolutePath = globalTypesInfo.absolutePath;
 		}
 		const vueLanguagePlugin = vue.createVueLanguagePlugin<string>(
 			ts,

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -33,10 +33,7 @@ describe('vue-tsc-dts', () => {
 		}
 		else {
 			vueOptions = vue.resolveVueCompilerOptions({ extensions: ['.vue', '.cext'] });
-			const absolutePath = vue.setupGlobalTypes(workspace.replace(windowsPathReg, '/'), vueOptions, ts.sys);
-			if (absolutePath) {
-				vueOptions.__setupedGlobalTypes = { absolutePath };
-			}
+			vueOptions.__setupedGlobalTypes = vue.setupGlobalTypes(workspace.replace(windowsPathReg, '/'), vueOptions, ts.sys);
 		}
 		const vueLanguagePlugin = vue.createVueLanguagePlugin<string>(
 			ts,

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -33,9 +33,10 @@ describe('vue-tsc-dts', () => {
 		}
 		else {
 			vueOptions = vue.resolveVueCompilerOptions({ extensions: ['.vue', '.cext'] });
-			const globalTypesInfo = vue.setupGlobalTypes(workspace.replace(windowsPathReg, '/'), vueOptions, ts.sys);
-			vueOptions.__setupedGlobalTypes = globalTypesInfo.done;
-			vueOptions.__setupedGlobalTypesAbsolutePath = globalTypesInfo.absolutePath;
+			const absolutePath = vue.setupGlobalTypes(workspace.replace(windowsPathReg, '/'), vueOptions, ts.sys);
+			if (absolutePath) {
+				vueOptions.__setupedGlobalTypes = { absolutePath };
+			}
 		}
 		const vueLanguagePlugin = vue.createVueLanguagePlugin<string>(
 			ts,


### PR DESCRIPTION
fix https://github.com/vuejs/language-tools/issues/4860

Check the detail info here
https://github.com/vuejs/language-tools/issues/4860#issuecomment-2406554626

## Solution

Change globalTypes reference to absolute path:

before: 
``` ts
/// <reference types=".vue-global-types/vue_3.4_false.d.ts" />
```
after:
```ts
/// <reference types="/absolute/path/to/.vue-global-types/vue_3.4_false.d.ts" />
```