### PR TITLE
feat: expose api via `vue-tsc`

### DIFF
--- a/packages/tsc/api.ts
+++ b/packages/tsc/api.ts
@@ -1,0 +1,2 @@
+export * from '@volar/typescript';
+export * from '@vue/language-core';


### PR DESCRIPTION
Expose all APIs from `vue-tsc`, so that `rolldown-plugin-dts` can just add one peer dependency, without increasing bundle size of `rolldown-plugin-dts` itself.

Also should be ported to v2 branch.