### PR TITLE
fix(language-core): prevent eager inference of slot props from generics

### DIFF
--- a/packages/language-core/lib/codegen/globalTypes.ts
+++ b/packages/language-core/lib/codegen/globalTypes.ts
@@ -158,7 +158,7 @@ export function generateGlobalTypes({
 		: (_: {}${checkUnknownProps ? '' : ' & Record<string, unknown>'}, ctx?: any) => { __ctx?: { attrs?: any, expose?: any, slots?: any, emit?: any, props?: {}${checkUnknownProps ? '' : ' & Record<string, unknown>'} } };
 	function __VLS_functionalComponentArgsRest<T extends (...args: any) => any>(t: T): 2 extends Parameters<T>['length'] ? [any] : [];
 	function __VLS_asFunctionalElement<T>(tag: T, endTag?: T): (attrs: T${checkUnknownComponents ? '' : ' & Record<string, unknown>'}) => void;
-	function __VLS_asFunctionalSlot<S>(slot: S): (props: NonNullable<S> extends (props: infer P) => any ? P : {}) => void;
+	function __VLS_asFunctionalSlot<S>(slot: S): S extends () => infer R ? (props: {}) => R : NonNullable<S>;
 	function __VLS_tryAsConstant<const T>(t: T): T;
 }
 `;

--- a/test-workspace/tsc/passedFixtures/vue3/#5228/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#5228/main.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts" generic="T extends string">
+defineSlots<{
+	[K in `slot:${T}`]?: () => any;
+}>();
+
+let slots!: T[];
+</script>
+
+<template>
+	<div v-for="slot of slots">
+		<slot :name="`slot:${slot}`"></slot>
+	</div>
+</template>


### PR DESCRIPTION
fix #5228, fix #5246 