### PR TITLE
fix(ci): Run auto-fix from the correct branch

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
     branches:
       - master
 

--- a/packages/language-core/index.ts
+++ b/packages/language-core/index.ts
@@ -5,7 +5,7 @@ export * from './lib/parsers/scriptSetupRanges';
 export * from './lib/plugins';
 export * from './lib/types';
 export * from './lib/utils/parseSfc';
-export * from './lib/utils/shared';
+export * from "./lib/utils/shared";
 export * from './lib/utils/ts';
 export * from './lib/virtualFile/vueFile';
 

--- a/packages/language-core/index.ts
+++ b/packages/language-core/index.ts
@@ -5,7 +5,7 @@ export * from './lib/parsers/scriptSetupRanges';
 export * from './lib/plugins';
 export * from './lib/types';
 export * from './lib/utils/parseSfc';
-export * from "./lib/utils/shared";
+export * from './lib/utils/shared';
 export * from './lib/utils/ts';
 export * from './lib/virtualFile/vueFile';
 


### PR DESCRIPTION
By default, `pull_request_target` checks out the main branch of vuejs/language-tools and runs the auto fix there. This is very likely not what you wanted to achive.

Also, the permissions pull_request_target has are very broad and can be dangerous.