### PR TITLE
fix(language-core): don't generate variable access of template refs using `useTemplateRef`

### DIFF
--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -602,7 +602,7 @@ function* generateReferencesForElements(
 			);
 			yield ` } */${endOfLine}`;
 
-			if (variableNameRegex.test(content)) {
+			if (variableNameRegex.test(content) && !options.templateRefNames.has(content)) {
 				ctx.accessExternalVariable(content, startOffset);
 			}
 


### PR DESCRIPTION
fix #5031 