### PR TITLE
chore(deps): replace `path-browserify` with `pathe`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 node_modules
 *.tsbuildinfo
 *.vsix
+.idea
 .vscode-test-web
 extensions/*/meta.json
 extensions/*/stats.html

--- a/packages/component-meta/lib/base.ts
+++ b/packages/component-meta/lib/base.ts
@@ -1,6 +1,6 @@
 import { TypeScriptProjectHost, createLanguageServiceHost, resolveFileLanguageId } from '@volar/typescript';
 import * as vue from '@vue/language-core';
-import { posix as path } from 'path-browserify';
+import { posix as path } from 'pathe';
 import type * as ts from 'typescript';
 import { code as typeHelpersCode } from 'vue-component-type-helpers';
 import { code as vue2TypeHelpersCode } from 'vue-component-type-helpers/vue2';

--- a/packages/component-meta/package.json
+++ b/packages/component-meta/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"@volar/typescript": "~2.4.11",
 		"@vue/language-core": "3.0.0-alpha.4",
-		"pathe": "catalog:",
+		"pathe": "^2.0.3",
 		"vue-component-type-helpers": "3.0.0-alpha.4"
 	},
 	"peerDependencies": {

--- a/packages/component-meta/package.json
+++ b/packages/component-meta/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"@volar/typescript": "~2.4.11",
 		"@vue/language-core": "3.0.0-alpha.4",
-		"path-browserify": "^1.0.1",
+		"pathe": "catalog:",
 		"vue-component-type-helpers": "3.0.0-alpha.4"
 	},
 	"peerDependencies": {
@@ -27,7 +27,6 @@
 		}
 	},
 	"devDependencies": {
-		"@types/node": "^22.10.4",
-		"@types/path-browserify": "^1.0.1"
+		"@types/node": "^22.10.4"
 	}
 }

--- a/packages/language-core/lib/codegen/script/componentSelf.ts
+++ b/packages/language-core/lib/codegen/script/componentSelf.ts
@@ -1,4 +1,4 @@
-import * as path from 'pathe';
+import path from 'pathe';
 import type { Code } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import type { TemplateCodegenContext } from '../template/context';

--- a/packages/language-core/lib/codegen/script/componentSelf.ts
+++ b/packages/language-core/lib/codegen/script/componentSelf.ts
@@ -1,4 +1,4 @@
-import * as path from 'path-browserify';
+import * as path from 'pathe';
 import type { Code } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import type { TemplateCodegenContext } from '../template/context';

--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -1,4 +1,4 @@
-import * as path from 'path-browserify';
+import * as path from 'pathe';
 import type * as ts from 'typescript';
 import type { ScriptRanges } from '../../parsers/scriptRanges';
 import type { ScriptSetupRanges } from '../../parsers/scriptSetupRanges';

--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -1,4 +1,4 @@
-import * as path from 'pathe';
+import path from 'pathe';
 import type * as ts from 'typescript';
 import type { ScriptRanges } from '../../parsers/scriptRanges';
 import type { ScriptSetupRanges } from '../../parsers/scriptSetupRanges';

--- a/packages/language-core/lib/plugins/vue-tsx.ts
+++ b/packages/language-core/lib/plugins/vue-tsx.ts
@@ -1,6 +1,6 @@
 import { camelize, capitalize } from '@vue/shared';
 import { computed } from 'alien-signals';
-import * as path from 'path-browserify';
+import * as path from 'pathe';
 import { generateScript } from '../codegen/script';
 import { generateTemplate } from '../codegen/template';
 import { parseScriptRanges } from '../parsers/scriptRanges';

--- a/packages/language-core/lib/plugins/vue-tsx.ts
+++ b/packages/language-core/lib/plugins/vue-tsx.ts
@@ -1,6 +1,6 @@
 import { camelize, capitalize } from '@vue/shared';
 import { computed } from 'alien-signals';
-import * as path from 'pathe';
+import path from 'pathe';
 import { generateScript } from '../codegen/script';
 import { generateTemplate } from '../codegen/template';
 import { parseScriptRanges } from '../parsers/scriptRanges';

--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -1,5 +1,5 @@
 import { camelize } from '@vue/shared';
-import { posix as path } from 'path-browserify';
+import { posix as path } from 'pathe';
 import type * as ts from 'typescript';
 import { generateGlobalTypes, getGlobalTypesFileName } from '../codegen/globalTypes';
 import { getAllExtensions } from '../languagePlugin';

--- a/packages/language-core/package.json
+++ b/packages/language-core/package.json
@@ -20,12 +20,11 @@
 		"alien-signals": "^1.0.3",
 		"minimatch": "^9.0.3",
 		"muggle-string": "^0.4.1",
-		"path-browserify": "^1.0.1"
+		"pathe": "catalog:"
 	},
 	"devDependencies": {
 		"@types/minimatch": "^5.1.2",
 		"@types/node": "^22.10.4",
-		"@types/path-browserify": "^1.0.1",
 		"@volar/typescript": "~2.4.11",
 		"@vue/compiler-sfc": "^3.5.0"
 	},

--- a/packages/language-core/package.json
+++ b/packages/language-core/package.json
@@ -20,7 +20,7 @@
 		"alien-signals": "^1.0.3",
 		"minimatch": "^9.0.3",
 		"muggle-string": "^0.4.1",
-		"pathe": "catalog:"
+		"pathe": "^2.0.3"
 	},
 	"devDependencies": {
 		"@types/minimatch": "^5.1.2",

--- a/packages/language-service/lib/plugins/vue-document-drop.ts
+++ b/packages/language-service/lib/plugins/vue-document-drop.ts
@@ -1,6 +1,6 @@
 import { VueVirtualCode, forEachEmbeddedCode } from '@vue/language-core';
 import { camelize, capitalize, hyphenate } from '@vue/shared';
-import { posix as path } from 'path-browserify';
+import { posix as path } from 'pathe';
 import { getUserPreferences } from 'volar-service-typescript/lib/configs/getUserPreferences';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -25,7 +25,7 @@
 		"@vue/shared": "^3.5.0",
 		"@vue/typescript-plugin": "3.0.0-alpha.4",
 		"alien-signals": "^1.0.3",
-		"pathe": "catalog:",
+		"pathe": "^2.0.3",
 		"volar-service-css": "0.0.64",
 		"volar-service-emmet": "0.0.64",
 		"volar-service-html": "0.0.64",

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -25,7 +25,7 @@
 		"@vue/shared": "^3.5.0",
 		"@vue/typescript-plugin": "3.0.0-alpha.4",
 		"alien-signals": "^1.0.3",
-		"path-browserify": "^1.0.1",
+		"pathe": "catalog:",
 		"volar-service-css": "0.0.64",
 		"volar-service-emmet": "0.0.64",
 		"volar-service-html": "0.0.64",
@@ -41,7 +41,6 @@
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.4",
-		"@types/path-browserify": "^1.0.1",
 		"@volar/kit": "~2.4.11",
 		"vscode-languageserver-protocol": "^3.17.5"
 	}

--- a/packages/typescript-plugin/lib/requests/utils.ts
+++ b/packages/typescript-plugin/lib/requests/utils.ts
@@ -1,6 +1,6 @@
 import type { VueVirtualCode } from '@vue/language-core';
 import { camelize, capitalize } from '@vue/shared';
-import * as path from 'pathe';
+import path from 'pathe';
 import type * as ts from 'typescript';
 
 export function getComponentType(

--- a/packages/typescript-plugin/lib/requests/utils.ts
+++ b/packages/typescript-plugin/lib/requests/utils.ts
@@ -1,6 +1,6 @@
 import type { VueVirtualCode } from '@vue/language-core';
 import { camelize, capitalize } from '@vue/shared';
-import * as path from 'path-browserify';
+import * as path from 'pathe';
 import type * as ts from 'typescript';
 
 export function getComponentType(

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -16,10 +16,9 @@
 		"@volar/typescript": "~2.4.11",
 		"@vue/language-core": "3.0.0-alpha.4",
 		"@vue/shared": "^3.5.0",
-		"path-browserify": "^1.0.1"
+		"pathe": "catalog:"
 	},
 	"devDependencies": {
-		"@types/node": "^22.10.4",
-		"@types/path-browserify": "^1.0.1"
+		"@types/node": "^22.10.4"
 	}
 }

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -16,7 +16,7 @@
 		"@volar/typescript": "~2.4.11",
 		"@vue/language-core": "3.0.0-alpha.4",
 		"@vue/shared": "^3.5.0",
-		"pathe": "catalog:"
+		"pathe": "^2.0.3"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    pathe:
-      specifier: ^2.0.3
-      version: 2.0.3
-
 importers:
 
   .:
@@ -90,7 +84,7 @@ importers:
         specifier: 3.0.0-alpha.4
         version: link:../language-core
       pathe:
-        specifier: 'catalog:'
+        specifier: ^2.0.3
         version: 2.0.3
       typescript:
         specifier: '*'
@@ -129,7 +123,7 @@ importers:
         specifier: ^0.4.1
         version: 0.4.1
       pathe:
-        specifier: 'catalog:'
+        specifier: ^2.0.3
         version: 2.0.3
       typescript:
         specifier: '*'
@@ -225,7 +219,7 @@ importers:
         specifier: ^1.0.3
         version: 1.0.4
       pathe:
-        specifier: 'catalog:'
+        specifier: ^2.0.3
         version: 2.0.3
       volar-service-css:
         specifier: 0.0.64
@@ -302,7 +296,7 @@ importers:
         specifier: ^3.5.0
         version: 3.5.13
       pathe:
-        specifier: 'catalog:'
+        specifier: ^2.0.3
         version: 2.0.3
     devDependencies:
       '@types/node':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    pathe:
+      specifier: ^2.0.3
+      version: 2.0.3
+
 importers:
 
   .:
@@ -83,9 +89,9 @@ importers:
       '@vue/language-core':
         specifier: 3.0.0-alpha.4
         version: link:../language-core
-      path-browserify:
-        specifier: ^1.0.1
-        version: 1.0.1
+      pathe:
+        specifier: 'catalog:'
+        version: 2.0.3
       typescript:
         specifier: '*'
         version: 5.8.3
@@ -96,9 +102,6 @@ importers:
       '@types/node':
         specifier: ^22.10.4
         version: 22.13.10
-      '@types/path-browserify':
-        specifier: ^1.0.1
-        version: 1.0.3
 
   packages/component-type-helpers: {}
 
@@ -125,9 +128,9 @@ importers:
       muggle-string:
         specifier: ^0.4.1
         version: 0.4.1
-      path-browserify:
-        specifier: ^1.0.1
-        version: 1.0.1
+      pathe:
+        specifier: 'catalog:'
+        version: 2.0.3
       typescript:
         specifier: '*'
         version: 5.8.3
@@ -138,9 +141,6 @@ importers:
       '@types/node':
         specifier: ^22.10.4
         version: 22.13.10
-      '@types/path-browserify':
-        specifier: ^1.0.1
-        version: 1.0.3
       '@volar/typescript':
         specifier: ~2.4.11
         version: 2.4.12
@@ -224,9 +224,9 @@ importers:
       alien-signals:
         specifier: ^1.0.3
         version: 1.0.4
-      path-browserify:
-        specifier: ^1.0.1
-        version: 1.0.1
+      pathe:
+        specifier: 'catalog:'
+        version: 2.0.3
       volar-service-css:
         specifier: 0.0.64
         version: 0.0.64(@volar/language-service@2.4.12)
@@ -267,9 +267,6 @@ importers:
       '@types/node':
         specifier: ^22.10.4
         version: 22.13.10
-      '@types/path-browserify':
-        specifier: ^1.0.1
-        version: 1.0.3
       '@volar/kit':
         specifier: ~2.4.11
         version: 2.4.12(typescript@5.9.0-dev.20250319)
@@ -304,16 +301,13 @@ importers:
       '@vue/shared':
         specifier: ^3.5.0
         version: 3.5.13
-      path-browserify:
-        specifier: ^1.0.1
-        version: 1.0.1
+      pathe:
+        specifier: 'catalog:'
+        version: 2.0.3
     devDependencies:
       '@types/node':
         specifier: ^22.10.4
         version: 22.13.10
-      '@types/path-browserify':
-        specifier: ^1.0.1
-        version: 1.0.3
 
   test-workspace:
     devDependencies:
@@ -1185,9 +1179,6 @@ packages:
 
   '@types/parse-path@7.0.3':
     resolution: {integrity: sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==}
-
-  '@types/path-browserify@1.0.3':
-    resolution: {integrity: sha512-ZmHivEbNCBtAfcrFeBCiTjdIc2dey0l7oCGNGpSuRTy8jP6UVND7oUowlvDujBy8r2Hoa8bfFUOCiPWfmtkfxw==}
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -2971,6 +2962,9 @@ packages:
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
@@ -4756,8 +4750,6 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-path@7.0.3': {}
-
-  '@types/path-browserify@1.0.3': {}
 
   '@types/semver@7.5.8': {}
 
@@ -6776,6 +6768,8 @@ snapshots:
       minipass: 7.1.2
 
   pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
 
   pathval@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,6 @@ packages:
   - 'extensions/*'
   - 'packages/*'
   - 'test-workspace'
+
+catalog:
+  pathe: '^2.0.3'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,3 @@ packages:
   - 'extensions/*'
   - 'packages/*'
   - 'test-workspace'
-
-catalog:
-  pathe: '^2.0.3'


### PR DESCRIPTION
Stumbling across https://github.com/vuejs/language-tools/pull/5304 I saw that `path-browserify` could be replaced by unjs `pathe`. `path-browserify` has not been updated for 5 years, is only commonjs and from its docs `path-browserify currently matches the Node.js 10.3 API.

I used pnpm catalog to synchronise versions across the monorepo. We can replace this with the current version if needed.
We can even think about replacing `node:path` with `pathe` too.

All vitest tests pass.

If this PR is accepted, I can open a backport to v2.