### PR TITLE
fix(language-core): prevent visiting functional components for parseScriptSetupRanges

### DIFF
--- a/packages/language-core/lib/parsers/scriptSetupRanges.ts
+++ b/packages/language-core/lib/parsers/scriptSetupRanges.ts
@@ -400,6 +400,9 @@ export function parseScriptSetupRanges(
 			}
 		}
 		ts.forEachChild(node, child => {
+			if (ts.isFunctionLike(node)) {
+				return;
+			}
 			parents.push(node);
 			visitNode(child, parents);
 			parents.pop();

--- a/test-workspace/tsc/passedFixtures/vue3/templateRef/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/templateRef/main.vue
@@ -1,10 +1,19 @@
 <script setup lang="ts">
-import TemplateRef from './template-ref.vue';
+import { useTemplateRef } from 'vue';
 import { exactType } from '../../shared';
+import TemplateRef from './template-ref.vue';
+
+function Comp() {
+	const foo = useTemplateRef('templateRef');
+	exactType(foo.value, {} as unknown);
+	return ''
+}
 </script>
 
 <template>
 	<TemplateRef ref="templateRef" />
 
 	{{ exactType($refs.templateRef?.$refs.generic?.foo, {} as (1 | undefined)) }}
+
+	<Comp />
 </template>

--- a/test-workspace/tsc/passedFixtures/vue3/templateRef/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/templateRef/main.vue
@@ -6,7 +6,7 @@ import TemplateRef from './template-ref.vue';
 function Comp() {
 	const foo = useTemplateRef('templateRef');
 	exactType(foo.value, {} as unknown);
-	return ''
+	return '';
 }
 </script>
 


### PR DESCRIPTION
`useTemplateRef` and `useCssModule` using in function maybe have a different instance.
In addition [jsx-macros](https://github.com/vue-macros/vue-macros/pull/794) can using in vue-sfc . 
