### PR TITLE
refactor(language-core): more robust code features resolution

### DIFF
--- a/packages/language-core/lib/codegen/codeFeatures.ts
+++ b/packages/language-core/lib/codegen/codeFeatures.ts
@@ -1,0 +1,67 @@
+import type { VueCodeInformation } from '../types';
+
+const raw = {
+	all: {
+		verification: true,
+		completion: true,
+		semantic: true,
+		navigation: true,
+	},
+	none: {},
+	verification: {
+		verification: true,
+	},
+	completion: {
+		completion: true,
+	},
+	additionalCompletion: {
+		completion: { isAdditional: true },
+	},
+	withoutCompletion: {
+		verification: true,
+		semantic: true,
+		navigation: true,
+	},
+	navigation: {
+		navigation: true,
+	},
+	navigationWithoutRename: {
+		navigation: { shouldRename: () => false },
+	},
+	navigationAndCompletion: {
+		navigation: true,
+		completion: true,
+	},
+	navigationAndAdditionalCompletion: {
+		navigation: true,
+		completion: { isAdditional: true },
+	},
+	navigationAndVerification: {
+		navigation: true,
+		verification: true,
+	},
+	withoutNavigation: {
+		verification: true,
+		completion: true,
+		semantic: true,
+	},
+	withoutHighlight: {
+		semantic: { shouldHighlight: () => false },
+		verification: true,
+		navigation: true,
+		completion: true,
+	},
+	withoutHighlightAndCompletion: {
+		semantic: { shouldHighlight: () => false },
+		verification: true,
+		navigation: true,
+	},
+	withoutHighlightAndCompletionAndNavigation: {
+		semantic: { shouldHighlight: () => false },
+		verification: true,
+	},
+} satisfies Record<string, VueCodeInformation>;
+
+export const codeFeatures = raw as {
+	[K in keyof typeof raw]: VueCodeInformation;
+};

--- a/packages/language-core/lib/codegen/script/component.ts
+++ b/packages/language-core/lib/codegen/script/component.ts
@@ -1,8 +1,9 @@
 import type { ScriptSetupRanges } from '../../parsers/scriptSetupRanges';
 import type { Code, Sfc } from '../../types';
+import { codeFeatures } from '../codeFeatures';
 import { endOfLine, generateSfcBlockSection, newLine } from '../utils';
 import type { ScriptCodegenContext } from './context';
-import { ScriptCodegenOptions, codeFeatures } from './index';
+import type { ScriptCodegenOptions } from './index';
 
 export function* generateComponent(
 	options: ScriptCodegenOptions,

--- a/packages/language-core/lib/codegen/script/componentSelf.ts
+++ b/packages/language-core/lib/codegen/script/componentSelf.ts
@@ -1,10 +1,11 @@
 import * as path from 'path-browserify';
 import type { Code } from '../../types';
+import { codeFeatures } from '../codeFeatures';
 import type { TemplateCodegenContext } from '../template/context';
 import { endOfLine, generateSfcBlockSection, newLine } from '../utils';
 import { generateComponentSetupReturns, generateEmitsOption, generatePropsOption } from './component';
 import type { ScriptCodegenContext } from './context';
-import { codeFeatures, type ScriptCodegenOptions } from './index';
+import type { ScriptCodegenOptions } from './index';
 import { getTemplateUsageVars } from './template';
 
 export function* generateComponentSelf(

--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -3,7 +3,8 @@ import * as path from 'path-browserify';
 import type * as ts from 'typescript';
 import type { ScriptRanges } from '../../parsers/scriptRanges';
 import type { ScriptSetupRanges } from '../../parsers/scriptSetupRanges';
-import type { Code, Sfc, VueCodeInformation, VueCompilerOptions } from '../../types';
+import type { Code, Sfc, VueCompilerOptions } from '../../types';
+import { codeFeatures } from '../codeFeatures';
 import { generateGlobalTypes, getGlobalTypesFileName } from '../globalTypes';
 import type { TemplateCodegenContext } from '../template/context';
 import { endOfLine, generateSfcBlockSection, newLine } from '../utils';
@@ -13,29 +14,6 @@ import { generateScriptSetup, generateScriptSetupImports } from './scriptSetup';
 import { generateSrc } from './src';
 import { generateStyleModulesType } from './styleModulesType';
 import { generateTemplate } from './template';
-
-export const codeFeatures = {
-	all: {
-		verification: true,
-		completion: true,
-		semantic: true,
-		navigation: true,
-	} as VueCodeInformation,
-	none: {} as VueCodeInformation,
-	verification: {
-		verification: true,
-	} as VueCodeInformation,
-	navigation: {
-		navigation: true,
-	} as VueCodeInformation,
-	navigationWithoutRename: {
-		navigation: {
-			shouldRename() {
-				return false;
-			},
-		},
-	} as VueCodeInformation,
-};
 
 export interface ScriptCodegenOptions {
 	ts: typeof ts;

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -1,10 +1,11 @@
 import type { ScriptSetupRanges } from '../../parsers/scriptSetupRanges';
 import type { Code, Sfc, TextRange } from '../../types';
+import { codeFeatures } from '../codeFeatures';
 import { combineLastMapping, endOfLine, generateSfcBlockSection, newLine } from '../utils';
 import { generateComponent, generateEmitsOption } from './component';
 import { generateComponentSelf } from './componentSelf';
 import type { ScriptCodegenContext } from './context';
-import { ScriptCodegenOptions, codeFeatures, generateScriptSectionPartiallyEnding } from './index';
+import { ScriptCodegenOptions, generateScriptSectionPartiallyEnding } from './index';
 import { generateTemplate } from './template';
 
 export function* generateScriptSetupImports(

--- a/packages/language-core/lib/codegen/script/src.ts
+++ b/packages/language-core/lib/codegen/script/src.ts
@@ -1,6 +1,6 @@
 import type { Code, Sfc } from '../../types';
+import { codeFeatures } from '../codeFeatures';
 import { endOfLine } from '../utils';
-import { codeFeatures } from './index';
 
 export function* generateSrc(
 	script: NonNullable<Sfc['script']>,

--- a/packages/language-core/lib/codegen/script/styleModulesType.ts
+++ b/packages/language-core/lib/codegen/script/styleModulesType.ts
@@ -1,7 +1,8 @@
 import type { Code } from '../../types';
+import { codeFeatures } from '../codeFeatures';
 import { endOfLine, newLine } from '../utils';
 import type { ScriptCodegenContext } from './context';
-import { ScriptCodegenOptions, codeFeatures } from './index';
+import type { ScriptCodegenOptions } from './index';
 import { generateCssClassProperty } from './template';
 
 export function* generateStyleModulesType(

--- a/packages/language-core/lib/codegen/script/template.ts
+++ b/packages/language-core/lib/codegen/script/template.ts
@@ -1,11 +1,12 @@
 import type { Code } from '../../types';
 import { hyphenateTag } from '../../utils/shared';
+import { codeFeatures } from '../codeFeatures';
 import { TemplateCodegenContext, createTemplateCodegenContext } from '../template/context';
 import { generateInterpolation } from '../template/interpolation';
 import { generateStyleScopedClassReferences } from '../template/styleScopedClasses';
 import { endOfLine, newLine } from '../utils';
 import type { ScriptCodegenContext } from './context';
-import { codeFeatures, type ScriptCodegenOptions } from './index';
+import type { ScriptCodegenOptions } from './index';
 
 export function* generateTemplate(
 	options: ScriptCodegenOptions,

--- a/packages/language-core/lib/codegen/template/context.ts
+++ b/packages/language-core/lib/codegen/template/context.ts
@@ -1,68 +1,9 @@
 import type * as CompilerDOM from '@vue/compiler-dom';
 import type { Code, VueCodeInformation } from '../../types';
+import { codeFeatures } from '../codeFeatures';
 import { InlayHintInfo } from '../inlayHints';
 import { endOfLine, newLine, wrapWith } from '../utils';
 import type { TemplateCodegenOptions } from './index';
-
-const _codeFeatures = {
-	all: {
-		verification: true,
-		completion: true,
-		semantic: true,
-		navigation: true,
-	} as VueCodeInformation,
-	verification: {
-		verification: true,
-	} as VueCodeInformation,
-	completion: {
-		completion: true,
-	} as VueCodeInformation,
-	additionalCompletion: {
-		completion: { isAdditional: true },
-	} as VueCodeInformation,
-	navigation: {
-		navigation: true,
-	} as VueCodeInformation,
-	navigationWithoutRename: {
-		navigation: {
-			shouldRename() {
-				return false;
-			},
-		},
-	} as VueCodeInformation,
-	navigationAndCompletion: {
-		navigation: true,
-		completion: true,
-	} as VueCodeInformation,
-	navigationAndAdditionalCompletion: {
-		navigation: true,
-		completion: { isAdditional: true },
-	} as VueCodeInformation,
-	navigationAndVerification: {
-		navigation: true,
-		verification: true,
-	} as VueCodeInformation,
-	withoutNavigation: {
-		verification: true,
-		completion: true,
-		semantic: true,
-	} as VueCodeInformation,
-	withoutHighlight: {
-		semantic: { shouldHighlight: () => false },
-		verification: true,
-		navigation: true,
-		completion: true,
-	} as VueCodeInformation,
-	withoutHighlightAndCompletion: {
-		semantic: { shouldHighlight: () => false },
-		verification: true,
-		navigation: true,
-	} as VueCodeInformation,
-	withoutHighlightAndCompletionAndNavigation: {
-		semantic: { shouldHighlight: () => false },
-		verification: true,
-	} as VueCodeInformation,
-};
 
 export type TemplateCodegenContext = ReturnType<typeof createTemplateCodegenContext>;
 
@@ -78,34 +19,30 @@ export function createTemplateCodegenContext(options: Pick<TemplateCodegenOption
 	} | undefined;
 	let variableId = 0;
 
-	const codeFeatures = new Proxy(_codeFeatures, {
-		get(target, key: keyof typeof _codeFeatures) {
-			const data = target[key];
-			if (data.verification) {
-				if (ignoredError) {
-					return {
-						...data,
-						verification: false,
-					};
-				}
-				if (expectErrorToken) {
-					const token = expectErrorToken;
-					if (typeof data.verification !== 'object' || !data.verification.shouldReport) {
-						return {
-							...data,
-							verification: {
-								shouldReport: () => {
-									token.errors++;
-									return false;
-								},
-							},
-						};
-					}
-				}
+	function resolveCodeFeatures(features: VueCodeInformation) {
+		if (features.verification) {
+			if (ignoredError) {
+				return {
+					...features,
+					verification: false,
+				};
 			}
-			return data;
-		},
-	});
+			if (expectErrorToken) {
+				const token = expectErrorToken;
+				return {
+					...features,
+					verification: {
+						shouldReport: () => {
+							token.errors++;
+							return false;
+						}
+ 					},
+				};
+			}
+		}
+		return features;
+	}
+
 	const localVars = new Map<string, number>();
 	const specialVars = new Set<string>();
 	const accessExternalVariables = new Map<string, Set<number>>();
@@ -133,9 +70,15 @@ export function createTemplateCodegenContext(options: Pick<TemplateCodegenOption
 	const templateRefs = new Map<string, [varName: string, offset: number]>();
 
 	return {
+		codeFeatures: new Proxy(codeFeatures, {
+			get(target, key: keyof typeof codeFeatures) {
+				const data = target[key];
+				return resolveCodeFeatures(data);
+			},
+		}),
+		resolveCodeFeatures,
 		slots,
 		dynamicSlots,
-		codeFeatures,
 		specialVars,
 		accessExternalVariables,
 		lastGenericComment,

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -134,10 +134,7 @@ export function* generateComponent(
 				options,
 				ctx,
 				'template',
-				{
-					...ctx.codeFeatures.all,
-					completion: false,
-				},
+				ctx.codeFeatures.withoutCompletion,
 				dynamicTagInfo.tag,
 				dynamicTagInfo.offsets[1],
 				dynamicTagInfo.astHolder,
@@ -227,13 +224,13 @@ export function* generateComponent(
 	yield* wrapWith(
 		node.loc.start.offset,
 		node.loc.end.offset,
-		{
+		ctx.resolveCodeFeatures({
 			verification: {
 				shouldReport(_source, code) {
 					return String(code) !== '6133';
 				},
 			}
-		},
+		}),
 		var_componentInstance
 	);
 	yield ` = ${var_functionalComponent}`;

--- a/packages/language-core/lib/codegen/template/elementDirectives.ts
+++ b/packages/language-core/lib/codegen/template/elementDirectives.ts
@@ -2,6 +2,7 @@ import * as CompilerDOM from '@vue/compiler-dom';
 import { camelize } from '@vue/shared';
 import type { Code } from '../../types';
 import { hyphenateAttr } from '../../utils/shared';
+import { codeFeatures } from '../codeFeatures';
 import { endOfLine, wrapWith } from '../utils';
 import { generateCamelized } from '../utils/camelized';
 import { generateStringLiteralKey } from '../utils/stringLiteralKey';
@@ -59,12 +60,10 @@ function* generateIdentifier(
 			rawName,
 			prop.loc.start.offset,
 			{
-				...ctx.codeFeatures.all,
 				verification: false,
-				completion: {
-					// fix https://github.com/vuejs/language-tools/issues/1905
-					isAdditional: true,
-				},
+				// fix https://github.com/vuejs/language-tools/issues/1905
+				...codeFeatures.additionalCompletion,
+				semantic: true,
 				navigation: {
 					resolveRenameNewName: camelize,
 					resolveRenameEditText: getPropRenameApply(prop.name),

--- a/packages/language-core/lib/codegen/template/elementDirectives.ts
+++ b/packages/language-core/lib/codegen/template/elementDirectives.ts
@@ -2,7 +2,6 @@ import * as CompilerDOM from '@vue/compiler-dom';
 import { camelize } from '@vue/shared';
 import type { Code } from '../../types';
 import { hyphenateAttr } from '../../utils/shared';
-import { codeFeatures } from '../codeFeatures';
 import { endOfLine, wrapWith } from '../utils';
 import { generateCamelized } from '../utils/camelized';
 import { generateStringLiteralKey } from '../utils/stringLiteralKey';
@@ -60,9 +59,8 @@ function* generateIdentifier(
 			rawName,
 			prop.loc.start.offset,
 			{
-				verification: false,
 				// fix https://github.com/vuejs/language-tools/issues/1905
-				...codeFeatures.additionalCompletion,
+				...ctx.codeFeatures.additionalCompletion,
 				semantic: true,
 				navigation: {
 					resolveRenameNewName: camelize,

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -2,7 +2,6 @@ import * as CompilerDOM from '@vue/compiler-dom';
 import { camelize, capitalize } from '@vue/shared';
 import type * as ts from 'typescript';
 import type { Code } from '../../types';
-import { codeFeatures } from '../codeFeatures';
 import { combineLastMapping, createTsAst, endOfLine, newLine, variableNameRegex, wrapWith } from '../utils';
 import { generateCamelized } from '../utils/camelized';
 import type { TemplateCodegenContext } from './context';
@@ -58,10 +57,10 @@ export function* generateEventArg(
 	start: number,
 	directive = 'on'
 ): Generator<Code> {
-	const features = ctx.resolveCodeFeatures({
-		...codeFeatures.withoutHighlightAndCompletion,
-		...codeFeatures.navigationWithoutRename,
-	});
+	const features = {
+		...ctx.codeFeatures.withoutHighlightAndCompletion,
+		...ctx.codeFeatures.navigationWithoutRename,
+	};
 	if (variableNameRegex.test(camelize(name))) {
 		yield ['', 'template', start, features];
 		yield directive;

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -2,6 +2,7 @@ import * as CompilerDOM from '@vue/compiler-dom';
 import { camelize, capitalize } from '@vue/shared';
 import type * as ts from 'typescript';
 import type { Code } from '../../types';
+import { codeFeatures } from '../codeFeatures';
 import { combineLastMapping, createTsAst, endOfLine, newLine, variableNameRegex, wrapWith } from '../utils';
 import { generateCamelized } from '../utils/camelized';
 import type { TemplateCodegenContext } from './context';
@@ -57,10 +58,10 @@ export function* generateEventArg(
 	start: number,
 	directive = 'on'
 ): Generator<Code> {
-	const features = {
-		...ctx.codeFeatures.withoutHighlightAndCompletion,
-		...ctx.codeFeatures.navigationWithoutRename,
-	};
+	const features = ctx.resolveCodeFeatures({
+		...codeFeatures.withoutHighlightAndCompletion,
+		...codeFeatures.navigationWithoutRename,
+	});
 	if (variableNameRegex.test(camelize(name))) {
 		yield ['', 'template', start, features];
 		yield directive;

--- a/packages/language-core/lib/codegen/template/elementProps.ts
+++ b/packages/language-core/lib/codegen/template/elementProps.ts
@@ -383,6 +383,10 @@ function getPropsCodeInfo(
 ): VueCodeInformation {
 	return ctx.resolveCodeFeatures({
 		...codeFeatures.withoutHighlightAndCompletion,
+		navigation: {
+			resolveRenameNewName: camelize,
+			resolveRenameEditText: shouldCamelize ? hyphenateAttr : undefined,
+		},
 		verification: strictPropsCheck || {
 			shouldReport(_source, code) {
 				if (String(code) === '2353' || String(code) === '2561') {
@@ -390,10 +394,6 @@ function getPropsCodeInfo(
 				}
 				return true;
 			},
-		},
-		navigation: {
-			resolveRenameNewName: camelize,
-			resolveRenameEditText: shouldCamelize ? hyphenateAttr : undefined,
 		},
 	});
 }


### PR DESCRIPTION
- Extract code features to share between the codegen of script and template.
- Use `resolveCodeFeatures` in the template codegen to ensure that all code info with verification enabled is converted by it, preventing `@vue-expect-error` from being invalid on certain mappings.