### PR TITLE
fix(vscode): correct syntax highlight for directives starting with `v-for`

### DIFF
--- a/extensions/vscode/syntaxes/vue.tmLanguage.json
+++ b/extensions/vscode/syntaxes/vue.tmLanguage.json
@@ -974,13 +974,13 @@
 					"include": "#vue-directives-control"
 				},
 				{
+					"include": "#vue-directives-generic-attr"
+				},
+				{
 					"include": "#vue-directives-style-attr"
 				},
 				{
 					"include": "#vue-directives-original"
-				},
-				{
-					"include": "#vue-directives-generic-attr"
 				}
 			]
 		},
@@ -1021,14 +1021,9 @@
 				}
 			},
 			"end": "(?=\\s*[^=\\s])",
-			"endCaptures": {
-				"1": {
-					"name": "punctuation.definition.string.end.html.vue"
-				}
-			},
 			"name": "meta.attribute.directive.vue",
 			"patterns": [
-			  {
+			    {
 					"match": "(\\.)([\\w-]*)",
 					"1": {
 						"name": "punctuation.separator.key-value.html.vue"
@@ -1043,8 +1038,8 @@
 			]
 		},
 		"vue-directives-control": {
-			"begin": "(v-for)|(v-if|v-else-if|v-else)",
-			"captures": {
+			"begin": "(?:(v-for)|(v-if|v-else-if|v-else))(?==)",
+			"beginCaptures": {
 				"1": {
 					"name": "keyword.control.loop.vue"
 				},
@@ -1052,7 +1047,7 @@
 					"name": "keyword.control.conditional.vue"
 				}
 			},
-			"end": "(?=\\s*+[^=\\s])",
+			"end": "(?=\\s*[^=\\s])",
 			"name": "meta.attribute.directive.control.vue",
 			"patterns": [
 				{
@@ -1116,7 +1111,7 @@
 		},
 		"vue-directives-style-attr": {
 			"begin": "\\b(style)\\s*(=)",
-			"captures": {
+			"beginCaptures": {
 				"1": {
 					"name": "entity.other.attribute-name.html.vue"
 				},
@@ -1200,7 +1195,7 @@
 		},
 		"vue-directives-generic-attr": {
 			"begin": "\\b(generic)\\s*(=)",
-			"captures": {
+			"beginCaptures": {
 				"1": {
 					"name": "entity.other.attribute-name.html.vue"
 				},


### PR DESCRIPTION
fix #5396