### PR TITLE
fix(language-core): flatten plugins

### DIFF
--- a/packages/language-core/lib/plugins.ts
+++ b/packages/language-core/lib/plugins.ts
@@ -34,7 +34,7 @@ export function createPlugins(pluginContext: Parameters<VueLanguagePlugin>[0]) {
 		...pluginContext.vueCompilerOptions.plugins,
 	];
 
-	const pluginInstances = plugins.flat()
+	const pluginInstances = plugins
 		.flatMap(plugin => {
 			try {
 				const instance = plugin(pluginContext);

--- a/packages/language-core/lib/plugins.ts
+++ b/packages/language-core/lib/plugins.ts
@@ -34,7 +34,7 @@ export function createPlugins(pluginContext: Parameters<VueLanguagePlugin>[0]) {
 		...pluginContext.vueCompilerOptions.plugins,
 	];
 
-	const pluginInstances = plugins
+	const pluginInstances = plugins.flat()
 		.flatMap(plugin => {
 			try {
 				const instance = plugin(pluginContext);

--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -176,7 +176,7 @@ export class CompilerOptionsResolver {
 					break;
 				case 'plugins':
 					this.plugins = (options.plugins ?? [])
-						.map<VueLanguagePlugin>((pluginPath: string) => {
+						.flatMap<VueLanguagePlugin>((pluginPath: string) => {
 							try {
 								const resolvedPath = resolvePath(pluginPath, rootDir);
 								if (resolvedPath) {


### PR DESCRIPTION
The line below returns a nested array of plugins, so use flat() to handle it.

https://github.com/vuejs/language-tools/blob/b4ac06071bcfc0aa011fc5c9cfa09578a3fb0b18/packages/language-core/lib/utils/ts.ts#L194