### PR TITLE
test: fix incorrect default value

### DIFF
--- a/test-workspace/tsc/passedFixtures/vue3/defineProp_A/script-setup.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/defineProp_A/script-setup.vue
@@ -12,7 +12,7 @@ const bar = defineProp<string>('bar', {
 });
 const baz = defineProp<string | number>('baz', {
     required: true,
-    default: () => [1, 2, 3],
+    default: () => 1,
 });
 defineProp<Qux>('qux')
 defineProp<boolean>('quux', { default: true })


### PR DESCRIPTION
In https://github.com/vuejs/core/pull/12227, I attempted to fix the `default` type restriction in `PropOptions`, but it caused CI failures (https://github.com/vuejs/ecosystem-ci/actions/runs/11435154446/job/31810009674).

Previously, `default` allowed arbitrary objects, leading to incorrect tests passing.