### PR TITLE
refactor(language-server): drop `typescript.tsdk` initialization option

### DIFF
--- a/extensions/vscode/rolldown.config.ts
+++ b/extensions/vscode/rolldown.config.ts
@@ -60,6 +60,17 @@ const config: RolldownOptions = {
 				},
 			},
 		},
+		{
+			name: 'typescript',
+			resolveId: {
+				filter: {
+					id: /^typescript$/,
+				},
+				handler() {
+					return { id: './typescript.js', external: true };
+				},
+			},
+		},
 	],
 };
 

--- a/extensions/vscode/src/languageClient.ts
+++ b/extensions/vscode/src/languageClient.ts
@@ -65,8 +65,7 @@ async function activateLc(
 
 	// Setup typescript.js in production mode
 	if (fs.existsSync(path.join(__dirname, 'server.js'))) {
-		const { tsdk } = (await lsp.getTsdk(context))!;
-		fs.writeFileSync(path.join(__dirname, 'typescript.js'), `module.exports = require("${tsdk}/typescript.js");`);
+		fs.writeFileSync(path.join(__dirname, 'typescript.js'), `module.exports = require("${vscode.env.appRoot.replace(/\\/g, '/')}/extensions/node_modules/typescript/lib/typescript.js");`);
 	}
 
 	client = createLc(

--- a/packages/language-server/lib/types.ts
+++ b/packages/language-server/lib/types.ts
@@ -1,6 +1,5 @@
 export type VueInitializationOptions = {
 	typescript: {
-		tsdk: string;
 		tsserverRequestCommand?: string | [request: string, response: string];
 	};
 };

--- a/packages/language-server/node.ts
+++ b/packages/language-server/node.ts
@@ -1,9 +1,9 @@
 import type { LanguageServer } from '@volar/language-server';
 import { createLanguageServiceEnvironment } from '@volar/language-server/lib/project/simpleProject';
-import { createConnection, createServer, loadTsdkByPath } from '@volar/language-server/node';
+import { createConnection, createServer } from '@volar/language-server/node';
 import { createLanguage, createParsedCommandLine, createVueLanguagePlugin, getDefaultCompilerOptions } from '@vue/language-core';
 import { createLanguageService, createUriMap, getHybridModeLanguageServicePlugins, type LanguageService } from '@vue/language-service';
-import type * as ts from 'typescript';
+import * as ts from 'typescript';
 import { URI } from 'vscode-uri';
 import type { VueInitializationOptions } from './lib/types';
 
@@ -15,14 +15,10 @@ connection.listen();
 connection.onInitialize(params => {
 	const options: VueInitializationOptions = params.initializationOptions;
 
-	if (!options.typescript?.tsdk) {
-		throw new Error('typescript.tsdk is required');
-	}
 	if (!options.typescript?.tsserverRequestCommand) {
 		connection.console.warn('typescript.tsserverRequestCommand is required since >= 3.0 for complete TS features');
 	}
 
-	const { typescript: ts } = loadTsdkByPath(options.typescript.tsdk, params.locale);
 	const tsconfigProjects = createUriMap<LanguageService>();
 	const file2ProjectInfo = new Map<string, Promise<ts.server.protocol.ProjectInfo | null>>();
 
@@ -204,4 +200,3 @@ connection.onInitialize(params => {
 connection.onInitialized(server.initialized);
 
 connection.onShutdown(server.shutdown);
-

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -25,6 +25,9 @@
 		"vscode-languageserver-protocol": "^3.17.5",
 		"vscode-uri": "^3.0.8"
 	},
+	"peerDependencies": {
+		"typescript": "*"
+	},
 	"devDependencies": {
 		"@typescript/server-harness": "latest"
 	}

--- a/packages/language-server/tests/server.ts
+++ b/packages/language-server/tests/server.ts
@@ -57,7 +57,6 @@ export async function getLanguageServer(): Promise<{
 			URI.file(testWorkspacePath).toString(),
 			{
 				typescript: {
-					tsdk: path.dirname(require.resolve('typescript/lib/typescript.js')),
 					tsserverRequestCommand: 'tsserverRequest',
 				},
 			} satisfies VueInitializationOptions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@vue/typescript-plugin':
         specifier: 3.0.0-alpha.8
         version: link:../typescript-plugin
+      typescript:
+        specifier: '*'
+        version: 5.8.3
       vscode-languageserver-protocol:
         specifier: ^3.17.5
         version: 3.17.5


### PR DESCRIPTION
In v3, the Vue language server no longer provides TS semantic functionality, and the configurable TSDK version no longer makes sense. Changing typescript to a peer dependency will simplify all IDE integrations.