### PR TITLE
feat(language-core): introduce options to control type inference of `$attrs`, `$el`, `$refs` and `$slots`

### DIFF
--- a/packages/language-core/lib/codegen/script/component.ts
+++ b/packages/language-core/lib/codegen/script/component.ts
@@ -39,14 +39,14 @@ export function* generateComponent(
 	}
 	if (
 		options.vueCompilerOptions.target >= 3.5
-		&& options.vueCompilerOptions.typedDollarRefs.expose
+		&& options.vueCompilerOptions.inferComponentDollarRefs
 		&& options.templateCodegen?.templateRefs.size
 	) {
 		yield `__typeRefs: {} as __VLS_TemplateRefs,${newLine}`;
 	}
 	if (
 		options.vueCompilerOptions.target >= 3.5
-		&& options.vueCompilerOptions.typedDollarEl.expose
+		&& options.vueCompilerOptions.inferComponentDollarEl
 		&& options.templateCodegen?.singleRootElType
 	) {
 		yield `__typeEl: {} as __VLS_RootEl,${newLine}`;

--- a/packages/language-core/lib/codegen/script/component.ts
+++ b/packages/language-core/lib/codegen/script/component.ts
@@ -37,10 +37,18 @@ export function* generateComponent(
 		}
 		yield* generatePropsOption(options, ctx, scriptSetup, scriptSetupRanges, !!emitOptionCodes.length, true);
 	}
-	if (options.vueCompilerOptions.target >= 3.5 && options.templateCodegen?.templateRefs.size) {
+	if (
+		options.vueCompilerOptions.target >= 3.5
+		&& options.vueCompilerOptions.typedDollarRefs.expose
+		&& options.templateCodegen?.templateRefs.size
+	) {
 		yield `__typeRefs: {} as __VLS_TemplateRefs,${newLine}`;
 	}
-	if (options.vueCompilerOptions.target >= 3.5 && options.templateCodegen?.singleRootElType) {
+	if (
+		options.vueCompilerOptions.target >= 3.5
+		&& options.vueCompilerOptions.typedDollarEl.expose
+		&& options.templateCodegen?.singleRootElType
+	) {
 		yield `__typeEl: {} as __VLS_RootEl,${newLine}`;
 	}
 	if (options.sfc.script && options.scriptRanges?.exportDefault?.args) {

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -171,7 +171,7 @@ function* generateSetupFunction(
 			]);
 		}
 	}
-	if (options.vueCompilerOptions.typedDollarAttrs.self) {
+	if (options.vueCompilerOptions.inferTemplateDollarAttrs) {
 		for (const { callExp } of scriptSetupRanges.useAttrs) {
 			setupCodeModifies.push([
 				[`(`],
@@ -212,7 +212,7 @@ function* generateSetupFunction(
 			]);
 		}
 	}
-	if (options.vueCompilerOptions.typedDollarSlots.self) {
+	if (options.vueCompilerOptions.inferTemplateDollarSlots) {
 		for (const { callExp } of scriptSetupRanges.useSlots) {
 			setupCodeModifies.push([
 				[`(`],

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -171,16 +171,18 @@ function* generateSetupFunction(
 			]);
 		}
 	}
-	for (const { callExp } of scriptSetupRanges.useAttrs) {
-		setupCodeModifies.push([
-			[`(`],
-			callExp.start,
-			callExp.start
-		], [
-			[` as typeof __VLS_special.$attrs)`],
-			callExp.end,
-			callExp.end
-		]);
+	if (options.vueCompilerOptions.typedDollarAttrs.self) {
+		for (const { callExp } of scriptSetupRanges.useAttrs) {
+			setupCodeModifies.push([
+				[`(`],
+				callExp.start,
+				callExp.start
+			], [
+				[` as typeof __VLS_dollars.$attrs)`],
+				callExp.end,
+				callExp.end
+			]);
+		}
 	}
 	for (const { callExp, exp, arg } of scriptSetupRanges.useCssModule) {
 		setupCodeModifies.push([
@@ -210,16 +212,18 @@ function* generateSetupFunction(
 			]);
 		}
 	}
-	for (const { callExp } of scriptSetupRanges.useSlots) {
-		setupCodeModifies.push([
-			[`(`],
-			callExp.start,
-			callExp.start
-		], [
-			[` as typeof __VLS_special.$slots)`],
-			callExp.end,
-			callExp.end
-		]);
+	if (options.vueCompilerOptions.typedDollarSlots.self) {
+		for (const { callExp } of scriptSetupRanges.useSlots) {
+			setupCodeModifies.push([
+				[`(`],
+				callExp.start,
+				callExp.start
+			], [
+				[` as typeof __VLS_dollars.$slots)`],
+				callExp.end,
+				callExp.end
+			]);
+		}
 	}
 	const isTs = options.lang !== 'js' && options.lang !== 'jsx';
 	for (const { callExp, exp, arg } of scriptSetupRanges.useTemplateRef) {

--- a/packages/language-core/lib/codegen/template/context.ts
+++ b/packages/language-core/lib/codegen/template/context.ts
@@ -45,7 +45,7 @@ export function createTemplateCodegenContext(options: Pick<TemplateCodegenOption
 
 	const hoistVars = new Map<string, string>();
 	const localVars = new Map<string, number>();
-	const specialVars = new Set<string>();
+	const dollarVars = new Set<string>();
 	const accessExternalVariables = new Map<string, Set<number>>();
 	const slots: {
 		name: string;
@@ -83,7 +83,7 @@ export function createTemplateCodegenContext(options: Pick<TemplateCodegenOption
 		resolveCodeFeatures,
 		slots,
 		dynamicSlots,
-		specialVars,
+		dollarVars,
 		accessExternalVariables,
 		lastGenericComment,
 		blockConditions,

--- a/packages/language-core/lib/codegen/template/index.ts
+++ b/packages/language-core/lib/codegen/template/index.ts
@@ -34,11 +34,20 @@ export function* generateTemplate(options: TemplateCodegenOptions): Generator<Co
 	if (options.propsAssignName) {
 		ctx.addLocalVariable(options.propsAssignName);
 	}
+
 	const slotsPropertyName = getSlotsPropertyName(options.vueCompilerOptions.target);
-	ctx.specialVars.add(slotsPropertyName);
-	ctx.specialVars.add('$attrs');
-	ctx.specialVars.add('$refs');
-	ctx.specialVars.add('$el');
+	if (options.vueCompilerOptions.typedDollarSlots.self) {
+		ctx.dollarVars.add(slotsPropertyName);
+	}
+	if (options.vueCompilerOptions.typedDollarAttrs.self) {
+		ctx.dollarVars.add('$attrs');
+	}
+	if (options.vueCompilerOptions.typedDollarRefs.self) {
+		ctx.dollarVars.add('$refs');
+	}
+	if (options.vueCompilerOptions.typedDollarEl.self) {
+		ctx.dollarVars.add('$el');
+	}
 
 	if (options.template.ast) {
 		yield* generateTemplateChild(options, ctx, options.template.ast, undefined);
@@ -55,7 +64,7 @@ export function* generateTemplate(options: TemplateCodegenOptions): Generator<Co
 		['$el', yield* generateRootEl(ctx)]
 	];
 
-	yield `var __VLS_special!: {${newLine}`;
+	yield `var __VLS_dollars!: {${newLine}`;
 	for (const [name, type] of speicalTypes) {
 		yield `${name}: ${type}${endOfLine}`;
 	}
@@ -114,7 +123,7 @@ function* generateInheritedAttrs(
 	if (ctx.bindingAttrLocs.length) {
 		yield `[`;
 		for (const loc of ctx.bindingAttrLocs) {
-			yield `__VLS_special.`;
+			yield `__VLS_dollars.`;
 			yield [
 				loc.source,
 				'template',

--- a/packages/language-core/lib/codegen/template/index.ts
+++ b/packages/language-core/lib/codegen/template/index.ts
@@ -36,16 +36,16 @@ export function* generateTemplate(options: TemplateCodegenOptions): Generator<Co
 	}
 
 	const slotsPropertyName = getSlotsPropertyName(options.vueCompilerOptions.target);
-	if (options.vueCompilerOptions.typedDollarSlots.self) {
+	if (options.vueCompilerOptions.inferTemplateDollarSlots) {
 		ctx.dollarVars.add(slotsPropertyName);
 	}
-	if (options.vueCompilerOptions.typedDollarAttrs.self) {
+	if (options.vueCompilerOptions.inferTemplateDollarAttrs) {
 		ctx.dollarVars.add('$attrs');
 	}
-	if (options.vueCompilerOptions.typedDollarRefs.self) {
+	if (options.vueCompilerOptions.inferTemplateDollarRefs) {
 		ctx.dollarVars.add('$refs');
 	}
-	if (options.vueCompilerOptions.typedDollarEl.self) {
+	if (options.vueCompilerOptions.inferTemplateDollarEl) {
 		ctx.dollarVars.add('$el');
 	}
 

--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -134,7 +134,7 @@ function* forEachInterpolationSegment(
 			const curVar = ctxVars[i];
 			const nextVar = ctxVars[i + 1];
 
-			yield* generateVar(code, ctx.specialVars, destructuredPropNames, templateRefNames, curVar);
+			yield* generateVar(code, ctx.dollarVars, destructuredPropNames, templateRefNames, curVar);
 
 			if (nextVar.isShorthand) {
 				yield [code.slice(curVar.offset + curVar.text.length, nextVar.offset + nextVar.text.length), curVar.offset + curVar.text.length];
@@ -146,7 +146,7 @@ function* forEachInterpolationSegment(
 		}
 
 		const lastVar = ctxVars.at(-1)!;
-		yield* generateVar(code, ctx.specialVars, destructuredPropNames, templateRefNames, lastVar);
+		yield* generateVar(code, ctx.dollarVars, destructuredPropNames, templateRefNames, lastVar);
 		if (lastVar.offset + lastVar.text.length < code.length) {
 			yield [code.slice(lastVar.offset + lastVar.text.length), lastVar.offset + lastVar.text.length, 'endText'];
 		}
@@ -158,7 +158,7 @@ function* forEachInterpolationSegment(
 
 function* generateVar(
 	code: string,
-	specialVars: Set<string>,
+	dollarVars: Set<string>,
 	destructuredPropNames: Set<string> | undefined,
 	templateRefNames: Set<string> | undefined,
 	curVar: CtxVar
@@ -175,8 +175,8 @@ function* generateVar(
 		yield [`)`, undefined];
 	}
 	else {
-		if (specialVars.has(curVar.text)) {
-			yield [`__VLS_special.`, undefined];
+		if (dollarVars.has(curVar.text)) {
+			yield [`__VLS_dollars.`, undefined];
 		}
 		else if (!isDestructuredProp) {
 			yield [`__VLS_ctx.`, undefined];

--- a/packages/language-core/lib/plugins/file-md.ts
+++ b/packages/language-core/lib/plugins/file-md.ts
@@ -7,6 +7,7 @@ import { parse } from '../utils/parseSfc';
 
 const codeblockReg = /(`{3,})[\s\S]+?\1/g;
 const inlineCodeblockReg = /`[^\n`]+?`/g;
+const latexBlockReg = /(\${2,})[\s\S]+?\1/g;
 const scriptSetupReg = /\\\<[\s\S]+?\>\n?/g;
 const sfcBlockReg = /\<(script|style)\b[\s\S]*?\>([\s\S]*?)\<\/\1\>/g;
 const angleBracketReg = /\<\S*\:\S*\>/g;
@@ -39,6 +40,8 @@ const plugin: VueLanguagePlugin = ({ vueCompilerOptions }) => {
 				.replace(codeblockReg, (match, quotes) => quotes + ' '.repeat(match.length - quotes.length * 2) + quotes)
 				// inline code block
 				.replace(inlineCodeblockReg, match => `\`${' '.repeat(match.length - 2)}\``)
+				// latex block
+				.replace(latexBlockReg, (match, quotes) => quotes + ' '.repeat(match.length - quotes.length * 2) + quotes)
 				// # \<script setup>
 				.replace(scriptSetupReg, match => ' '.repeat(match.length))
 				// <<< https://vitepress.dev/guide/markdown#import-code-snippets

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -32,6 +32,12 @@ export interface VueCompilerOptions {
 	checkUnknownEvents: boolean;
 	checkUnknownDirectives: boolean;
 	checkUnknownComponents: boolean;
+	inferComponentDollarEl: boolean;
+	inferComponentDollarRefs: boolean;
+	inferTemplateDollarAttrs: boolean;
+	inferTemplateDollarEl: boolean;
+	inferTemplateDollarRefs: boolean;
+	inferTemplateDollarSlots: boolean;
 	skipTemplateCodegen: boolean;
 	fallthroughAttributes: boolean;
 	dataAttributes: string[];
@@ -52,20 +58,6 @@ export interface VueCompilerOptions {
 		useSlots: string[];
 		useTemplateRef: string[];
 	};
-	typedDollarAttrs: {
-		self: boolean;
-	},
-	typedDollarEl: {
-		self: boolean;
-		expose: boolean;
-	},
-	typedDollarRefs: {
-		self: boolean;
-		expose: boolean;
-	},
-	typedDollarSlots: {
-		self: boolean;
-	},
 	plugins: VueLanguagePlugin[];
 
 	// experimental

--- a/packages/language-core/lib/types.ts
+++ b/packages/language-core/lib/types.ts
@@ -52,6 +52,20 @@ export interface VueCompilerOptions {
 		useSlots: string[];
 		useTemplateRef: string[];
 	};
+	typedDollarAttrs: {
+		self: boolean;
+	},
+	typedDollarEl: {
+		self: boolean;
+		expose: boolean;
+	},
+	typedDollarRefs: {
+		self: boolean;
+		expose: boolean;
+	},
+	typedDollarSlots: {
+		self: boolean;
+	},
 	plugins: VueLanguagePlugin[];
 
 	// experimental

--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -219,6 +219,22 @@ export class CompilerOptionsResolver {
 				...defaults.composables,
 				...this.options.composables,
 			},
+			typedDollarAttrs: mergeTypedDollar(
+				this.options.typedDollarAttrs,
+				defaults.typedDollarAttrs
+			),
+			typedDollarEl: mergeTypedDollar(
+				this.options.typedDollarEl,
+				defaults.typedDollarEl
+			),
+			typedDollarRefs: mergeTypedDollar(
+				this.options.typedDollarRefs,
+				defaults.typedDollarRefs
+			),
+			typedDollarSlots: mergeTypedDollar(
+				this.options.typedDollarSlots,
+				defaults.typedDollarSlots
+			),
 			// https://github.com/vuejs/vue-next/blob/master/packages/compiler-dom/src/transforms/vModel.ts#L49-L51
 			// https://vuejs.org/guide/essentials/forms.html#form-input-bindings
 			experimentalModelPropName: Object.fromEntries(Object.entries(
@@ -349,4 +365,17 @@ export function setupGlobalTypes(rootDir: string, vueOptions: VueCompilerOptions
 		host.writeFile(globalTypesPath, globalTypesContents);
 		return { absolutePath: globalTypesPath };
 	} catch { }
+}
+
+function mergeTypedDollar<T>(
+	value: T | undefined,
+	defaults: { self: boolean; expose?: boolean; }
+) {
+	return (typeof value === "boolean" ? {
+		self: value,
+		expose: value
+	} : {
+		...defaults,
+		...value
+	}) as T;
 }

--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -288,6 +288,20 @@ export function getDefaultCompilerOptions(target = 99, lib = 'vue', strictTempla
 			useSlots: ['useSlots'],
 			useTemplateRef: ['useTemplateRef', 'templateRef'],
 		},
+		typedDollarAttrs: {
+			self: true
+		},
+		typedDollarEl: {
+			self: true,
+			expose: false
+		},
+		typedDollarRefs: {
+			self: true,
+			expose: false
+		},
+		typedDollarSlots: {
+			self: true
+		},
 		plugins: [],
 		experimentalDefinePropProposal: false,
 		experimentalResolveStyleCssClasses: 'scoped',

--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -219,22 +219,6 @@ export class CompilerOptionsResolver {
 				...defaults.composables,
 				...this.options.composables,
 			},
-			typedDollarAttrs: mergeTypedDollar(
-				this.options.typedDollarAttrs,
-				defaults.typedDollarAttrs
-			),
-			typedDollarEl: mergeTypedDollar(
-				this.options.typedDollarEl,
-				defaults.typedDollarEl
-			),
-			typedDollarRefs: mergeTypedDollar(
-				this.options.typedDollarRefs,
-				defaults.typedDollarRefs
-			),
-			typedDollarSlots: mergeTypedDollar(
-				this.options.typedDollarSlots,
-				defaults.typedDollarSlots
-			),
 			// https://github.com/vuejs/vue-next/blob/master/packages/compiler-dom/src/transforms/vModel.ts#L49-L51
 			// https://vuejs.org/guide/essentials/forms.html#form-input-bindings
 			experimentalModelPropName: Object.fromEntries(Object.entries(
@@ -282,6 +266,12 @@ export function getDefaultCompilerOptions(target = 99, lib = 'vue', strictTempla
 		checkUnknownEvents: strictTemplates,
 		checkUnknownDirectives: strictTemplates,
 		checkUnknownComponents: strictTemplates,
+		inferComponentDollarEl: false,
+		inferComponentDollarRefs: false,
+		inferTemplateDollarAttrs: false,
+		inferTemplateDollarEl: false,
+		inferTemplateDollarRefs: false,
+		inferTemplateDollarSlots: false,
 		skipTemplateCodegen: false,
 		fallthroughAttributes: false,
 		dataAttributes: [],
@@ -303,20 +293,6 @@ export function getDefaultCompilerOptions(target = 99, lib = 'vue', strictTempla
 			useCssModule: ['useCssModule'],
 			useSlots: ['useSlots'],
 			useTemplateRef: ['useTemplateRef', 'templateRef'],
-		},
-		typedDollarAttrs: {
-			self: true
-		},
-		typedDollarEl: {
-			self: true,
-			expose: false
-		},
-		typedDollarRefs: {
-			self: true,
-			expose: false
-		},
-		typedDollarSlots: {
-			self: true
 		},
 		plugins: [],
 		experimentalDefinePropProposal: false,
@@ -365,17 +341,4 @@ export function setupGlobalTypes(rootDir: string, vueOptions: VueCompilerOptions
 		host.writeFile(globalTypesPath, globalTypesContents);
 		return { absolutePath: globalTypesPath };
 	} catch { }
-}
-
-function mergeTypedDollar<T>(
-	value: T | undefined,
-	defaults: { self: boolean; expose?: boolean; }
-) {
-	return (typeof value === "boolean" ? {
-		self: value,
-		expose: value
-	} : {
-		...defaults,
-		...value
-	}) as T;
 }

--- a/packages/language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/language-core/schemas/vue-tsconfig.schema.json
@@ -85,11 +85,6 @@
 					"default": [ "aria-*" ],
 					"markdownDescription": "A glob matcher array that should always be recognizing as HTML Attributes rather than Component props. Attribute name will never convert to camelize case."
 				},
-				"plugins": {
-					"type": "array",
-					"default": [ ],
-					"markdownDescription": "Plugins to be used in the SFC compiler."
-				},
 				"optionsWrapper": {
 					"type": "array",
 					"default": [
@@ -118,6 +113,39 @@
 						"useSlots": [ "useSlots" ],
 						"useTemplateRef": [ "useTemplateRef", "templateRef" ]
 					}
+				},
+				"typedDollarAttrs": {
+					"type": ["boolean", "object"],
+					"default": {
+						"self": true,
+						"expose": false
+					}
+				},
+				"typedDollarEl": {
+					"type": ["boolean", "object"],
+					"default": {
+						"self": true,
+						"expose": false
+					}
+				},
+				"typedDollarRefs": {
+					"type": ["boolean", "object"],
+					"default": {
+						"self": true,
+						"expose": false
+					}
+				},
+				"typedDollarSlots": {
+					"type": ["boolean", "object"],
+					"default": {
+						"self": false,
+						"expose": true
+					}
+				},
+				"plugins": {
+					"type": "array",
+					"default": [ ],
+					"markdownDescription": "Plugins to be used in the SFC compiler."
 				},
 				"experimentalResolveStyleCssClasses": {
 					"enum": [

--- a/packages/language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/language-core/schemas/vue-tsconfig.schema.json
@@ -65,6 +65,36 @@
 					"default": false,
 					"markdownDescription": "Check unknown components. If not set, uses the 'strictTemplates' value."
 				},
+				"inferComponentDollarEl": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Infer `$el` type on the component instance."
+				},
+				"inferComponentDollarRefs": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Infer `$refs` type on the component instance."
+				},
+				"inferTemplateDollarAttrs": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Infer `$attrs` type in the template and the return type of `useAttrs`."
+				},
+				"inferTemplateDollarEl": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Infer `$el` type in the template."
+				},
+				"inferTemplateDollarRefs": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Infer `$refs` type in the template."
+				},
+				"inferTemplateDollarSlots": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Infer `$slots` type in the template and the return type of `useSlots`."
+				},
 				"skipTemplateCodegen": {
 					"type": "boolean",
 					"default": false,
@@ -113,36 +143,6 @@
 						"useSlots": [ "useSlots" ],
 						"useTemplateRef": [ "useTemplateRef", "templateRef" ]
 					}
-				},
-				"typedDollarAttrs": {
-					"type": ["boolean", "object"],
-					"default": {
-						"self": true
-					},
-					"markdownDescription": "\"self\" to control the type inference of `$attrs` in the template and the return type of `useAttrs`."
-				},
-				"typedDollarEl": {
-					"type": ["boolean", "object"],
-					"default": {
-						"self": true,
-						"expose": false
-					},
-					"markdownDescription": "\"self\" to control the type inference of `$el` in the template, \"expose\" to control the type inference of `$el` on the component instance."
-				},
-				"typedDollarRefs": {
-					"type": ["boolean", "object"],
-					"default": {
-						"self": true,
-						"expose": false
-					},
-					"markdownDescription": "\"self\" to control the type inference of `$refs` in the template, \"expose\" to control the type inference of `$refs` on the component instance."
-				},
-				"typedDollarSlots": {
-					"type": ["boolean", "object"],
-					"default": {
-						"self": true
-					},
-					"markdownDescription": "\"self\" to control the type inference of `$slots` in the template and the return type of `useSlots`."
 				},
 				"plugins": {
 					"type": "array",

--- a/packages/language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/language-core/schemas/vue-tsconfig.schema.json
@@ -119,7 +119,7 @@
 					"default": {
 						"self": true
 					},
-					"markdownDescription": "`self` to control the type inference of `$attrs` in the template and the return type of `useAttrs`."
+					"markdownDescription": "\"self\" to control the type inference of `$attrs` in the template and the return type of `useAttrs`."
 				},
 				"typedDollarEl": {
 					"type": ["boolean", "object"],
@@ -127,7 +127,7 @@
 						"self": true,
 						"expose": false
 					},
-					"markdownDescription": "`self` to control the type inference of `$el` in the template, `expose` to control the type inference of `$el` on the component instance."
+					"markdownDescription": "\"self\" to control the type inference of `$el` in the template, \"expose\" to control the type inference of `$el` on the component instance."
 				},
 				"typedDollarRefs": {
 					"type": ["boolean", "object"],
@@ -135,14 +135,14 @@
 						"self": true,
 						"expose": false
 					},
-					"markdownDescription": "`self` to control the type inference of `$refs` in the template, `expose` to control the type inference of `$refs` on the component instance."
+					"markdownDescription": "\"self\" to control the type inference of `$refs` in the template, \"expose\" to control the type inference of `$refs` on the component instance."
 				},
 				"typedDollarSlots": {
 					"type": ["boolean", "object"],
 					"default": {
 						"self": true
 					},
-					"markdownDescription": "`self` to control the type inference of `$slots` in the template and the return type of `useSlots`."
+					"markdownDescription": "\"self\" to control the type inference of `$slots` in the template and the return type of `useSlots`."
 				},
 				"plugins": {
 					"type": "array",

--- a/packages/language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/language-core/schemas/vue-tsconfig.schema.json
@@ -117,30 +117,32 @@
 				"typedDollarAttrs": {
 					"type": ["boolean", "object"],
 					"default": {
-						"self": true,
-						"expose": false
-					}
+						"self": true
+					},
+					"markdownDescription": "`self` to control the type inference of `$attrs` in the template and the return type of `useAttrs`."
 				},
 				"typedDollarEl": {
 					"type": ["boolean", "object"],
 					"default": {
 						"self": true,
 						"expose": false
-					}
+					},
+					"markdownDescription": "`self` to control the type inference of `$el` in the template, `expose` to control the type inference of `$el` on the component instance."
 				},
 				"typedDollarRefs": {
 					"type": ["boolean", "object"],
 					"default": {
 						"self": true,
 						"expose": false
-					}
+					},
+					"markdownDescription": "`self` to control the type inference of `$refs` in the template, `expose` to control the type inference of `$refs` on the component instance."
 				},
 				"typedDollarSlots": {
 					"type": ["boolean", "object"],
 					"default": {
-						"self": false,
-						"expose": true
-					}
+						"self": false
+					},
+					"markdownDescription": "`self` to control the type inference of `$slots` in the template and the return type of `useSlots`."
 				},
 				"plugins": {
 					"type": "array",

--- a/packages/language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/language-core/schemas/vue-tsconfig.schema.json
@@ -140,7 +140,7 @@
 				"typedDollarSlots": {
 					"type": ["boolean", "object"],
 					"default": {
-						"self": false
+						"self": true
 					},
 					"markdownDescription": "`self` to control the type inference of `$slots` in the template and the return type of `useSlots`."
 				},

--- a/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -331,7 +331,7 @@ exports[`vue-tsc-dts > Input: reference-type-props/component-destructure.vue, Ou
 "type __VLS_Props = {
     text: string;
 };
-declare const _default: import("vue").DefineComponent<__VLS_Props, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, false, {}, HTMLDivElement>;
+declare const _default: import("vue").DefineComponent<__VLS_Props, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, false, {}, any>;
 export default _default;
 "
 `;

--- a/test-workspace/tsc/passedFixtures/vue3/rootEl/base.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/rootEl/base.vue
@@ -1,4 +1,5 @@
-<!-- @typedDollarEl true -->
+<!-- @inferComponentDollarEl true -->
+<!-- @inferTemplateDollarEl true -->
 
 <script setup lang="ts">
 import { exactType } from '../../shared';

--- a/test-workspace/tsc/passedFixtures/vue3/rootEl/base.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/rootEl/base.vue
@@ -1,3 +1,5 @@
+<!-- @typedDollarEl true -->
+
 <script setup lang="ts">
 import { exactType } from '../../shared';
 </script>

--- a/test-workspace/tsc/passedFixtures/vue3/rootEl/child.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/rootEl/child.vue
@@ -1,4 +1,5 @@
-<!-- @typedDollarEl true -->
+<!-- @inferComponentDollarEl true -->
+<!-- @inferTemplateDollarEl true -->
  
 <script setup lang="ts">
 import { exactType } from '../../shared';

--- a/test-workspace/tsc/passedFixtures/vue3/rootEl/child.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/rootEl/child.vue
@@ -1,3 +1,5 @@
+<!-- @typedDollarEl true -->
+ 
 <script setup lang="ts">
 import { exactType } from '../../shared';
 import Base from './base.vue';

--- a/test-workspace/tsc/passedFixtures/vue3/rootEl/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/rootEl/main.vue
@@ -1,3 +1,5 @@
+<!-- @inferTemplateDollarEl true -->
+
 <script setup lang="ts">
 import { exactType } from '../../shared';
 import Child from './child.vue';

--- a/test-workspace/tsc/passedFixtures/vue3/slots/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/slots/main.vue
@@ -1,3 +1,5 @@
+<!-- @inferTemplateDollarSlots true -->
+
 <template>
 	<!-- component slots type -->
 	<Comp value="1">

--- a/test-workspace/tsc/passedFixtures/vue3/templateRef/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/templateRef/main.vue
@@ -1,3 +1,5 @@
+<!-- @inferTemplateDollarRefs true -->
+
 <script setup lang="ts">
 import { useTemplateRef } from 'vue';
 import { exactType } from '../../shared';

--- a/test-workspace/tsc/passedFixtures/vue3/templateRef/template-refs.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/templateRef/template-refs.vue
@@ -1,3 +1,5 @@
+<!-- @typedDollarRefs true -->
+
 <script setup lang="ts">
 import { useTemplateRef } from 'vue';
 import { exactType } from '../../shared';

--- a/test-workspace/tsc/passedFixtures/vue3/templateRef/template-refs.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/templateRef/template-refs.vue
@@ -1,4 +1,4 @@
-<!-- @typedDollarRefs true -->
+<!-- @inferComponentDollarRefs true -->
 
 <script setup lang="ts">
 import { useTemplateRef } from 'vue';


### PR DESCRIPTION
close #5116, close #5183, close #5197, fix #5128

```json
{
	"inferComponentDollarEl": {
	  "type": "boolean",
	  "default": false,
	  "markdownDescription": "Infer `$el` type on the component instance."
	},
	"inferComponentDollarRefs": {
	  "type": "boolean",
	  "default": false,
	  "markdownDescription": "Infer `$refs` type on the component instance."
	},
	"inferTemplateDollarAttrs": {
	  "type": "boolean",
	  "default": false,
	  "markdownDescription": "Infer `$attrs` type in the template and the return type of `useAttrs`."
	},
	"inferTemplateDollarEl": {
	  "type": "boolean",
	  "default": false,
	  "markdownDescription": "Infer `$el` type in the template."
	},
	"inferTemplateDollarRefs": {
	  "type": "boolean",
	  "default": false,
	  "markdownDescription": "Infer `$refs` type in the template."
	},
	"inferTemplateDollarSlots": {
	  "type": "boolean",
	  "default": false,
	  "markdownDescription": "Infer `$slots` type in the template and the return type of `useSlots`."
	}
}
```

Now the types of `$el` and `$refs` will not mount to component instance by default, but need to be enabled through the above options.

You can use [comment syntax](#4987) to turn on or off only for the current component:

```vue
<!-- @inferTemplateDollarSlots true -->
```