### PR TITLE
chore: mark prereleases when publishing to Open VSX

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -27,12 +27,12 @@ jobs:
 
       - name: Publish
         run: |
-          TAG_NAME=${GITHUB_REF##*/}
-          if [[ "$TAG_NAME" == *-* ]]; then
-            echo "Detected prerelease version: $TAG_NAME"
+          VERSION=$(jq -r .version package.json)
+          if [[ "$VERSION" == *-* ]]; then
+            echo "Detected prerelease version: $VERSION"
             pnpm ovsx publish --pre-release
           else
-            echo "Detected stable release version: $TAG_NAME"
+            echo "Detected stable release version: $VERSION"
             pnpm ovsx publish
           fi
         working-directory: extensions/vscode

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -26,7 +26,15 @@ jobs:
         run: pnpm run build && pnpm --filter volar run build:prod
 
       - name: Publish
-        run: pnpm ovsx publish
+        run: |
+          TAG_NAME=${GITHUB_REF##*/}
+          if [[ "$TAG_NAME" == *-* ]]; then
+            echo "Detected prerelease version: $TAG_NAME"
+            pnpm ovsx publish --pre-release
+          else
+            echo "Detected stable release version: $TAG_NAME"
+            pnpm ovsx publish
+          fi
         working-directory: extensions/vscode
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
Fixes the pre-release status of future versions. As discussed here: https://github.com/vuejs/language-tools/pull/1255#issuecomment-2906731482