### PR TITLE
feat(component-meta): extend component meta

### DIFF
--- a/packages/component-meta/lib/types.ts
+++ b/packages/component-meta/lib/types.ts
@@ -13,6 +13,7 @@ export interface ComponentMeta {
 	events: EventMeta[];
 	slots: SlotMeta[];
 	exposed: ExposeMeta[];
+	[key: string]: any
 }
 
 export enum TypeMeta {

--- a/packages/component-meta/tests/index.spec.ts
+++ b/packages/component-meta/tests/index.spec.ts
@@ -859,6 +859,27 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) => describ
 		expect(a).toBeDefined();
 		expect(b).toBeDefined();
 	});
+
+	test('component-define-meta', () => {
+		const componentPath = path.resolve(__dirname, '../../../test-workspace/component-meta/define-meta/component-define-meta.vue');
+		const meta = checker.getComponentMeta(componentPath);
+		expect(meta.foo).toMatch('bar')
+		expect(meta.nested).toMatch(`{ foo: 'baz', arr: [1, 2] }`)
+	});
+
+	test('component-define-meta.ts', () => {
+		const componentPath = path.resolve(__dirname, '../../../test-workspace/component-meta/define-meta/component-define-meta.ts');
+		const meta = checker.getComponentMeta(componentPath);
+		expect(meta.foo).toMatch('bar')
+		expect(meta.nested).toMatch(`{ foo: 'baz', arr: [1, 2] }`)
+	});
+
+	test('component-define-meta.tsx', () => {
+		const componentPath = path.resolve(__dirname, '../../../test-workspace/component-meta/define-meta/component-define-meta.tsx');
+		const meta = checker.getComponentMeta(componentPath);
+		expect(meta.foo).toMatch('bar')
+		expect(meta.nested).toMatch(`{ foo: 'baz', arr: [1, 2] }`)
+	});
 });
 
 const checkerOptions: MetaCheckerOptions = {

--- a/test-workspace/component-meta/define-meta/component-define-meta.ts
+++ b/test-workspace/component-meta/define-meta/component-define-meta.ts
@@ -1,0 +1,6 @@
+import { h, defineComponent } from 'vue';
+
+export default defineComponent(() => {
+	defineComponentMeta({ foo: 'bar', nested: { foo: 'baz', arr: [1, 2] } })
+	return () => h('span');
+});

--- a/test-workspace/component-meta/define-meta/component-define-meta.tsx
+++ b/test-workspace/component-meta/define-meta/component-define-meta.tsx
@@ -1,0 +1,6 @@
+import { defineComponent } from 'vue';
+
+export default defineComponent(() => {
+	defineComponentMeta({ foo: 'bar', nested: { foo: 'baz', arr: [1, 2] } })
+	return () => <span />
+});

--- a/test-workspace/component-meta/define-meta/component-define-meta.vue
+++ b/test-workspace/component-meta/define-meta/component-define-meta.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineComponentMeta({ foo: 'bar', nested: { foo: 'baz', arr: [1, 2] } })
+</script>
+
+<template>
+	<span />
+</template>


### PR DESCRIPTION
Resolves #5168 

Introduces a new macro `defineComponentMeta` to extend component meta with arbitrary values.

```vue
<script setup lang="ts">
defineComponentMeta({
  foo: 'bar'
})
</script>

<template>
  <span />
</template>
```

Results in the following meta:

```ts
{
    bar: 'baz',
    props: [ /* ... */ ],
    // ...
}
```