### PR TITLE
fix(language-core): always report missing props on `<slot>`

### DIFF
--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -85,7 +85,7 @@ export function* generateComponent(
 		yield `// @ts-ignore${newLine}`; // #2304
 		yield `/** @type { [`;
 		for (const tagOffset of tagOffsets) {
-			yield `typeof `
+			yield `typeof `;
 			if (var_originalComponent === node.tag) {
 				yield [
 					var_originalComponent,
@@ -201,7 +201,7 @@ export function* generateComponent(
 
 	yield `// @ts-ignore${newLine}`;
 	yield `const ${var_functionalComponent} = __VLS_asFunctionalComponent(${var_originalComponent}, new ${var_originalComponent}({`;
-	yield* generateElementProps(options, ctx, node, props, false);
+	yield* generateElementProps(options, ctx, node, props, options.vueCompilerOptions.strictTemplates, false);
 	yield `}))${endOfLine}`;
 
 	yield `const ${var_componentInstance} = ${var_functionalComponent}`;
@@ -212,7 +212,7 @@ export function* generateComponent(
 		startTagOffset + node.tag.length,
 		ctx.codeFeatures.verification,
 		`{`,
-		...generateElementProps(options, ctx, node, props, true, false, failedPropExps),
+		...generateElementProps(options, ctx, node, props, options.vueCompilerOptions.strictTemplates, true, failedPropExps),
 		`}`
 	);
 	yield `, ...__VLS_functionalComponentArgsRest(${var_functionalComponent}))${endOfLine}`;
@@ -315,7 +315,7 @@ export function* generateElement(
 		startTagOffset + node.tag.length,
 		ctx.codeFeatures.verification,
 		`{`,
-		...generateElementProps(options, ctx, node, node.props, true, false, failedPropExps),
+		...generateElementProps(options, ctx, node, node.props, options.vueCompilerOptions.strictTemplates, true, failedPropExps),
 		`}`
 	);
 	yield `)${endOfLine}`;

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -212,7 +212,7 @@ export function* generateComponent(
 		startTagOffset + node.tag.length,
 		ctx.codeFeatures.verification,
 		`{`,
-		...generateElementProps(options, ctx, node, props, true, failedPropExps),
+		...generateElementProps(options, ctx, node, props, true, false, failedPropExps),
 		`}`
 	);
 	yield `, ...__VLS_functionalComponentArgsRest(${var_functionalComponent}))${endOfLine}`;
@@ -315,7 +315,7 @@ export function* generateElement(
 		startTagOffset + node.tag.length,
 		ctx.codeFeatures.verification,
 		`{`,
-		...generateElementProps(options, ctx, node, node.props, true, failedPropExps),
+		...generateElementProps(options, ctx, node, node.props, true, false, failedPropExps),
 		`}`
 	);
 	yield `)${endOfLine}`;

--- a/packages/language-core/lib/codegen/template/elementProps.ts
+++ b/packages/language-core/lib/codegen/template/elementProps.ts
@@ -25,8 +25,8 @@ export function* generateElementProps(
 	ctx: TemplateCodegenContext,
 	node: CompilerDOM.ElementNode,
 	props: CompilerDOM.ElementNode['props'],
+	strictPropsCheck: boolean,
 	enableCodeFeatures: boolean,
-	alwaysReport: boolean = false,
 	failedPropExps?: FailedPropExpression[]
 ): Generator<Code> {
 	const isComponent = node.tagType === CompilerDOM.ElementTypes.COMPONENT;
@@ -113,7 +113,7 @@ export function* generateElementProps(
 			if (shouldSpread) {
 				yield `...{ `;
 			}
-			const codeInfo = getPropsCodeInfo(options, ctx, alwaysReport, shouldCamelize);
+			const codeInfo = getPropsCodeInfo(ctx, strictPropsCheck, shouldCamelize);
 			const codes = wrapWith(
 				prop.loc.start.offset,
 				prop.loc.end.offset,
@@ -180,7 +180,7 @@ export function* generateElementProps(
 			if (shouldSpread) {
 				yield `...{ `;
 			}
-			const codeInfo = getPropsCodeInfo(options, ctx, alwaysReport, true);
+			const codeInfo = getPropsCodeInfo(ctx, strictPropsCheck, true);
 			const codes = conditionWrapWith(
 				enableCodeFeatures,
 				prop.loc.start.offset,
@@ -250,9 +250,8 @@ export function* generateElementProps(
 }
 
 function getPropsCodeInfo(
-	options: TemplateCodegenOptions,
 	ctx: TemplateCodegenContext,
-	alwaysReport: boolean,
+	strictPropsCheck: boolean,
 	shouldCamelize: boolean
 ): VueCodeInformation {
 	const codeInfo = ctx.codeFeatures.withoutHighlightAndCompletion;
@@ -264,7 +263,7 @@ function getPropsCodeInfo(
 				resolveRenameEditText: shouldCamelize ? hyphenateAttr : undefined,
 			}
 			: false,
-		verification: options.vueCompilerOptions.strictTemplates || alwaysReport
+		verification: strictPropsCheck
 			? codeInfo.verification
 			: {
 				shouldReport(_source, code) {

--- a/packages/language-core/lib/codegen/template/elementProps.ts
+++ b/packages/language-core/lib/codegen/template/elementProps.ts
@@ -26,6 +26,7 @@ export function* generateElementProps(
 	node: CompilerDOM.ElementNode,
 	props: CompilerDOM.ElementNode['props'],
 	enableCodeFeatures: boolean,
+	alwaysReport: boolean = false,
 	failedPropExps?: FailedPropExpression[]
 ): Generator<Code> {
 	const isComponent = node.tagType === CompilerDOM.ElementTypes.COMPONENT;
@@ -112,7 +113,7 @@ export function* generateElementProps(
 			if (shouldSpread) {
 				yield `...{ `;
 			}
-			const codeInfo = getPropsCodeInfo(options, ctx, shouldCamelize);
+			const codeInfo = getPropsCodeInfo(options, ctx, alwaysReport, shouldCamelize);
 			const codes = wrapWith(
 				prop.loc.start.offset,
 				prop.loc.end.offset,
@@ -179,7 +180,7 @@ export function* generateElementProps(
 			if (shouldSpread) {
 				yield `...{ `;
 			}
-			const codeInfo = getPropsCodeInfo(options, ctx, true);
+			const codeInfo = getPropsCodeInfo(options, ctx, alwaysReport, true);
 			const codes = conditionWrapWith(
 				enableCodeFeatures,
 				prop.loc.start.offset,
@@ -251,6 +252,7 @@ export function* generateElementProps(
 function getPropsCodeInfo(
 	options: TemplateCodegenOptions,
 	ctx: TemplateCodegenContext,
+	alwaysReport: boolean,
 	shouldCamelize: boolean
 ): VueCodeInformation {
 	const codeInfo = ctx.codeFeatures.withoutHighlightAndCompletion;
@@ -262,7 +264,7 @@ function getPropsCodeInfo(
 				resolveRenameEditText: shouldCamelize ? hyphenateAttr : undefined,
 			}
 			: false,
-		verification: options.vueCompilerOptions.strictTemplates
+		verification: options.vueCompilerOptions.strictTemplates || alwaysReport
 			? codeInfo.verification
 			: {
 				shouldReport(_source, code) {

--- a/packages/language-core/lib/codegen/template/slotOutlet.ts
+++ b/packages/language-core/lib/codegen/template/slotOutlet.ts
@@ -55,7 +55,7 @@ export function* generateSlotOutlet(
 			startTagOffset + node.tag.length,
 			ctx.codeFeatures.verification,
 			`{${newLine}`,
-			...generateElementProps(options, ctx, node, node.props.filter(prop => prop !== nameProp), true),
+			...generateElementProps(options, ctx, node, node.props.filter(prop => prop !== nameProp), true, true),
 			`}`
 		);
 		yield `)${endOfLine}`;

--- a/packages/language-core/lib/codegen/template/slotOutlet.ts
+++ b/packages/language-core/lib/codegen/template/slotOutlet.ts
@@ -62,7 +62,7 @@ export function* generateSlotOutlet(
 	}
 	else {
 		yield `var ${varSlot} = {${newLine}`;
-		yield* generateElementProps(options, ctx, node, node.props.filter(prop => prop !== nameProp), true);
+		yield* generateElementProps(options, ctx, node, node.props.filter(prop => prop !== nameProp), options.vueCompilerOptions.strictTemplates, true);
 		yield `}${endOfLine}`;
 
 		if (

--- a/test-workspace/tsc/passedFixtures/vue3/#4979/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#4979/main.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+defineSlots<{
+	default(props: { foo: string }): any;
+}>();
+</script>
+
+<template>
+	<!-- @vue-expect-error -->
+	<slot bar="..."></slot>
+</template>


### PR DESCRIPTION
fix #4979 