### PR TITLE
fix(language-core): correct error mapping when prop exp is arrow function

### DIFF
--- a/packages/language-core/lib/codegen/template/elementProps.ts
+++ b/packages/language-core/lib/codegen/template/elementProps.ts
@@ -141,13 +141,18 @@ export function* generateElementProps(
 						)
 				),
 				`: `,
-				...generatePropExp(
-					options,
-					ctx,
-					prop,
-					prop.exp,
-					ctx.codeFeatures.all,
-					enableCodeFeatures
+				...wrapWith(
+					prop.arg?.loc.start.offset ?? prop.loc.start.offset,
+					prop.arg?.loc.end.offset ?? prop.loc.end.offset,
+					ctx.codeFeatures.verification,
+					...generatePropExp(
+						options,
+						ctx,
+						prop,
+						prop.exp,
+						ctx.codeFeatures.all,
+						enableCodeFeatures
+					)
 				)
 			)];
 			if (enableCodeFeatures) {

--- a/test-workspace/tsc/passedFixtures/vue3/#5262/comp.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#5262/comp.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+defineProps<{
+	foo: string;
+}>();
+</script>

--- a/test-workspace/tsc/passedFixtures/vue3/#5262/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#5262/main.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import Comp from './comp.vue';
+</script>
+
+<template>
+	<!-- @vue-expect-error -->
+	<Comp :foo="() => []" />
+</template>


### PR DESCRIPTION
fix vuejs/core#13012 