### PR TITLE
fix(component-meta): error when signatures is undefined

### DIFF
--- a/packages/component-meta/lib/base.ts
+++ b/packages/component-meta/lib/base.ts
@@ -540,7 +540,7 @@ function createSchemaResolvers(
 	function resolveSlotProperties(prop: ts.Symbol): SlotMeta {
 		const propType = typeChecker.getNonNullableType(typeChecker.getTypeOfSymbolAtLocation(prop, symbolNode));
 		const signatures = propType.getCallSignatures();
-		const paramType = signatures[0].parameters[0];
+		const paramType = signatures.length > 0 ? signatures[0].parameters[0] : [];
 		const subtype = paramType ? typeChecker.getTypeOfSymbolAtLocation(paramType, symbolNode) : typeChecker.getAnyType();
 		let schema: PropertyMetaSchema;
 		let declarations: Declaration[];

--- a/packages/component-meta/lib/base.ts
+++ b/packages/component-meta/lib/base.ts
@@ -540,7 +540,7 @@ function createSchemaResolvers(
 	function resolveSlotProperties(prop: ts.Symbol): SlotMeta {
 		const propType = typeChecker.getNonNullableType(typeChecker.getTypeOfSymbolAtLocation(prop, symbolNode));
 		const signatures = propType.getCallSignatures();
-		const paramType = signatures.length > 0 ? signatures[0].parameters[0] : [];
+		const paramType = signatures[0]?.parameters[0];
 		const subtype = paramType ? typeChecker.getTypeOfSymbolAtLocation(paramType, symbolNode) : typeChecker.getAnyType();
 		let schema: PropertyMetaSchema;
 		let declarations: Declaration[];


### PR DESCRIPTION
In certain cases, `signatures[0].parameters[0]` returns undefined. We need to prevent this from causing an error.