### PR TITLE
chore(docs): update vue language package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ lspconfig.ts_ls.setup {
 }
 
 -- No need to set `hybridMode` to `true` as it's the default value
-lspconfig.volar.setup {}
+lspconfig.vue_ls.setup {}
 ```
 
 ### Non-Hybrid mode(similar to takeover mode) configuration (Requires `@vue/language-server` version `^2.0.7`)


### PR DESCRIPTION
`Volar` package name in Mason registry has changed to `vue_ls` in latest, see commit history https://github.com/mason-org/mason-registry/tree/main/packages/vue-language-server