### PR TITLE
chore(docs): vue_language_server_path in nvim setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Note: The "Take Over" mode has been discontinued. Instead, a new "Hybrid" mode h
 -- local vue_language_server_path = mason_registry.get_package('vue-language-server'):get_install_path() .. '/node_modules/@vue/language-server'
 -- For Mason v2,
 -- local vue_language_server_path = vim.fn.expand '$MASON/packages' .. '/vue-language-server' .. '/node_modules/@vue/language-server'
+-- or even
+-- local vue_language_server_path = vim.fn.stdpath('data') .. "/mason/packages/vue-language-server/node_modules/@vue/language-server"
 
 local vue_language_server_path = '/path/to/@vue/language-server'
 


### PR DESCRIPTION
I couldn't make the vue_language_server work in my nvim setup, I may have an issue related with the order my plugins are loading because I simply can't get the variable $MASON in my lspconfig setup file, but I do have it right when I run `:echo $MASON` from nvim command mode. Anyway, this is the approach that works for me, I guess it's worth it to also mention it to users as an alternative. I haven't used vuejs ever since I got this issue just because I couldn't make it work. 