### PR TITLE
fix(language-core): do not drop leading comments of `defineModels`

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -97,15 +97,6 @@ function* generateSetupFunction(
 	syntax: 'return' | 'export default' | undefined
 ): Generator<Code> {
 	let setupCodeModifies: [Code[], number, number][] = [];
-	for (const { comments } of scriptSetupRanges.defineProp) {
-		if (comments) {
-			setupCodeModifies.push([
-				[``],
-				comments.start,
-				comments.end,
-			]);
-		}
-	}
 	if (scriptSetupRanges.defineProps) {
 		const { name, statement, callExp, typeArg } = scriptSetupRanges.defineProps;
 		setupCodeModifies.push(...generateDefineWithType(
@@ -506,7 +497,7 @@ function* generateComponentProps(
 			const [propName, localName] = getPropAndLocalName(scriptSetup, defineProp);
 
 			if (defineProp.comments) {
-				yield generateSfcBlockSection(scriptSetup, defineProp.comments.start, defineProp.comments.end, codeFeatures.all);
+				yield scriptSetup.content.slice(defineProp.comments.start, defineProp.comments.end);
 				yield newLine;
 			}
 

--- a/packages/language-core/lib/parsers/scriptSetupRanges.ts
+++ b/packages/language-core/lib/parsers/scriptSetupRanges.ts
@@ -249,7 +249,7 @@ export function parseScriptSetupRanges(
 					defaultValue,
 					required,
 					isModel: isDefineModel,
-					comments: getCommentsRange(ts, node, parents, ast),
+					comments: getClosestMultiLineCommentRange(ts, node, parents, ast),
 					argNode: options,
 				});
 			}
@@ -537,7 +537,7 @@ function getStatementRange(
 	return statementRange;
 }
 
-function getCommentsRange(
+function getClosestMultiLineCommentRange(
 	ts: typeof import('typescript'),
 	node: ts.Node,
 	parents: ts.Node[],
@@ -549,11 +549,14 @@ function getCommentsRange(
 		}
 		node = parents[i];
 	}
-	const comments = ts.getLeadingCommentRanges(ast.text, node.pos);
-	if (comments?.length) {
+	const comment = ts.getLeadingCommentRanges(ast.text, node.pos)
+		?.reverse()
+		.find(range => range.kind === 3 satisfies ts.SyntaxKind.MultiLineCommentTrivia);
+
+	if (comment) {
 		return {
-			start: comments[0].pos,
-			end: comments.at(-1)!.end,
+			start: comment.pos,
+			end: comment.end,
 		};
 	}
 }


### PR DESCRIPTION
fix #5272 