### PR TITLE
refactor(vscode): remove Vite problem matcher

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -454,21 +454,7 @@
 					"group": "navigation"
 				}
 			]
-		},
-		"problemMatchers": [
-			{
-				"name": "vite",
-				"label": "Vite problems",
-				"pattern": {
-					"regexp": ""
-				},
-				"background": {
-					"activeOnStart": true,
-					"beginsPattern": "restarting server...$",
-					"endsPattern": "\\s*ready in|server restarted."
-				}
-			}
-		]
+		}
 	},
 	"scripts": {
 		"build:dev": "rolldown --config",


### PR DESCRIPTION
Remove Vite problem matcher that added in #1320. We should recommend VSCode to have a built-in Vite problem matcher instead.