### PR TITLE
fix(language-core): avoid unchecked index access when parsing `defineEmits`

### DIFF
--- a/packages/language-core/lib/parsers/scriptSetupRanges.ts
+++ b/packages/language-core/lib/parsers/scriptSetupRanges.ts
@@ -308,15 +308,13 @@ export function parseScriptSetupRanges(
 				}
 				if (node.typeArguments?.length && ts.isTypeLiteralNode(node.typeArguments[0])) {
 					for (const member of node.typeArguments[0].members) {
-						if (!ts.isCallSignatureDeclaration(member)) {
-							continue;
+						if (ts.isCallSignatureDeclaration(member)) {
+							const type = member.parameters[0]?.type;
+							if (type && ts.isUnionTypeNode(type)) {
+								emits.define.hasUnionTypeArg = true;
+								break;
+							}
 						}
-						const type = member.parameters[0]?.type;
-						if (!type || !ts.isUnionTypeNode(type)) {
-							continue;
-						}
-						emits.define.hasUnionTypeArg = true;
-						return;
 					}
 				}
 			}

--- a/packages/language-core/lib/parsers/scriptSetupRanges.ts
+++ b/packages/language-core/lib/parsers/scriptSetupRanges.ts
@@ -306,12 +306,17 @@ export function parseScriptSetupRanges(
 				if (ts.isVariableDeclaration(parent)) {
 					emits.name = getNodeText(ts, parent.name, ast);
 				}
-				if (node.typeArguments?.length && ts.isTypeLiteralNode(node.typeArguments[0]) && node.typeArguments[0].members.at(0)) {
+				if (node.typeArguments?.length && ts.isTypeLiteralNode(node.typeArguments[0])) {
 					for (const member of node.typeArguments[0].members) {
-						if (ts.isCallSignatureDeclaration(member) && member.parameters[0].type && ts.isUnionTypeNode(member.parameters[0].type)) {
-							emits.define.hasUnionTypeArg = true;
-							return;
+						if (!ts.isCallSignatureDeclaration(member)) {
+							continue;
 						}
+						const type = member.parameters[0]?.type;
+						if (!type || !ts.isUnionTypeNode(type)) {
+							continue;
+						}
+						emits.define.hasUnionTypeArg = true;
+						return;
 					}
 				}
 			}

--- a/packages/language-core/lib/parsers/scriptSetupRanges.ts
+++ b/packages/language-core/lib/parsers/scriptSetupRanges.ts
@@ -380,7 +380,8 @@ export function parseScriptSetupRanges(
 						}
 					}
 				}
-			} else if (vueCompilerOptions.composibles.useTemplateRef.includes(callText) && node.arguments.length && !node.typeArguments?.length) {
+			}
+			else if (vueCompilerOptions.composibles.useTemplateRef.includes(callText) && node.arguments.length && !node.typeArguments?.length) {
 				const define = parseDefineFunction(node);
 				let name;
 				if (ts.isVariableDeclaration(parent)) {

--- a/test-workspace/tsc/passedFixtures/vue3/#5027/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#5027/main.vue
@@ -1,3 +1,4 @@
 <script setup lang="ts">
+// @ts-expect-error
 defineEmits<{()}>();
 </script>

--- a/test-workspace/tsc/passedFixtures/vue3/#5027/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#5027/main.vue
@@ -1,0 +1,3 @@
+<script setup lang="ts">
+defineEmits<{()}>();
+</script>


### PR DESCRIPTION
fix #5027 