### PR TITLE
perf(typescript-plugin): use named pipe servers more efficiently

### DIFF
--- a/packages/language-server/lib/hybridModeProject.ts
+++ b/packages/language-server/lib/hybridModeProject.ts
@@ -2,7 +2,7 @@ import type { Language, LanguagePlugin, LanguageServer, LanguageServerProject, P
 import { createLanguageServiceEnvironment } from '@volar/language-server/lib/project/simpleProject';
 import { createLanguage } from '@vue/language-core';
 import { createLanguageService, createUriMap, LanguageService } from '@vue/language-service';
-import { getReadyNamedPipePaths, onSomePipeReadyCallbacks, searchNamedPipeServerForFile } from '@vue/typescript-plugin/lib/utils';
+import { configuredServers, getBestServer, inferredServers, onSomePipeReadyCallbacks } from '@vue/typescript-plugin/lib/utils';
 import { URI } from 'vscode-uri';
 
 export function createHybridModeProject(
@@ -38,16 +38,20 @@ export function createHybridModeProject(
 			});
 			const end = Date.now() + 60000;
 			const pipeWatcher = setInterval(() => {
-				getReadyNamedPipePaths();
+				for (const server of configuredServers) {
+					server.update();
+				}
+				for (const server of inferredServers) {
+					server.update();
+				}
 				if (Date.now() > end) {
 					clearInterval(pipeWatcher);
 				}
-			}, 1000);
+			}, 2500);
 		},
 		async getLanguageService(uri) {
 			const fileName = asFileName(uri);
-			const namedPipeServer = (await searchNamedPipeServerForFile(fileName));
-			namedPipeServer?.socket.end();
+			const namedPipeServer = await getBestServer(fileName);
 			if (namedPipeServer?.projectInfo?.kind === 1) {
 				const tsconfig = namedPipeServer.projectInfo.name;
 				const tsconfigUri = URI.file(tsconfig);

--- a/packages/language-server/lib/hybridModeProject.ts
+++ b/packages/language-server/lib/hybridModeProject.ts
@@ -2,7 +2,7 @@ import type { Language, LanguagePlugin, LanguageServer, LanguageServerProject, P
 import { createLanguageServiceEnvironment } from '@volar/language-server/lib/project/simpleProject';
 import { createLanguage } from '@vue/language-core';
 import { createLanguageService, createUriMap, LanguageService } from '@vue/language-service';
-import { configuredServers, getBestServer, inferredServers, onSomePipeReadyCallbacks } from '@vue/typescript-plugin/lib/utils';
+import { configuredServers, getBestServer, inferredServers, onServerReady } from '@vue/typescript-plugin/lib/utils';
 import { URI } from 'vscode-uri';
 
 export function createHybridModeProject(
@@ -24,7 +24,7 @@ export function createHybridModeProject(
 	const project: LanguageServerProject = {
 		setup(_server) {
 			server = _server;
-			onSomePipeReadyCallbacks.push(() => {
+			onServerReady.push(() => {
 				server.languageFeatures.requestRefresh(false);
 			});
 			server.fileWatcher.onDidChangeWatchedFiles(({ changes }) => {

--- a/packages/language-service/lib/plugins/vue-template.ts
+++ b/packages/language-service/lib/plugins/vue-template.ts
@@ -242,7 +242,9 @@ export function create(
 									? tagName
 									: components.find(component => component === tagName || hyphenateTag(component) === tagName);
 								if (checkTag) {
-									componentProps[checkTag] ??= (await tsPluginClient?.getComponentProps(code.fileName, checkTag, true) ?? []).map(prop => prop.name);
+									componentProps[checkTag] ??= (await tsPluginClient?.getComponentProps(code.fileName, checkTag) ?? [])
+										.filter(prop => prop.required)
+										.map(prop => prop.name);
 									current = {
 										unburnedRequiredProps: [...componentProps[checkTag]],
 										labelOffset: scanner.getTokenOffset() + scanner.getTokenLength(),
@@ -469,7 +471,7 @@ export function create(
 				const promises: Promise<void>[] = [];
 				const tagInfos = new Map<string, {
 					attrs: string[];
-					propsInfo: { name: string, commentMarkdown: string; }[];
+					propsInfo: { name: string, commentMarkdown?: string; }[];
 					events: string[];
 				}>();
 
@@ -1010,7 +1012,7 @@ function parseLabel(label: string) {
 	return {
 		name,
 		leadingSlash
-	}
+	};
 }
 
 function generateItemKey(type: InternalItemId, tag: string, prop: string) {

--- a/packages/typescript-plugin/lib/client.ts
+++ b/packages/typescript-plugin/lib/client.ts
@@ -66,13 +66,12 @@ export function getTemplateContextProps(
 	);
 }
 
-export function getComponentNames(
-	...args: Parameters<typeof import('./requests/componentInfos.js')['getComponentNames']>
-) {
-	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getComponentNames']>>(
-		'getComponentNames',
-		...args
-	);
+export async function getComponentNames(fileName: string) {
+	const server = await getBestServer(fileName);
+	if (!server) {
+		return;
+	}
+	return server.getComponentNames(fileName);
 }
 
 export function getElementAttrs(
@@ -85,7 +84,7 @@ export function getElementAttrs(
 }
 
 async function sendRequest<T>(requestType: RequestData[1], fileName: string, ...rest: any[]) {
-	const server = (await getBestServer(fileName));
+	const server = await getBestServer(fileName);
 	if (!server) {
 		return;
 	}

--- a/packages/typescript-plugin/lib/client.ts
+++ b/packages/typescript-plugin/lib/client.ts
@@ -39,13 +39,16 @@ export function getQuickInfoAtPosition(
 
 // Component Infos
 
-export function getComponentProps(
-	...args: Parameters<typeof import('./requests/componentInfos.js')['getComponentProps']>
-) {
-	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getComponentProps']>>(
-		'getComponentProps',
-		...args
-	);
+export async function getComponentProps(fileName: string, componentName: string) {
+	const server = await getBestServer(fileName);
+	if (!server) {
+		return;
+	}
+	const componentAndProps = await server.getAllComponentAndProps(fileName);
+	if (!componentAndProps) {
+		return;
+	}
+	return componentAndProps[componentName];
 }
 
 export function getComponentEvents(
@@ -71,7 +74,11 @@ export async function getComponentNames(fileName: string) {
 	if (!server) {
 		return;
 	}
-	return server.getComponentNames(fileName);
+	const componentAndProps = await server.getAllComponentAndProps(fileName);
+	if (!componentAndProps) {
+		return;
+	}
+	return Object.keys(componentAndProps);
 }
 
 export function getElementAttrs(

--- a/packages/typescript-plugin/lib/client.ts
+++ b/packages/typescript-plugin/lib/client.ts
@@ -44,7 +44,7 @@ export async function getComponentProps(fileName: string, componentName: string)
 	if (!server) {
 		return;
 	}
-	const componentAndProps = await server.getAllComponentAndProps(fileName);
+	const componentAndProps = await server.componentNamesAndProps.get(fileName);
 	if (!componentAndProps) {
 		return;
 	}
@@ -74,7 +74,7 @@ export async function getComponentNames(fileName: string) {
 	if (!server) {
 		return;
 	}
-	const componentAndProps = await server.getAllComponentAndProps(fileName);
+	const componentAndProps = server.componentNamesAndProps.get(fileName);
 	if (!componentAndProps) {
 		return;
 	}

--- a/packages/typescript-plugin/lib/client.ts
+++ b/packages/typescript-plugin/lib/client.ts
@@ -1,40 +1,40 @@
-import type { Request } from './server';
-import { searchNamedPipeServerForFile, sendRequestWorker } from './utils';
+import type { RequestData } from './server';
+import { getBestServer } from './utils';
 
 export function collectExtractProps(
 	...args: Parameters<typeof import('./requests/collectExtractProps.js')['collectExtractProps']>
 ) {
-	return sendRequest<ReturnType<typeof import('./requests/collectExtractProps')['collectExtractProps']>>({
-		type: 'collectExtractProps',
-		args,
-	});
+	return sendRequest<ReturnType<typeof import('./requests/collectExtractProps')['collectExtractProps']>>(
+		'collectExtractProps',
+		...args
+	);
 }
 
 export async function getImportPathForFile(
 	...args: Parameters<typeof import('./requests/getImportPathForFile.js')['getImportPathForFile']>
 ) {
-	return await sendRequest<ReturnType<typeof import('./requests/getImportPathForFile')['getImportPathForFile']>>({
-		type: 'getImportPathForFile',
-		args,
-	});
+	return await sendRequest<ReturnType<typeof import('./requests/getImportPathForFile')['getImportPathForFile']>>(
+		'getImportPathForFile',
+		...args
+	);
 }
 
 export async function getPropertiesAtLocation(
 	...args: Parameters<typeof import('./requests/getPropertiesAtLocation.js')['getPropertiesAtLocation']>
 ) {
-	return await sendRequest<ReturnType<typeof import('./requests/getPropertiesAtLocation')['getPropertiesAtLocation']>>({
-		type: 'getPropertiesAtLocation',
-		args,
-	});
+	return await sendRequest<ReturnType<typeof import('./requests/getPropertiesAtLocation')['getPropertiesAtLocation']>>(
+		'getPropertiesAtLocation',
+		...args
+	);
 }
 
 export function getQuickInfoAtPosition(
 	...args: Parameters<typeof import('./requests/getQuickInfoAtPosition.js')['getQuickInfoAtPosition']>
 ) {
-	return sendRequest<ReturnType<typeof import('./requests/getQuickInfoAtPosition')['getQuickInfoAtPosition']>>({
-		type: 'getQuickInfoAtPosition',
-		args,
-	});
+	return sendRequest<ReturnType<typeof import('./requests/getQuickInfoAtPosition')['getQuickInfoAtPosition']>>(
+		'getQuickInfoAtPosition',
+		...args
+	);
 }
 
 // Component Infos
@@ -42,55 +42,52 @@ export function getQuickInfoAtPosition(
 export function getComponentProps(
 	...args: Parameters<typeof import('./requests/componentInfos.js')['getComponentProps']>
 ) {
-	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getComponentProps']>>({
-		type: 'getComponentProps',
-		args,
-	});
+	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getComponentProps']>>(
+		'getComponentProps',
+		...args
+	);
 }
 
 export function getComponentEvents(
 	...args: Parameters<typeof import('./requests/componentInfos.js')['getComponentEvents']>
 ) {
-	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getComponentEvents']>>({
-		type: 'getComponentEvents',
-		args,
-	});
+	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getComponentEvents']>>(
+		'getComponentEvents',
+		...args
+	);
 }
 
 export function getTemplateContextProps(
 	...args: Parameters<typeof import('./requests/componentInfos.js')['getTemplateContextProps']>
 ) {
-	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getTemplateContextProps']>>({
-		type: 'getTemplateContextProps',
-		args,
-	});
+	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getTemplateContextProps']>>(
+		'getTemplateContextProps',
+		...args
+	);
 }
 
 export function getComponentNames(
 	...args: Parameters<typeof import('./requests/componentInfos.js')['getComponentNames']>
 ) {
-	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getComponentNames']>>({
-		type: 'getComponentNames',
-		args,
-	});
+	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getComponentNames']>>(
+		'getComponentNames',
+		...args
+	);
 }
 
 export function getElementAttrs(
 	...args: Parameters<typeof import('./requests/componentInfos.js')['getElementAttrs']>
 ) {
-	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getElementAttrs']>>({
-		type: 'getElementAttrs',
-		args,
-	});
+	return sendRequest<ReturnType<typeof import('./requests/componentInfos')['getElementAttrs']>>(
+		'getElementAttrs',
+		...args
+	);
 }
 
-async function sendRequest<T>(request: Request) {
-	const server = (await searchNamedPipeServerForFile(request.args[0]));
+async function sendRequest<T>(requestType: RequestData[1], fileName: string, ...rest: any[]) {
+	const server = (await getBestServer(fileName));
 	if (!server) {
-		console.warn('[Vue Named Pipe Client] No server found for', request.args[0]);
 		return;
 	}
-	const res = await sendRequestWorker<T>(request, server.socket);
-	server.socket.end();
-	return res;
+	return server.request<T>(requestType, fileName, ...rest);
 }

--- a/packages/typescript-plugin/lib/requests/componentInfos.ts
+++ b/packages/typescript-plugin/lib/requests/componentInfos.ts
@@ -6,8 +6,7 @@ import type { RequestContext } from './types';
 export function getComponentProps(
 	this: RequestContext,
 	fileName: string,
-	tag: string,
-	requiredOnly = false
+	tag: string
 ) {
 	const { typescript: ts, language, languageService, getFileId } = this;
 	const volarFile = language.scripts.get(getFileId(fileName));
@@ -47,7 +46,11 @@ export function getComponentProps(
 		}
 	}
 
-	const result = new Map<string, { name: string, commentMarkdown: string; }>();
+	const result = new Map<string, {
+		name: string;
+		required?: true;
+		commentMarkdown?: string;
+	}>();
 
 	for (const sig of componentType.getCallSignatures()) {
 		const propParam = sig.parameters[0];
@@ -55,12 +58,11 @@ export function getComponentProps(
 			const propsType = checker.getTypeOfSymbolAtLocation(propParam, components.node);
 			const props = propsType.getProperties();
 			for (const prop of props) {
-				if (!requiredOnly || !(prop.flags & ts.SymbolFlags.Optional)) {
-					const name = prop.name;
-					const commentMarkdown = generateCommentMarkdown(prop.getDocumentationComment(checker), prop.getJsDocTags());
+				const name = prop.name;
+				const required = !(prop.flags & ts.SymbolFlags.Optional) || undefined;
+				const commentMarkdown = generateCommentMarkdown(prop.getDocumentationComment(checker), prop.getJsDocTags()) || undefined;
 
-					result.set(name, { name, commentMarkdown });
-				}
+				result.set(name, { name, required, commentMarkdown });
 			}
 		}
 	}
@@ -75,12 +77,11 @@ export function getComponentProps(
 				if (prop.flags & ts.SymbolFlags.Method) { // #2443
 					continue;
 				}
-				if (!requiredOnly || !(prop.flags & ts.SymbolFlags.Optional)) {
-					const name = prop.name;
-					const commentMarkdown = generateCommentMarkdown(prop.getDocumentationComment(checker), prop.getJsDocTags());
+				const name = prop.name;
+				const required = !(prop.flags & ts.SymbolFlags.Optional) || undefined;
+				const commentMarkdown = generateCommentMarkdown(prop.getDocumentationComment(checker), prop.getJsDocTags()) || undefined;
 
-					result.set(name, { name, commentMarkdown });
-				}
+				result.set(name, { name, required, commentMarkdown });
 			}
 		}
 	}

--- a/packages/typescript-plugin/lib/server.ts
+++ b/packages/typescript-plugin/lib/server.ts
@@ -65,7 +65,7 @@ export async function startNamedPipeServer(
 		getFileId: (fileName: string) => fileName,
 	};
 	const dataChunks: Buffer[] = [];
-	const componentNamesSubscriptions = new Map<string, [Awaited<ReturnType<typeof getComponentAndProps>>, Set<net.Socket>]>();
+	const componentNamesSubscriptions = new Map<string, [ReturnType<typeof getComponentAndProps> | Awaited<ReturnType<typeof getComponentAndProps>>, Set<net.Socket>]>();
 	const server = net.createServer(connection => {
 		connection.on('data', buffer => {
 			dataChunks.push(buffer);
@@ -203,12 +203,12 @@ export async function startNamedPipeServer(
 		else if (requestType === 'subscribeAllComponentAndProps') {
 			let subscriptions = componentNamesSubscriptions.get(args[0]);
 			if (!subscriptions) {
-				const result = await getComponentAndProps.apply(requestContext, args as any);
+				const result = getComponentAndProps.apply(requestContext, args as any);
 				subscriptions = [result, new Set()];
 				componentNamesSubscriptions.set(args[0], subscriptions);
 			}
 			subscriptions[1].add(connection);
-			sendResponse(subscriptions[0]);
+			sendResponse(await subscriptions[0]);
 		}
 		else {
 			console.warn('[Vue Named Pipe Server] Unknown request:', requestType);

--- a/packages/typescript-plugin/lib/server.ts
+++ b/packages/typescript-plugin/lib/server.ts
@@ -8,9 +8,10 @@ import { getImportPathForFile } from './requests/getImportPathForFile';
 import { getPropertiesAtLocation } from './requests/getPropertiesAtLocation';
 import { getQuickInfoAtPosition } from './requests/getQuickInfoAtPosition';
 import type { RequestContext } from './requests/types';
-import { connect, getNamedPipePath } from './utils';
+import { getServerPath } from './utils';
 
-export interface Request {
+export type RequestData = [
+	seq: number,
 	type: 'containsFile'
 	| 'projectInfo'
 	| 'collectExtractProps'
@@ -22,9 +23,15 @@ export interface Request {
 	| 'getComponentEvents'
 	| 'getTemplateContextProps'
 	| 'getComponentNames'
-	| 'getElementAttrs';
-	args: [fileName: string, ...rest: any];
-}
+	| 'getElementAttrs',
+	fileName: string,
+	...args: any[],
+];
+
+export type ResponseData = [
+	seq: number,
+	data: any,
+];
 
 export interface ProjectInfo {
 	name: string;
@@ -39,14 +46,9 @@ export async function startNamedPipeServer(
 	projectKind: ts.server.ProjectKind.Inferred | ts.server.ProjectKind.Configured
 ) {
 	const server = net.createServer(connection => {
-		connection.on('data', data => {
-			const text = data.toString();
-			if (text === 'ping') {
-				connection.write('pong');
-				return;
-			}
-			const request: Request = JSON.parse(text);
-			const fileName = request.args[0];
+		connection.on('data', text => {
+			const json = text.toString();
+			const [seq, requestType, ...args]: RequestData = JSON.parse(json);
 			const requestContext: RequestContext = {
 				typescript: ts,
 				languageService: info.languageService,
@@ -55,68 +57,70 @@ export async function startNamedPipeServer(
 				isTsPlugin: true,
 				getFileId: (fileName: string) => fileName,
 			};
-			if (request.type === 'containsFile') {
-				sendResponse(
-					info.project.containsFile(ts.server.toNormalizedPath(fileName))
-				);
-			}
-			else if (request.type === 'projectInfo') {
+			if (requestType === 'projectInfo') {
 				sendResponse({
 					name: info.project.getProjectName(),
 					kind: info.project.projectKind,
 					currentDirectory: info.project.getCurrentDirectory(),
 				} satisfies ProjectInfo);
+				return;
 			}
-			else if (request.type === 'collectExtractProps') {
-				const result = collectExtractProps.apply(requestContext, request.args as any);
+			else if (requestType === 'containsFile') {
+				sendResponse(
+					info.project.containsFile(ts.server.toNormalizedPath(args[0]))
+				);
+			}
+			else if (requestType === 'collectExtractProps') {
+				const result = collectExtractProps.apply(requestContext, args as any);
 				sendResponse(result);
 			}
-			else if (request.type === 'getImportPathForFile') {
-				const result = getImportPathForFile.apply(requestContext, request.args as any);
+			else if (requestType === 'getImportPathForFile') {
+				const result = getImportPathForFile.apply(requestContext, args as any);
 				sendResponse(result);
 			}
-			else if (request.type === 'getPropertiesAtLocation') {
-				const result = getPropertiesAtLocation.apply(requestContext, request.args as any);
+			else if (requestType === 'getPropertiesAtLocation') {
+				const result = getPropertiesAtLocation.apply(requestContext, args as any);
 				sendResponse(result);
 			}
-			else if (request.type === 'getQuickInfoAtPosition') {
-				const result = getQuickInfoAtPosition.apply(requestContext, request.args as any);
+			else if (requestType === 'getQuickInfoAtPosition') {
+				const result = getQuickInfoAtPosition.apply(requestContext, args as any);
 				sendResponse(result);
 			}
 			// Component Infos
-			else if (request.type === 'getComponentProps') {
-				const result = getComponentProps.apply(requestContext, request.args as any);
+			else if (requestType === 'getComponentProps') {
+				const result = getComponentProps.apply(requestContext, args as any);
 				sendResponse(result);
 			}
-			else if (request.type === 'getComponentEvents') {
-				const result = getComponentEvents.apply(requestContext, request.args as any);
+			else if (requestType === 'getComponentEvents') {
+				const result = getComponentEvents.apply(requestContext, args as any);
 				sendResponse(result);
 			}
-			else if (request.type === 'getTemplateContextProps') {
-				const result = getTemplateContextProps.apply(requestContext, request.args as any);
+			else if (requestType === 'getTemplateContextProps') {
+				const result = getTemplateContextProps.apply(requestContext, args as any);
 				sendResponse(result);
 			}
-			else if (request.type === 'getComponentNames') {
-				const result = getComponentNames.apply(requestContext, request.args as any);
+			else if (requestType === 'getComponentNames') {
+				const result = getComponentNames.apply(requestContext, args as any);
 				sendResponse(result);
 			}
-			else if (request.type === 'getElementAttrs') {
-				const result = getElementAttrs.apply(requestContext, request.args as any);
+			else if (requestType === 'getElementAttrs') {
+				const result = getElementAttrs.apply(requestContext, args as any);
 				sendResponse(result);
 			}
 			else {
-				console.warn('[Vue Named Pipe Server] Unknown request type:', request.type);
+				console.warn('[Vue Named Pipe Server] Unknown request:', json);
+				debugger;
+			}
+
+			function sendResponse(data: any | undefined) {
+				connection.write(JSON.stringify([seq, data ?? null]) + '\n\n');
 			}
 		});
 		connection.on('error', err => console.error('[Vue Named Pipe Server]', err.message));
-
-		function sendResponse(data: any | undefined) {
-			connection.write(JSON.stringify(data ?? null) + '\n\n');
-		}
 	});
 
-	for (let i = 0; i < 20; i++) {
-		const path = getNamedPipePath(projectKind, i);
+	for (let i = 0; i < 10; i++) {
+		const path = getServerPath(projectKind, i);
 		const socket = await connect(path, 100);
 		if (typeof socket === 'object') {
 			socket.end();
@@ -130,6 +134,43 @@ export async function startNamedPipeServer(
 			break;
 		}
 	}
+}
+
+function connect(namedPipePath: string, timeout?: number) {
+	return new Promise<net.Socket | 'error' | 'timeout'>(resolve => {
+		const socket = net.connect(namedPipePath);
+		if (timeout) {
+			socket.setTimeout(timeout);
+		}
+		const onConnect = () => {
+			cleanup();
+			resolve(socket);
+		};
+		const onError = (err: any) => {
+			if (err.code === 'ECONNREFUSED') {
+				try {
+					console.log('[Vue Named Pipe Client] Deleting:', namedPipePath);
+					fs.promises.unlink(namedPipePath);
+				} catch { }
+			}
+			cleanup();
+			resolve('error');
+			socket.end();
+		};
+		const onTimeout = () => {
+			cleanup();
+			resolve('timeout');
+			socket.end();
+		};
+		const cleanup = () => {
+			socket.off('connect', onConnect);
+			socket.off('error', onError);
+			socket.off('timeout', onTimeout);
+		};
+		socket.on('connect', onConnect);
+		socket.on('error', onError);
+		socket.on('timeout', onTimeout);
+	});
 }
 
 function tryListen(server: net.Server, namedPipePath: string) {

--- a/packages/typescript-plugin/lib/server.ts
+++ b/packages/typescript-plugin/lib/server.ts
@@ -10,9 +10,7 @@ import { getQuickInfoAtPosition } from './requests/getQuickInfoAtPosition';
 import type { RequestContext } from './requests/types';
 import { getServerPath } from './utils';
 
-export type RequestData = [
-	seq: number,
-	type: 'containsFile'
+export type RequestType = 'containsFile'
 	| 'projectInfo'
 	| 'collectExtractProps'
 	| 'getImportPathForFile'
@@ -22,14 +20,25 @@ export type RequestData = [
 	| 'getComponentProps'
 	| 'getComponentEvents'
 	| 'getTemplateContextProps'
-	| 'getComponentNames'
-	| 'getElementAttrs',
+	// | 'getComponentNames'
+	| 'getElementAttrs'
+	| 'subscribeComponentNames';
+
+export type RequestData = [
+	seq: number,
+	type: RequestType,
 	fileName: string,
 	...args: any[],
 ];
 
 export type ResponseData = [
 	seq: number,
+	data: any,
+];
+
+export type NotificationData = [
+	type: 'componentNamesUpdated',
+	fileName: string,
 	data: any,
 ];
 
@@ -45,7 +54,18 @@ export async function startNamedPipeServer(
 	language: Language<string>,
 	projectKind: ts.server.ProjectKind.Inferred | ts.server.ProjectKind.Configured
 ) {
+	let lastProjectVersion = info.project.getProjectVersion();
+
+	const requestContext: RequestContext = {
+		typescript: ts,
+		languageService: info.languageService,
+		languageServiceHost: info.languageServiceHost,
+		language: language,
+		isTsPlugin: true,
+		getFileId: (fileName: string) => fileName,
+	};
 	const dataChunks: Buffer[] = [];
+	const componentNamesSubscriptions = new Map<string, [ReturnType<typeof getComponentNames>, Set<net.Socket>]>();
 	const server = net.createServer(connection => {
 		connection.on('data', buffer => {
 			dataChunks.push(buffer);
@@ -59,72 +79,7 @@ export async function startNamedPipeServer(
 						continue;
 					}
 					try {
-						const [seq, requestType, ...args]: RequestData = JSON.parse(json);
-						const requestContext: RequestContext = {
-							typescript: ts,
-							languageService: info.languageService,
-							languageServiceHost: info.languageServiceHost,
-							language: language,
-							isTsPlugin: true,
-							getFileId: (fileName: string) => fileName,
-						};
-						if (requestType === 'projectInfo') {
-							sendResponse({
-								name: info.project.getProjectName(),
-								kind: info.project.projectKind,
-								currentDirectory: info.project.getCurrentDirectory(),
-							} satisfies ProjectInfo);
-						}
-						else if (requestType === 'containsFile') {
-							sendResponse(
-								info.project.containsFile(ts.server.toNormalizedPath(args[0]))
-							);
-						}
-						else if (requestType === 'collectExtractProps') {
-							const result = collectExtractProps.apply(requestContext, args as any);
-							sendResponse(result);
-						}
-						else if (requestType === 'getImportPathForFile') {
-							const result = getImportPathForFile.apply(requestContext, args as any);
-							sendResponse(result);
-						}
-						else if (requestType === 'getPropertiesAtLocation') {
-							const result = getPropertiesAtLocation.apply(requestContext, args as any);
-							sendResponse(result);
-						}
-						else if (requestType === 'getQuickInfoAtPosition') {
-							const result = getQuickInfoAtPosition.apply(requestContext, args as any);
-							sendResponse(result);
-						}
-						// Component Infos
-						else if (requestType === 'getComponentProps') {
-							const result = getComponentProps.apply(requestContext, args as any);
-							sendResponse(result);
-						}
-						else if (requestType === 'getComponentEvents') {
-							const result = getComponentEvents.apply(requestContext, args as any);
-							sendResponse(result);
-						}
-						else if (requestType === 'getTemplateContextProps') {
-							const result = getTemplateContextProps.apply(requestContext, args as any);
-							sendResponse(result);
-						}
-						else if (requestType === 'getComponentNames') {
-							const result = getComponentNames.apply(requestContext, args as any);
-							sendResponse(result);
-						}
-						else if (requestType === 'getElementAttrs') {
-							const result = getElementAttrs.apply(requestContext, args as any);
-							sendResponse(result);
-						}
-						else {
-							console.warn('[Vue Named Pipe Server] Unknown request:', json);
-							debugger;
-						}
-
-						function sendResponse(data: any | undefined) {
-							connection.write(JSON.stringify([seq, data ?? null]) + '\n\n');
-						}
+						onRequest(connection, JSON.parse(json));
 					} catch (e) {
 						console.error('[Vue Named Pipe Server] JSON parse error:', e);
 					}
@@ -147,6 +102,103 @@ export async function startNamedPipeServer(
 		const success = await tryListen(server, path);
 		if (success) {
 			break;
+		}
+	}
+
+	setInterval(() => {
+		const projectVersion = info.project.getProjectVersion();
+		if (lastProjectVersion !== projectVersion) {
+			lastProjectVersion = projectVersion;
+			onProjectUpdate();
+		}
+	}, 500);
+
+	function onProjectUpdate() {
+		for (const [fileName, [oldComponentNames, subscriptions]] of componentNamesSubscriptions) {
+			const connections = [...subscriptions].filter(connection => !connection.destroyed);
+			if (connections.length) {
+				const script = info.project.getScriptInfo(fileName);
+				if (script?.isScriptOpen()) {
+					const newComponentNames = getComponentNames.apply(requestContext, [fileName]);
+					if (JSON.stringify(oldComponentNames) !== JSON.stringify(newComponentNames)) {
+						// Update cache
+						componentNamesSubscriptions.set(fileName, [newComponentNames, subscriptions]);
+						// Notify
+						for (const connection of connections) {
+							notify(connection, 'componentNamesUpdated', fileName, newComponentNames);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	function notify(connection: net.Socket, type: NotificationData[0], fileName: string, data: any) {
+		connection.write(JSON.stringify([type, fileName, data] satisfies NotificationData) + '\n\n');
+	}
+
+	function onRequest(connection: net.Socket, [seq, requestType, ...args]: RequestData) {
+		if (requestType === 'projectInfo') {
+			sendResponse({
+				name: info.project.getProjectName(),
+				kind: info.project.projectKind,
+				currentDirectory: info.project.getCurrentDirectory(),
+			} satisfies ProjectInfo);
+		}
+		else if (requestType === 'containsFile') {
+			sendResponse(
+				info.project.containsFile(ts.server.toNormalizedPath(args[0]))
+			);
+		}
+		else if (requestType === 'collectExtractProps') {
+			const result = collectExtractProps.apply(requestContext, args as any);
+			sendResponse(result);
+		}
+		else if (requestType === 'getImportPathForFile') {
+			const result = getImportPathForFile.apply(requestContext, args as any);
+			sendResponse(result);
+		}
+		else if (requestType === 'getPropertiesAtLocation') {
+			const result = getPropertiesAtLocation.apply(requestContext, args as any);
+			sendResponse(result);
+		}
+		else if (requestType === 'getQuickInfoAtPosition') {
+			const result = getQuickInfoAtPosition.apply(requestContext, args as any);
+			sendResponse(result);
+		}
+		else if (requestType === 'getComponentProps') {
+			const result = getComponentProps.apply(requestContext, args as any);
+			sendResponse(result);
+		}
+		else if (requestType === 'getComponentEvents') {
+			const result = getComponentEvents.apply(requestContext, args as any);
+			sendResponse(result);
+		}
+		else if (requestType === 'getTemplateContextProps') {
+			const result = getTemplateContextProps.apply(requestContext, args as any);
+			sendResponse(result);
+		}
+		else if (requestType === 'getElementAttrs') {
+			const result = getElementAttrs.apply(requestContext, args as any);
+			sendResponse(result);
+		}
+		else if (requestType === 'subscribeComponentNames') {
+			let subscriptions = componentNamesSubscriptions.get(args[0]);
+			if (!subscriptions) {
+				const result = getComponentNames.apply(requestContext, args as any);
+				subscriptions = [result, new Set()];
+				componentNamesSubscriptions.set(args[0], subscriptions);
+			}
+			subscriptions[1].add(connection);
+			sendResponse(subscriptions[0]);
+		}
+		else {
+			console.warn('[Vue Named Pipe Server] Unknown request:', requestType);
+			debugger;
+		}
+
+		function sendResponse(data: any | undefined) {
+			connection.write(JSON.stringify([seq, data ?? null]) + '\n\n');
 		}
 	}
 }

--- a/packages/typescript-plugin/lib/server.ts
+++ b/packages/typescript-plugin/lib/server.ts
@@ -129,7 +129,7 @@ export async function startNamedPipeServer(
 			if (!script?.isScriptOpen()) {
 				continue;
 			}
-			await sleep(0);
+			await sleep(10);
 			if (token?.isCancellationRequested()) {
 				return;
 			}
@@ -228,7 +228,7 @@ export async function startNamedPipeServer(
 			commentMarkdown?: string;
 		}[]> = {};
 		for (const component of getComponentNames.apply(requestContext, [fileName]) ?? []) {
-			await sleep(0);
+			await sleep(10);
 			if (token?.isCancellationRequested()) {
 				return;
 			}

--- a/packages/typescript-plugin/lib/server.ts
+++ b/packages/typescript-plugin/lib/server.ts
@@ -63,7 +63,6 @@ export async function startNamedPipeServer(
 					kind: info.project.projectKind,
 					currentDirectory: info.project.getCurrentDirectory(),
 				} satisfies ProjectInfo);
-				return;
 			}
 			else if (requestType === 'containsFile') {
 				sendResponse(

--- a/packages/typescript-plugin/lib/server.ts
+++ b/packages/typescript-plugin/lib/server.ts
@@ -20,7 +20,6 @@ export type RequestType = 'containsFile'
 	| 'getComponentProps'
 	| 'getComponentEvents'
 	| 'getTemplateContextProps'
-	// | 'getComponentNames'
 	| 'getElementAttrs'
 	| 'subscribeAllComponentAndProps';
 

--- a/packages/typescript-plugin/lib/utils.ts
+++ b/packages/typescript-plugin/lib/utils.ts
@@ -13,22 +13,14 @@ if (version === '2.1.10') {
 }
 const platform = os.platform();
 const pipeDir = platform === 'win32'
-	? `\\\\.\\pipe`
-	: `/tmp`;
-const toFullPath = (file: string) => {
-	if (platform === 'win32') {
-		return pipeDir + '\\' + file;
-	}
-	else {
-		return pipeDir + '/' + file;
-	}
-};
+	? `\\\\.\\pipe\\`
+	: `/tmp/`;
 
 export function getServerPath(kind: ts.server.ProjectKind, id: number) {
 	if (kind === 1 satisfies ts.server.ProjectKind.Configured) {
-		return toFullPath(`vue-named-pipe-${version}-configured-${id}`);
+		return `${pipeDir}vue-named-pipe-${version}-configured-${id}`;
 	} else {
-		return toFullPath(`vue-named-pipe-${version}-inferred-${id}`);
+		return `${pipeDir}vue-named-pipe-${version}-inferred-${id}`;
 	}
 }
 

--- a/packages/typescript-plugin/lib/utils.ts
+++ b/packages/typescript-plugin/lib/utils.ts
@@ -161,13 +161,6 @@ class NamedPipeServer {
 				this.requestHandlers.delete(seq);
 				resolve(data);
 			});
-			// setTimeout(() => {
-			// 	if (this.requestHandlers.has(seq)) {
-			// 		console.error(`[${seq}] ${requestType} ${fileName} timeout`);
-			// 		this.requestHandlers.delete(seq);
-			// 		resolve(undefined);
-			// 	}
-			// }, 5000);
 			this.socket!.write(JSON.stringify([seq, requestType, fileName, ...args] satisfies RequestData) + '\n\n');
 		});
 	}

--- a/packages/typescript-plugin/lib/utils.ts
+++ b/packages/typescript-plugin/lib/utils.ts
@@ -7,7 +7,10 @@ import type { ProjectInfo, RequestData, ResponseData } from './server';
 
 export { TypeScriptProjectHost } from '@volar/typescript';
 
-const { version } = require('../package.json');
+let { version } = require('../package.json');
+if (version === '2.1.10') {
+	version += '-dev';
+}
 const platform = os.platform();
 const pipeDir = platform === 'win32'
 	? `\\\\.\\pipe`

--- a/packages/typescript-plugin/lib/utils.ts
+++ b/packages/typescript-plugin/lib/utils.ts
@@ -161,13 +161,13 @@ class NamedPipeServer {
 				this.requestHandlers.delete(seq);
 				resolve(data);
 			});
-			setTimeout(() => {
-				if (this.requestHandlers.has(seq)) {
-					console.error(`[${seq}] ${requestType} ${fileName} timeout`);
-					this.requestHandlers.delete(seq);
-					resolve(undefined);
-				}
-			}, 5000);
+			// setTimeout(() => {
+			// 	if (this.requestHandlers.has(seq)) {
+			// 		console.error(`[${seq}] ${requestType} ${fileName} timeout`);
+			// 		this.requestHandlers.delete(seq);
+			// 		resolve(undefined);
+			// 	}
+			// }, 5000);
 			this.socket!.write(JSON.stringify([seq, requestType, fileName, ...args] satisfies RequestData) + '\n\n');
 		});
 	}

--- a/packages/typescript-plugin/lib/utils.ts
+++ b/packages/typescript-plugin/lib/utils.ts
@@ -3,7 +3,7 @@ import * as net from 'node:net';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type * as ts from 'typescript';
-import type { ProjectInfo, Request } from './server';
+import type { ProjectInfo, RequestData, ResponseData } from './server';
 
 export { TypeScriptProjectHost } from '@volar/typescript';
 
@@ -20,194 +20,176 @@ const toFullPath = (file: string) => {
 		return pipeDir + '/' + file;
 	}
 };
-const configuredNamedPipePathPrefix = toFullPath(`vue-named-pipe-${version}-configured-`);
-const inferredNamedPipePathPrefix = toFullPath(`vue-named-pipe-${version}-inferred-`);
-const pipes = new Map<string, 'unknown' | 'ready'>();
+
+export function getServerPath(kind: ts.server.ProjectKind, id: number) {
+	if (kind === 1 satisfies ts.server.ProjectKind.Configured) {
+		return toFullPath(`vue-named-pipe-${version}-configured-${id}`);
+	} else {
+		return toFullPath(`vue-named-pipe-${version}-inferred-${id}`);
+	}
+}
+
+class NamedPipeServer {
+	path: string;
+	connecting = false;
+	projectInfo?: ProjectInfo;
+	containsFileRequests = new Map<string, Promise<boolean | undefined | null>>();
+
+	constructor(kind: ts.server.ProjectKind, id: number) {
+		this.path = getServerPath(kind, id);
+	}
+
+	containsFile(fileName: string) {
+		if (this.projectInfo) {
+			const containsFile = this.request<boolean>('containsFile', fileName)
+				?? this.request<boolean>('containsFile', fileName);
+			this.containsFileRequests.set(fileName, containsFile);
+			return containsFile;
+		}
+	}
+
+	update() {
+		if (!this.connecting && !this.projectInfo) {
+			this.connecting = true;
+			this.connect();
+		}
+	}
+
+	connect() {
+		this.socket = net.connect(this.path);
+		this.socket.on('data', this.onData.bind(this));
+		this.socket.on('connect', async () => {
+			const projectInfo = await this.request<ProjectInfo>('projectInfo', '');
+			if (projectInfo) {
+				console.log('TSServer project ready:', projectInfo.name);
+				this.projectInfo = projectInfo;
+				this.containsFileRequests.clear();
+			} else {
+				this.close();
+			}
+		});
+		this.socket.on('error', err => {
+			if ((err as any).code === 'ECONNREFUSED') {
+				try {
+					console.log('Deleteing invalid named pipe file:', this.path);
+					fs.promises.unlink(this.path);
+				} catch { }
+			}
+			this.close();
+		});
+		this.socket.on('timeout', () => {
+			this.close();
+		});
+	}
+
+	close() {
+		this.connecting = false;
+		this.projectInfo = undefined;
+		this.socket?.end();
+	}
+
+	socket?: net.Socket;
+	seq = 0;
+	dataChunks: Buffer[] = [];
+	requestHandlers: Map<number, (res: any) => void> = new Map();
+
+	onData(chunk: Buffer) {
+		this.dataChunks.push(chunk);
+		const data = Buffer.concat(this.dataChunks);
+		const text = data.toString();
+		if (text.endsWith('\n\n')) {
+			const results = text.split('\n\n');
+			for (let result of results) {
+				result = result.trim();
+				if (!result) {
+					continue;
+				}
+				try {
+					const [seq, res]: ResponseData = JSON.parse(result.trim());
+					this.requestHandlers.get(seq)?.(res);
+				} catch (e) {
+					console.error('JSON parse error:', e);
+				}
+			}
+		}
+	}
+
+	request<T>(requestType: RequestData[1], fileName: string, ...args: any[]) {
+		return new Promise<T>(resolve => {
+			const seq = this.seq++;
+			this.requestHandlers.set(seq, data => {
+				this.requestHandlers.delete(seq);
+				resolve(data);
+			});
+			this.socket!.write(JSON.stringify([seq, requestType, fileName, ...args] satisfies RequestData) + '\n\n');
+		});
+	}
+}
+
+export const configuredServers: NamedPipeServer[] = [];
+export const inferredServers: NamedPipeServer[] = [];
+
+for (let i = 0; i < 10; i++) {
+	configuredServers.push(new NamedPipeServer(1 satisfies ts.server.ProjectKind.Configured, i));
+	inferredServers.push(new NamedPipeServer(0 satisfies ts.server.ProjectKind.Inferred, i));
+}
 
 export const onSomePipeReadyCallbacks: (() => void)[] = [];
 
-function waitingForNamedPipeServerReady(namedPipePath: string) {
-	const socket = net.connect(namedPipePath);
-	const start = Date.now();
-	socket.on('connect', () => {
-		console.log('[Vue Named Pipe Client] Connected:', namedPipePath, 'in', (Date.now() - start) + 'ms');
-		socket.write('ping');
-	});
-	socket.on('data', () => {
-		console.log('[Vue Named Pipe Client] Ready:', namedPipePath, 'in', (Date.now() - start) + 'ms');
-		pipes.set(namedPipePath, 'ready');
-		socket.end();
-		onSomePipeReadyCallbacks.forEach(cb => cb());
-	});
-	socket.on('error', err => {
-		if ((err as any).code === 'ECONNREFUSED') {
-			try {
-				console.log('[Vue Named Pipe Client] Deleting:', namedPipePath);
-				fs.promises.unlink(namedPipePath);
-			} catch { }
-		}
-		pipes.delete(namedPipePath);
-		socket.end();
-	});
-	socket.on('timeout', () => {
-		pipes.delete(namedPipePath);
-		socket.end();
-	});
-}
-
-export function getNamedPipePath(projectKind: ts.server.ProjectKind.Configured | ts.server.ProjectKind.Inferred, key: number) {
-	return projectKind === 1 satisfies ts.server.ProjectKind.Configured
-		? `${configuredNamedPipePathPrefix}${key}`
-		: `${inferredNamedPipePathPrefix}${key}`;
-}
-
-export function getReadyNamedPipePaths() {
-	const configuredPipes: string[] = [];
-	const inferredPipes: string[] = [];
-	for (let i = 0; i < 20; i++) {
-		const configuredPipe = getNamedPipePath(1 satisfies ts.server.ProjectKind.Configured, i);
-		const inferredPipe = getNamedPipePath(0 satisfies ts.server.ProjectKind.Inferred, i);
-		if (pipes.get(configuredPipe) === 'ready') {
-			configuredPipes.push(configuredPipe);
-		}
-		else if (!pipes.has(configuredPipe)) {
-			pipes.set(configuredPipe, 'unknown');
-			waitingForNamedPipeServerReady(configuredPipe);
-		}
-		if (pipes.get(inferredPipe) === 'ready') {
-			inferredPipes.push(inferredPipe);
-		}
-		else if (!pipes.has(inferredPipe)) {
-			pipes.set(inferredPipe, 'unknown');
-			waitingForNamedPipeServerReady(inferredPipe);
-		}
+export async function getBestServer(fileName: string) {
+	for (const server of configuredServers) {
+		server.update();
 	}
-	return {
-		configured: configuredPipes,
-		inferred: inferredPipes,
-	};
-}
 
-export function connect(namedPipePath: string, timeout?: number) {
-	return new Promise<net.Socket | 'error' | 'timeout'>(resolve => {
-		const socket = net.connect(namedPipePath);
-		if (timeout) {
-			socket.setTimeout(timeout);
-		}
-		const onConnect = () => {
-			cleanup();
-			resolve(socket);
-		};
-		const onError = (err: any) => {
-			if (err.code === 'ECONNREFUSED') {
-				try {
-					console.log('[Vue Named Pipe Client] Deleting:', namedPipePath);
-					fs.promises.unlink(namedPipePath);
-				} catch { }
-			}
-			pipes.delete(namedPipePath);
-			cleanup();
-			resolve('error');
-			socket.end();
-		};
-		const onTimeout = () => {
-			cleanup();
-			resolve('timeout');
-			socket.end();
-		};
-		const cleanup = () => {
-			socket.off('connect', onConnect);
-			socket.off('error', onError);
-			socket.off('timeout', onTimeout);
-		};
-		socket.on('connect', onConnect);
-		socket.on('error', onError);
-		socket.on('timeout', onTimeout);
-	});
-}
-
-export async function searchNamedPipeServerForFile(fileName: string) {
-	const paths = await getReadyNamedPipePaths();
-
-	const configuredServers = (await Promise.all(
-		paths.configured.map(async path => {
-			// Find existing servers
-			const socket = await connect(path);
-			if (typeof socket !== 'object') {
-				return;
-			}
-
-			// Find servers containing the current file
-			const containsFile = await sendRequestWorker<boolean>({ type: 'containsFile', args: [fileName] }, socket);
-			if (!containsFile) {
-				socket.end();
-				return;
-			}
-
-			// Get project info for each server
-			const projectInfo = await sendRequestWorker<ProjectInfo>({ type: 'projectInfo', args: [fileName] }, socket);
+	let servers = (await Promise.all(
+		configuredServers.map(async server => {
+			const projectInfo = server.projectInfo;
 			if (!projectInfo) {
-				socket.end();
 				return;
 			}
-
-			return {
-				socket,
-				projectInfo,
-			};
+			const containsFile = await server.containsFile(fileName);
+			if (!containsFile) {
+				return;
+			}
+			return server;
 		})
 	)).filter(server => !!server);
 
 	// Sort servers by tsconfig
-	configuredServers.sort((a, b) => sortTSConfigs(fileName, a.projectInfo.name, b.projectInfo.name));
+	servers.sort((a, b) => sortTSConfigs(fileName, a.projectInfo!.name, b.projectInfo!.name));
 
-	if (configuredServers.length) {
-		// Close all but the first server
-		for (let i = 1; i < configuredServers.length; i++) {
-			configuredServers[i].socket.end();
-		}
+	if (servers.length) {
 		// Return the first server
-		return configuredServers[0];
+		return servers[0];
 	}
 
-	const inferredServers = (await Promise.all(
-		paths.inferred.map(async namedPipePath => {
-			// Find existing servers
-			const socket = await connect(namedPipePath);
-			if (typeof socket !== 'object') {
-				return;
-			}
+	for (const server of inferredServers) {
+		server.update();
+	}
 
-			// Get project info for each server
-			const projectInfo = await sendRequestWorker<ProjectInfo>({ type: 'projectInfo', args: [fileName] }, socket);
+	servers = (await Promise.all(
+		inferredServers.map(server => {
+			const projectInfo = server.projectInfo;
 			if (!projectInfo) {
-				socket.end();
 				return;
 			}
-
 			// Check if the file is in the project's directory
-			if (!path.relative(projectInfo.currentDirectory, fileName).startsWith('..')) {
-				return {
-					socket,
-					projectInfo,
-				};
+			if (path.relative(projectInfo.currentDirectory, fileName).startsWith('..')) {
+				return;
 			}
+			return server;
 		})
 	)).filter(server => !!server);
 
 	// Sort servers by directory
-	inferredServers.sort((a, b) =>
-		b.projectInfo.currentDirectory.replace(/\\/g, '/').split('/').length
-		- a.projectInfo.currentDirectory.replace(/\\/g, '/').split('/').length
+	servers.sort((a, b) =>
+		b.projectInfo!.currentDirectory.replace(/\\/g, '/').split('/').length
+		- a.projectInfo!.currentDirectory.replace(/\\/g, '/').split('/').length
 	);
 
-	if (inferredServers.length) {
-		// Close all but the first server
-		for (let i = 1; i < inferredServers.length; i++) {
-			inferredServers[i].socket.end();
-		}
+	if (servers.length) {
 		// Return the first server
-		return inferredServers[0];
+		return servers[0];
 	}
 }
 
@@ -231,37 +213,4 @@ function sortTSConfigs(file: string, a: string, b: string) {
 function isFileInDir(fileName: string, dir: string) {
 	const relative = path.relative(dir, fileName);
 	return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
-}
-
-export function sendRequestWorker<T>(request: Request, socket: net.Socket) {
-	return new Promise<T | undefined | null>(resolve => {
-		let dataChunks: Buffer[] = [];
-		const onData = (chunk: Buffer) => {
-			dataChunks.push(chunk);
-			const data = Buffer.concat(dataChunks);
-			const text = data.toString();
-			if (text.endsWith('\n\n')) {
-				let json = null;
-				try {
-					json = JSON.parse(text);
-				} catch (e) {
-					console.error('[Vue Named Pipe Client] Failed to parse response:', text);
-				}
-				cleanup();
-				resolve(json);
-			}
-		};
-		const onError = (err: any) => {
-			console.error('[Vue Named Pipe Client] Error:', err.message);
-			cleanup();
-			resolve(undefined);
-		};
-		const cleanup = () => {
-			socket.off('data', onData);
-			socket.off('error', onError);
-		};
-		socket.on('data', onData);
-		socket.on('error', onError);
-		socket.write(JSON.stringify(request));
-	});
 }

--- a/packages/typescript-plugin/lib/utils.ts
+++ b/packages/typescript-plugin/lib/utils.ts
@@ -64,6 +64,7 @@ class NamedPipeServer {
 				console.log('TSServer project ready:', projectInfo.name);
 				this.projectInfo = projectInfo;
 				this.containsFileRequests.clear();
+				onServerReady.forEach(cb => cb());
 			} else {
 				this.close();
 			}
@@ -128,13 +129,12 @@ class NamedPipeServer {
 
 export const configuredServers: NamedPipeServer[] = [];
 export const inferredServers: NamedPipeServer[] = [];
+export const onServerReady: (() => void)[] = [];
 
 for (let i = 0; i < 10; i++) {
 	configuredServers.push(new NamedPipeServer(1 satisfies ts.server.ProjectKind.Configured, i));
 	inferredServers.push(new NamedPipeServer(0 satisfies ts.server.ProjectKind.Inferred, i));
 }
-
-export const onSomePipeReadyCallbacks: (() => void)[] = [];
 
 export async function getBestServer(fileName: string) {
 	for (const server of configuredServers) {


### PR DESCRIPTION
- [x] Named pipe server search number dropped from 40 to 20
- [x] Instead of re-doing the server connect every time for every request, a valid server connect is retained and reused for all requests.
- [x] containsFile results are now cached.
- [x] Server status polling interval changed from 1 second to 2.5 seconds
- [x] Pushed by the named pipe server when component names/props change rather than pulled by the client everytime