### PR TITLE
fix(tsc): point to shimmed tsc entry point to support ts 5.7

### DIFF
--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -3,7 +3,7 @@ import * as vue from '@vue/language-core';
 
 const windowsPathReg = /\\/g;
 
-export function run(tscPath = require.resolve('typescript/lib/tsc')) {
+export function run(tscPath = require.resolve('typescript/lib/_tsc')) {
 
 	let runExtensions = ['.vue'];
 


### PR DESCRIPTION
Typescript 5.7 uses the `tsc.js` entrypoint for handling the node compile cache. This fix points to the new `_tsc.js` entry point but doesn't handle anything regarding the node compile cache. This needs to be looked at in a future release.