### PR TITLE
fix(language-core): remove semantic highlight of v-bind shorthand

### DIFF
--- a/packages/language-core/lib/codegen/template/elementDirectives.ts
+++ b/packages/language-core/lib/codegen/template/elementDirectives.ts
@@ -176,7 +176,6 @@ function* generateValue(
 		options,
 		ctx,
 		prop,
-		exp,
-		ctx.codeFeatures.all
+		exp
 	);
 }

--- a/packages/language-core/lib/codegen/template/elementProps.ts
+++ b/packages/language-core/lib/codegen/template/elementProps.ts
@@ -150,7 +150,6 @@ export function* generateElementProps(
 						ctx,
 						prop,
 						prop.exp,
-						ctx.codeFeatures.all,
 						enableCodeFeatures
 					)
 				)
@@ -260,7 +259,6 @@ export function* generateElementProps(
 						ctx,
 						prop,
 						prop.exp,
-						ctx.codeFeatures.all,
 						enableCodeFeatures
 					)
 				)];
@@ -281,17 +279,13 @@ export function* generatePropExp(
 	ctx: TemplateCodegenContext,
 	prop: CompilerDOM.DirectiveNode,
 	exp: CompilerDOM.SimpleExpressionNode | undefined,
-	features: VueCodeInformation,
 	enableCodeFeatures: boolean = true
 ): Generator<Code> {
 	const isShorthand = prop.arg?.loc.start.offset === prop.exp?.loc.start.offset;
+	const features = isShorthand
+		? ctx.codeFeatures.withoutHighlightAndCompletion
+		: ctx.codeFeatures.all;
 
-	if (isShorthand && features.completion) {
-		features = {
-			...features,
-			completion: undefined,
-		};
-	}
 	if (exp && exp.constType !== CompilerDOM.ConstantTypes.CAN_STRINGIFY) { // style='z-index: 2' will compile to {'z-index':'2'}
 		if (!isShorthand) { // vue 3.4+
 			yield* generateInterpolation(

--- a/packages/language-core/lib/codegen/template/slotOutlet.ts
+++ b/packages/language-core/lib/codegen/template/slotOutlet.ts
@@ -59,8 +59,7 @@ export function* generateSlotOutlet(
 						options,
 						ctx,
 						nameProp,
-						nameProp.exp,
-						ctx.codeFeatures.all
+						nameProp.exp
 					),
 					`]`
 				];


### PR DESCRIPTION
| ts | before | after |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/d987ade7-1f07-4980-b84b-d6ebe39db4b3) | ![image](https://github.com/user-attachments/assets/14e03b79-12d3-4b59-9e44-58a7001e8d72) | ![image](https://github.com/user-attachments/assets/47fdb5f9-1c55-463d-966f-006b14d669e1) |