### PR TITLE
fix(language-core): move generateSfcBlockSection to the end to fix missing comma errors

### DIFF
--- a/packages/language-core/lib/codegen/script/component.ts
+++ b/packages/language-core/lib/codegen/script/component.ts
@@ -37,15 +37,15 @@ export function* generateComponent(
 		}
 		yield* generatePropsOption(options, ctx, scriptSetup, scriptSetupRanges, !!emitOptionCodes.length, true);
 	}
-	if (options.sfc.script && options.scriptRanges?.exportDefault?.args) {
-		const { args } = options.scriptRanges.exportDefault;
-		yield generateSfcBlockSection(options.sfc.script, args.start + 1, args.end - 1, codeFeatures.all);
-	}
 	if (options.vueCompilerOptions.target >= 3.5 && options.templateCodegen?.templateRefs.size) {
 		yield `__typeRefs: {} as __VLS_TemplateRefs,${newLine}`;
 	}
 	if (options.vueCompilerOptions.target >= 3.5 && options.templateCodegen?.singleRootElType) {
 		yield `__typeEl: {} as __VLS_RootEl,${newLine}`;
+	}
+	if (options.sfc.script && options.scriptRanges?.exportDefault?.args) {
+		const { args } = options.scriptRanges.exportDefault;
+		yield generateSfcBlockSection(options.sfc.script, args.start + 1, args.end - 1, codeFeatures.all);
 	}
 	yield `})`;
 }


### PR DESCRIPTION
If defineComponent's options don't end with a comma, it will cause a TS 1005 error.

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/b3ee5f1e-0f91-42e1-91c2-6727cb1e7d4f" />
