### PR TITLE
fix(language-core): set the parent id of template inline embedded codes to `root_tags`

### DIFF
--- a/packages/language-core/lib/plugins/vue-template-inline-css.ts
+++ b/packages/language-core/lib/plugins/vue-template-inline-css.ts
@@ -26,7 +26,7 @@ const plugin: VueLanguagePlugin = () => {
 			if (embeddedFile.id !== 'template_inline_css' || !sfc.template?.ast) {
 				return;
 			}
-			embeddedFile.parentCodeId = 'template';
+			embeddedFile.parentCodeId = sfc.template.lang === 'md' ? 'root_tags' : 'template';
 			embeddedFile.content.push(...generate(sfc.template.ast));
 		},
 	};

--- a/packages/language-core/lib/plugins/vue-template-inline-ts.ts
+++ b/packages/language-core/lib/plugins/vue-template-inline-ts.ts
@@ -48,14 +48,14 @@ const plugin: VueLanguagePlugin = ctx => {
 
 		resolveEmbeddedCode(_fileName, sfc, embeddedFile) {
 			// access template content to watch change
-			(() => sfc.template?.content)();
+			void sfc.template?.content;
 
 			const parsed = parseds.get(sfc);
 			if (parsed) {
 				const codes = parsed.get(embeddedFile.id);
 				if (codes) {
 					embeddedFile.content.push(...codes);
-					embeddedFile.parentCodeId = 'template';
+					embeddedFile.parentCodeId = sfc.template?.lang === 'md' ? 'root_tags' : 'template';
 				}
 			}
 		},


### PR DESCRIPTION
fix #5299 