### PR TITLE
fix(language-core): make model modifiers optional

### DIFF
--- a/packages/component-meta/tests/index.spec.ts
+++ b/packages/component-meta/tests/index.spec.ts
@@ -39,6 +39,8 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) => describ
 		expect(bar).toBeDefined();
 		expect(qux).toBeDefined();
 		expect(quxModifiers).toBeDefined();
+		// @todo: order vary depending on withTsconfig option
+		expect(quxModifiers?.type).toMatch(/Partial<Record<(?:"lazy" \| "trim"|"trim" \| "lazy"), true>> \| undefined/);
 		expect(onUpdateFoo).toBeDefined();
 		expect(onUpdateBar).toBeDefined();
 		expect(onUpdateQux).toBeDefined();

--- a/packages/component-meta/tests/index.spec.ts
+++ b/packages/component-meta/tests/index.spec.ts
@@ -39,8 +39,6 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) => describ
 		expect(bar).toBeDefined();
 		expect(qux).toBeDefined();
 		expect(quxModifiers).toBeDefined();
-		// @todo: order vary depending on withTsconfig option
-		expect(quxModifiers?.type).toMatch(/Partial<Record<(?:"lazy" \| "trim"|"trim" \| "lazy"), true>> \| undefined/);
 		expect(onUpdateFoo).toBeDefined();
 		expect(onUpdateBar).toBeDefined();
 		expect(onUpdateQux).toBeDefined();

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -441,7 +441,7 @@ function* generateComponentProps(
 				}
 				const modifierType = getRangeName(scriptSetup, defineProp.modifierType);
 				definePropMirrors.set(propModifierName, options.getGeneratedLength());
-				yield `${propModifierName}?: Record<${modifierType}, true>,${endOfLine}`;
+				yield `${propModifierName}?: Partial<Record<${modifierType}, true>>,${endOfLine}`;
 			}
 		}
 		yield `}`;

--- a/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -318,7 +318,7 @@ exports[`vue-tsc-dts > Input: reference-type-model/component.vue, Output: refere
     "foo"?: number;
     "bar"?: string[];
     "qux"?: string;
-    quxModifiers?: Record<'lazy' | 'trim', true>;
+    quxModifiers?: Partial<Record<'lazy' | 'trim', true>>;
 };
 declare const _default: import("vue").DefineComponent<import("vue").ExtractPropTypes<__VLS_TypePropsToOption<__VLS_PublicProps>>, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {
     "update:foo": (value: number) => void;

--- a/test-workspace/tsc/passedFixtures/vue3/#4978/comp.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#4978/comp.vue
@@ -1,0 +1,3 @@
+<script setup lang="ts">
+defineModel<string, 'foo' | 'bar'>();
+</script>

--- a/test-workspace/tsc/passedFixtures/vue3/#4978/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#4978/main.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import Comp from './comp.vue';
+</script>
+
+<template>
+	<Comp :model-modifiers="{ foo: true }" />
+</template>


### PR DESCRIPTION
This pull request includes changes to improve the handling of component property modifiers in the `generateComponentProps` function and its associated tests.

It aims to better reflect `modelModifiers` type marking keys as optional:

```html
<!-- MyComp.vue -->
<script setup lang="ts">
const [modelValue, modelModifiers] = defineModel<string, 'foo' | 'bar'>()

// modelModifiers.foo?: true
// modelModifiers.bar?: true
</script>
```

With this update, we can omit keys when manually defining `model-modifiers` prop
```html
<template>
  <!-- Type '{ foo: true; }' is missing the following properties from type 'Record<"foo" | "bar", true>': bar -->
  <MyComp :model-modifiers="{ foo: true }" />
</template>
```

Note that it will also fix type when using `vitest` and `@vue/test-utils`:
```ts
import { MyComp } from './MyComp.vue'
import { mount } from '@vue/test-utils'
import { it } from 'vitest'

it('should foo modifier', async () => {
  const component = mount(MyComp, {
    props: {
	  // Type '{ foo: true; }' is missing the following properties from type 'Record<"foo" | "bar", true>': bar
      'modelModifiers': { foo: true },
    },
  })
})
```