### PR TITLE
fix(language-core): ignore ts errors in function-scoped declare expressions

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -321,6 +321,7 @@ function* generateMacros(
 	ctx: ScriptCodegenContext
 ): Generator<Code> {
 	if (options.vueCompilerOptions.target >= 3.3) {
+		yield `// @ts-ignore${newLine}`;
 		yield `declare const { `;
 		for (const macro of Object.keys(options.vueCompilerOptions.macros)) {
 			if (!ctx.bindingNames.has(macro)) {


### PR DESCRIPTION
https://github.com/twoslashes/twoslash/pull/62