### PR TITLE
test(tsc): remove typescript-next test

### DIFF
--- a/packages/tsc/tests/typecheck.spec.ts
+++ b/packages/tsc/tests/typecheck.spec.ts
@@ -6,28 +6,7 @@ describe(`vue-tsc`, () => {
 
 	test(`TypeScript - Stable`, () => {
 		expect(
-			getTscOutput('stable').sort()
-		).toMatchInlineSnapshot(`
-			[
-			  "test-workspace/tsc/failureFixtures/#3632/both.vue(3,1): error TS1109: Expression expected.",
-			  "test-workspace/tsc/failureFixtures/#3632/both.vue(7,1): error TS1109: Expression expected.",
-			  "test-workspace/tsc/failureFixtures/#3632/script.vue(3,1): error TS1109: Expression expected.",
-			  "test-workspace/tsc/failureFixtures/#3632/scriptSetup.vue(3,1): error TS1109: Expression expected.",
-			  "test-workspace/tsc/failureFixtures/#5071/withScript.vue(1,19): error TS1005: ';' expected.",
-			  "test-workspace/tsc/failureFixtures/#5071/withoutScript.vue(2,26): error TS1005: ';' expected.",
-			  "test-workspace/tsc/failureFixtures/directives/main.vue(12,2): error TS2578: Unused '@ts-expect-error' directive.",
-			  "test-workspace/tsc/failureFixtures/directives/main.vue(4,6): error TS2339: Property 'notExist' does not exist on type 'CreateComponentPublicInstanceWithMixins<Readonly<{} & {} & {}>, { exist: {}; }, {}, {}, {}, {}, {}, {}, PublicProps, {}, true, {}, {}, GlobalComponents, GlobalDirectives, ... 12 more ..., {}>'.",
-			  "test-workspace/tsc/failureFixtures/directives/main.vue(9,6): error TS2339: Property 'notExist' does not exist on type 'CreateComponentPublicInstanceWithMixins<Readonly<{} & {} & {}>, { exist: {}; }, {}, {}, {}, {}, {}, {}, PublicProps, {}, true, {}, {}, GlobalComponents, GlobalDirectives, ... 12 more ..., {}>'.",
-			]
-		`);
-	});
-
-	const isUpdateEvent = process.env.npm_lifecycle_event === 'test:update';
-	const isGithubActions = !!process.env.GITHUB_ACTIONS;
-
-	test.skipIf(!isUpdateEvent && isGithubActions)(`TypeScript - Next`, () => {
-		expect(
-			getTscOutput('next').sort()
+			getTscOutput().sort()
 		).toMatchInlineSnapshot(`
 			[
 			  "test-workspace/tsc/failureFixtures/#3632/both.vue(3,1): error TS1109: Expression expected.",
@@ -44,7 +23,7 @@ describe(`vue-tsc`, () => {
 	});
 });
 
-function getTscOutput(tsVersion: 'stable' | 'next') {
+function getTscOutput() {
 	const consoleOutput: string[] = [];
 	const originalConsoleLog = process.stdout.write;
 	const originalArgv = process.argv;
@@ -61,7 +40,7 @@ function getTscOutput(tsVersion: 'stable' | 'next') {
 	];
 	try {
 		const tscPath = require.resolve(
-			`typescript-${tsVersion}/lib/tsc`,
+			`typescript/lib/tsc`,
 			{ paths: [path.resolve(__dirname, '../../../test-workspace')] }
 		);
 		run(tscPath);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,12 +314,9 @@ importers:
 
   test-workspace:
     devDependencies:
-      typescript-next:
-        specifier: npm:typescript@next
-        version: typescript@5.9.0-dev.20250425
-      typescript-stable:
-        specifier: npm:typescript@latest
-        version: typescript@5.8.3
+      typescript:
+        specifier: latest
+        version: 5.8.3
       vue:
         specifier: https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72
         version: https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript@5.8.3)

--- a/test-workspace/package.json
+++ b/test-workspace/package.json
@@ -2,8 +2,7 @@
 	"private": true,
 	"version": "3.0.0-alpha.10",
 	"devDependencies": {
-		"typescript-next": "npm:typescript@next",
-		"typescript-stable": "npm:typescript@latest",
+		"typescript": "latest",
 		"vue": "https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72",
 		"vue-component-type-helpers": "3.0.0-alpha.10",
 		"vue3.4": "npm:vue@3.4.38"


### PR DESCRIPTION
We tried adding typescript@next to CI tests to catch regressions in future TS versions in advance, but in real experience this approach never really helped us find regressions, and we should remove it to speed up testing time and look for other more suitable approaches.