### PR TITLE
fix(vscode): handle `typescript-language-features` module load race condition

### DIFF
--- a/extensions/vscode/src/nodeClientMain.ts
+++ b/extensions/vscode/src/nodeClientMain.ts
@@ -199,4 +199,11 @@ try {
 		// @ts-expect-error
 		return readFileSync(...args);
 	};
+
+	const loadedModule = require.cache[extensionJsPath];
+	if (loadedModule) {
+		delete require.cache[extensionJsPath];
+		const patchedModule = require(extensionJsPath);
+		Object.assign(loadedModule.exports, patchedModule);
+	}
 } catch { }


### PR DESCRIPTION
In some cases, VSCode will prioritize loading `typescript-language-features` main script instead of Vue extension main script, so our fs hack code does not work. This PR makes it fault-tolerant.