### PR TITLE
fix(language-core): prevent global types generation in declaration files

### DIFF
--- a/packages/language-core/lib/codegen/globalTypes.ts
+++ b/packages/language-core/lib/codegen/globalTypes.ts
@@ -117,9 +117,6 @@ export function generateGlobalTypes({
 		'__ctx' extends keyof __VLS_PickNotAny<K, {}> ? K extends { __ctx?: infer Ctx } ? Ctx : never : any
 		, T extends (props: any, ctx: infer Ctx) => any ? Ctx : any
 	>>;
-	type __VLS_OmitStringIndex<T> = {
-		[K in keyof T as string extends K ? never : K]: T[K];
-	};
 	type __VLS_UseTemplateRef<T> = Readonly<import('${lib}').ShallowRef<T | null>>;
 
 	function __VLS_getVForSourceType<T extends number | string | any[] | Iterable<any>>(source: T): [

--- a/packages/language-core/lib/codegen/template/index.ts
+++ b/packages/language-core/lib/codegen/template/index.ts
@@ -79,8 +79,7 @@ function* generateSlots(
 	ctx: TemplateCodegenContext
 ): Generator<Code> {
 	if (!options.hasDefineSlots) {
-		const name = getSlotsPropertyName(options.vueCompilerOptions.target);
-		yield `type __VLS_Slots = __VLS_PrettifyGlobal<__VLS_OmitStringIndex<typeof __VLS_ctx.${name}>`;
+		yield `type __VLS_Slots = {}`;
 		for (const { expVar, propsVar } of ctx.dynamicSlots) {
 			yield `${newLine}& { [K in NonNullable<typeof ${expVar}>]?: (props: typeof ${propsVar}) => any }`;
 		}
@@ -106,7 +105,7 @@ function* generateSlots(
 			}
 			yield `?: (props: typeof ${slot.propsVar}) => any }`;
 		}
-		yield `>${endOfLine}`;
+		yield `${endOfLine}`;
 	}
 	return `__VLS_Slots`;
 }

--- a/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -595,8 +595,7 @@ export {};
 `;
 
 exports[`vue-tsc-dts > Input: template-slots/component.vue, Output: template-slots/component.vue.d.ts 1`] = `
-"declare const __VLS_ctx: InstanceType<__VLS_PickNotAny<typeof __VLS_self, new () => {}>>;
-declare var __VLS_1: {}, __VLS_3: {
+"declare var __VLS_1: {}, __VLS_3: {
     num: number;
 }, __VLS_5: {
     str: string;
@@ -604,7 +603,7 @@ declare var __VLS_1: {}, __VLS_3: {
     num: number;
     str: string;
 };
-type __VLS_Slots = __VLS_PrettifyGlobal<__VLS_OmitStringIndex<typeof __VLS_ctx.$slots> & {
+type __VLS_Slots = {} & {
     'no-bind'?: (props: typeof __VLS_1) => any;
 } & {
     default?: (props: typeof __VLS_3) => any;
@@ -612,8 +611,7 @@ type __VLS_Slots = __VLS_PrettifyGlobal<__VLS_OmitStringIndex<typeof __VLS_ctx.$
     'named-slot'?: (props: typeof __VLS_5) => any;
 } & {
     vbind?: (props: typeof __VLS_7) => any;
-}>;
-declare const __VLS_self: import("vue").DefineComponent<{}, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+};
 declare const __VLS_component: import("vue").DefineComponent<{}, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
 declare const _default: __VLS_WithSlots<typeof __VLS_component, __VLS_Slots>;
 export default _default;
@@ -669,8 +667,7 @@ type __VLS_WithSlots<T, S> = T & {
 `;
 
 exports[`vue-tsc-dts > Input: template-slots/component-no-script.vue, Output: template-slots/component-no-script.vue.d.ts 1`] = `
-"declare const __VLS_ctx: InstanceType<__VLS_PickNotAny<typeof __VLS_self, new () => {}>>;
-declare var __VLS_1: {}, __VLS_3: {
+"declare var __VLS_1: {}, __VLS_3: {
     num: number;
 }, __VLS_5: {
     str: string;
@@ -678,7 +675,7 @@ declare var __VLS_1: {}, __VLS_3: {
     num: number;
     str: string;
 };
-type __VLS_Slots = __VLS_PrettifyGlobal<__VLS_OmitStringIndex<typeof __VLS_ctx.$slots> & {
+type __VLS_Slots = {} & {
     'no-bind'?: (props: typeof __VLS_1) => any;
 } & {
     default?: (props: typeof __VLS_3) => any;
@@ -686,8 +683,7 @@ type __VLS_Slots = __VLS_PrettifyGlobal<__VLS_OmitStringIndex<typeof __VLS_ctx.$
     'named-slot'?: (props: typeof __VLS_5) => any;
 } & {
     vbind?: (props: typeof __VLS_7) => any;
-}>;
-declare const __VLS_self: import("vue").DefineComponent<{}, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
+};
 declare const __VLS_component: import("vue").DefineComponent<{}, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<{}> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
 declare const _default: __VLS_WithSlots<typeof __VLS_component, __VLS_Slots>;
 export default _default;

--- a/test-workspace/tsc/passedFixtures/vue3/slots/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/slots/main.vue
@@ -30,7 +30,6 @@
 <script lang="ts">
 export default {
 	name: 'Self',
-	slots: Object as SlotsType<{ foo?: (props: any) => any }>,
 };
 
 declare const Comp: new <T>(props: { value: T; }) => {
@@ -42,15 +41,15 @@ declare const Comp: new <T>(props: { value: T; }) => {
 </script>
 
 <script lang="ts" setup>
-import { ref, type SlotsType, useSlots, type VNode } from 'vue';
+import { ref, useSlots, type VNode } from 'vue';
 import { exactType } from '../../shared';
 
 const baz = ref('baz' as const);
 
 const slots = useSlots();
 exactType(slots, {} as {
-	readonly foo?: (props: any) => any;
 	bar?: (props: { str: string; num: number; }) => any;
+} & {
 	baz?: (props: { str: string; num: number; }) => any;
 });
 </script>


### PR DESCRIPTION
fix #5232 

Due to the above limitations, we will not intersect `$slots` with slot types declared by option api now.