### PR TITLE
fix: depend on exact volar version

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -482,7 +482,7 @@
 		"@types/node": "^22.10.4",
 		"@types/semver": "^7.5.3",
 		"@types/vscode": "^1.82.0",
-		"@volar/vscode": "~2.4.13",
+		"@volar/vscode": "2.4.13",
 		"@vscode/vsce": "^3.2.1",
 		"@vue/language-core": "3.0.0-alpha.4",
 		"@vue/language-server": "3.0.0-alpha.4",

--- a/packages/component-meta/package.json
+++ b/packages/component-meta/package.json
@@ -13,7 +13,7 @@
 		"directory": "packages/component-meta"
 	},
 	"dependencies": {
-		"@volar/typescript": "~2.4.13",
+		"@volar/typescript": "2.4.13",
 		"@vue/language-core": "3.0.0-alpha.4",
 		"path-browserify": "^1.0.1",
 		"vue-component-type-helpers": "3.0.0-alpha.4"

--- a/packages/language-core/package.json
+++ b/packages/language-core/package.json
@@ -13,7 +13,7 @@
 		"directory": "packages/language-core"
 	},
 	"dependencies": {
-		"@volar/language-core": "~2.4.13",
+		"@volar/language-core": "2.4.13",
 		"@vue/compiler-dom": "^3.5.0",
 		"@vue/compiler-vue2": "^2.7.16",
 		"@vue/shared": "^3.5.0",
@@ -26,7 +26,7 @@
 		"@types/minimatch": "^5.1.2",
 		"@types/node": "^22.10.4",
 		"@types/path-browserify": "^1.0.1",
-		"@volar/typescript": "~2.4.13",
+		"@volar/typescript": "2.4.13",
 		"@vue/compiler-sfc": "^3.5.0"
 	},
 	"peerDependencies": {

--- a/packages/language-plugin-pug/package.json
+++ b/packages/language-plugin-pug/package.json
@@ -13,7 +13,7 @@
 		"directory": "packages/language-plugin-pug"
 	},
 	"dependencies": {
-		"@volar/source-map": "~2.4.13",
+		"@volar/source-map": "2.4.13",
 		"volar-service-pug": "0.0.64"
 	},
 	"devDependencies": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -16,9 +16,9 @@
 		"directory": "packages/language-server"
 	},
 	"dependencies": {
-		"@volar/language-core": "~2.4.13",
-		"@volar/language-server": "~2.4.13",
-		"@volar/test-utils": "~2.4.13",
+		"@volar/language-core": "2.4.13",
+		"@volar/language-server": "2.4.13",
+		"@volar/test-utils": "2.4.13",
 		"@vue/language-core": "3.0.0-alpha.4",
 		"@vue/language-service": "3.0.0-alpha.4",
 		"@vue/typescript-plugin": "3.0.0-alpha.4",

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -17,9 +17,9 @@
 		"update-html-data": "node ./scripts/update-html-data.js"
 	},
 	"dependencies": {
-		"@volar/language-core": "~2.4.13",
-		"@volar/language-service": "~2.4.13",
-		"@volar/typescript": "~2.4.13",
+		"@volar/language-core": "2.4.13",
+		"@volar/language-service": "2.4.13",
+		"@volar/typescript": "2.4.13",
 		"@vue/compiler-dom": "^3.5.0",
 		"@vue/language-core": "3.0.0-alpha.4",
 		"@vue/shared": "^3.5.0",
@@ -42,7 +42,7 @@
 	"devDependencies": {
 		"@types/node": "^22.10.4",
 		"@types/path-browserify": "^1.0.1",
-		"@volar/kit": "~2.4.13",
+		"@volar/kit": "2.4.13",
 		"vscode-languageserver-protocol": "^3.17.5"
 	}
 }

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -20,7 +20,7 @@
 		"typescript": ">=5.0.0"
 	},
 	"dependencies": {
-		"@volar/typescript": "~2.4.13",
+		"@volar/typescript": "2.4.13",
 		"@vue/language-core": "3.0.0-alpha.4"
 	},
 	"devDependencies": {

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -13,7 +13,7 @@
 		"directory": "packages/typescript-plugin"
 	},
 	"dependencies": {
-		"@volar/typescript": "~2.4.13",
+		"@volar/typescript": "2.4.13",
 		"@vue/language-core": "3.0.0-alpha.4",
 		"@vue/shared": "^3.5.0",
 		"path-browserify": "^1.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         specifier: ^1.82.0
         version: 1.99.1
       '@volar/vscode':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@vscode/vsce':
         specifier: ^3.2.1
@@ -78,7 +78,7 @@ importers:
   packages/component-meta:
     dependencies:
       '@volar/typescript':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@vue/language-core':
         specifier: 3.0.0-alpha.4
@@ -105,7 +105,7 @@ importers:
   packages/language-core:
     dependencies:
       '@volar/language-core':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@vue/compiler-dom':
         specifier: ^3.5.0
@@ -142,7 +142,7 @@ importers:
         specifier: ^1.0.1
         version: 1.0.3
       '@volar/typescript':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@vue/compiler-sfc':
         specifier: ^3.5.0
@@ -151,7 +151,7 @@ importers:
   packages/language-plugin-pug:
     dependencies:
       '@volar/source-map':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       volar-service-pug:
         specifier: 0.0.64
@@ -170,13 +170,13 @@ importers:
   packages/language-server:
     dependencies:
       '@volar/language-core':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@volar/language-server':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@volar/test-utils':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@vue/language-core':
         specifier: 3.0.0-alpha.4
@@ -201,13 +201,13 @@ importers:
   packages/language-service:
     dependencies:
       '@volar/language-core':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@volar/language-service':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@volar/typescript':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@vue/compiler-dom':
         specifier: ^3.5.0
@@ -271,7 +271,7 @@ importers:
         specifier: ^1.0.1
         version: 1.0.3
       '@volar/kit':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13(typescript@5.9.0-dev.20250425)
       vscode-languageserver-protocol:
         specifier: ^3.17.5
@@ -280,7 +280,7 @@ importers:
   packages/tsc:
     dependencies:
       '@volar/typescript':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@vue/language-core':
         specifier: 3.0.0-alpha.4
@@ -296,7 +296,7 @@ importers:
   packages/typescript-plugin:
     dependencies:
       '@volar/typescript':
-        specifier: ~2.4.13
+        specifier: 2.4.13
         version: 2.4.13
       '@vue/language-core':
         specifier: 3.0.0-alpha.4


### PR DESCRIPTION
Patch versions of Volar are known to create incompatibilities with Vue Language Tools. This change fixes this problem for the @vue/language-server package downloaded from the npm registry.

For example something here https://github.com/volarjs/volar.js/compare/v2.4.11...v2.4.12 breaks Vue Language Server 2.2.8, and npm will download the latest patch release of dependency. This doesn't show up in VSCode Extension, because Volar 2.4.11 was specified in pnpm-lock of vue-language-tools monorepo, but as far as I know it might affect all other editors.

Next I'd create similar PR for `v2` branch.