### PR TITLE
refactor(language-server): move in server code from insiders edition

### DIFF
--- a/extensions/vscode/lib/splitEditors.ts
+++ b/extensions/vscode/lib/splitEditors.ts
@@ -1,4 +1,4 @@
-import { ExecuteCommandRequest, type BaseLanguageClient, type ExecuteCommandParams } from '@volar/vscode';
+import { type BaseLanguageClient } from '@volar/vscode';
 import type { SFCBlock, SFCParseResult } from '@vue/compiler-sfc';
 import { executeCommand, useActiveTextEditor, useCommand } from 'reactive-vscode';
 import * as vscode from 'vscode';
@@ -20,10 +20,9 @@ export function activate(client: BaseLanguageClient) {
 		if (!astMap.has(doc) || astMap.get(doc)![0] !== doc.version) {
 			astMap.set(doc, [
 				doc.version,
-				client.sendRequest(ExecuteCommandRequest.type, {
-					command: 'vue.parseSfc',
-					arguments: [doc.getText()],
-				} satisfies ExecuteCommandParams),
+				client.sendRequest('vue/parseSfc', {
+					textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(doc),
+				}),
 			]);
 		}
 		const ast = await astMap.get(doc)![1];

--- a/packages/language-core/lib/parsers/scriptSetupRanges.ts
+++ b/packages/language-core/lib/parsers/scriptSetupRanges.ts
@@ -451,7 +451,7 @@ export function parseBindingRanges(ts: typeof import('typescript'), ast: ts.Sour
 	}
 }
 
-function findBindingVars(
+export function findBindingVars(
 	ts: typeof import('typescript'),
 	left: ts.BindingName,
 	ast: ts.SourceFile

--- a/packages/language-server/index.ts
+++ b/packages/language-server/index.ts
@@ -1,10 +1,13 @@
-import type { LanguageServer } from '@volar/language-server';
+import type { LanguageServer, Position, TextDocumentIdentifier } from '@volar/language-server';
+import { type Range, TextDocument } from '@volar/language-server';
 import { createLanguageServiceEnvironment } from '@volar/language-server/lib/project/simpleProject';
 import { createConnection, createServer } from '@volar/language-server/node';
-import { createLanguage, createParsedCommandLine, createVueLanguagePlugin, getDefaultCompilerOptions } from '@vue/language-core';
-import { createLanguageService, createUriMap, createVueLanguageServicePlugins, type LanguageService } from '@vue/language-service';
+import { createLanguage, createParsedCommandLine, createVueLanguagePlugin, forEachEmbeddedCode, getDefaultCompilerOptions, isReferencesEnabled, parse } from '@vue/language-core';
+import { createLanguageService, createUriMap, createVueLanguageServicePlugins, type DocumentsAndMap, getSourceRange, type LanguageService } from '@vue/language-service';
 import * as ts from 'typescript';
 import { URI } from 'vscode-uri';
+import { analyze } from './lib/reactionsAnalyze';
+import { getLanguageService } from './lib/reactionsAnalyzeLS';
 
 const connection = createConnection();
 const server = createServer(connection);
@@ -186,3 +189,183 @@ connection.onInitialize(params => {
 connection.onInitialized(server.initialized);
 
 connection.onShutdown(server.shutdown);
+
+connection.onRequest('vue/parseSfc', (params: {
+	textDocument: TextDocumentIdentifier;
+}) => {
+	const document = server.documents.get(URI.parse(params.textDocument.uri));
+	if (document) {
+		return parse(document.getText());
+	}
+});
+
+connection.onRequest('vue/interpolationRanges', async (params: {
+	textDocument: TextDocumentIdentifier;
+}): Promise<[number, number][]> => {
+	const uri = URI.parse(params.textDocument.uri);
+	const languageService = await server.project.getLanguageService(uri);
+	if (languageService) {
+		const sourceFile = languageService.context.language.scripts.get(uri);
+		if (sourceFile?.generated) {
+			const ranges: [number, number][] = [];
+			for (const code of forEachEmbeddedCode(sourceFile.generated.root)) {
+				const codeText = code.snapshot.getText(0, code.snapshot.getLength());
+				if (
+					(
+						code.id.startsWith('template_inline_ts_')
+						&& codeText.startsWith('0 +')
+						&& codeText.endsWith('+ 0;')
+					)
+					|| (code.id.startsWith('style_') && code.id.endsWith('_inline_ts'))
+				) {
+					for (const mapping of code.mappings) {
+						for (let i = 0; i < mapping.sourceOffsets.length; i++) {
+							ranges.push([
+								mapping.sourceOffsets[i],
+								mapping.sourceOffsets[i] + mapping.lengths[i],
+							]);
+						}
+					}
+				}
+			}
+			return ranges;
+		}
+	}
+	return [];
+});
+
+const cacheDocuments = new Map<string, [TextDocument, import('typescript').IScriptSnapshot]>();
+
+connection.onRequest('vue/reactionsAnalyze', async (params: {
+	textDocument: TextDocumentIdentifier;
+	position: Position;
+	syncDocument?: {
+		content: string;
+		languageId: string;
+	};
+}): Promise<{
+	subscribers: Range[];
+	dependencies: Range[];
+} | undefined> => {
+	if (params.syncDocument) {
+		const document = TextDocument.create(params.textDocument.uri, params.syncDocument.languageId, 0, params.syncDocument.content);
+		const snapshot = ts.ScriptSnapshot.fromString(params.syncDocument.content);
+		cacheDocuments.set(params.textDocument.uri, [document, snapshot]);
+	}
+	const uri = URI.parse(params.textDocument.uri);
+	const languageService = await server.project.getLanguageService(uri);
+	const sourceScript = languageService.context.language.scripts.get(uri);
+	let document: TextDocument | undefined;
+	let snapshot: import('typescript').IScriptSnapshot | undefined;
+	if (sourceScript) {
+		document = languageService.context.documents.get(sourceScript.id, sourceScript.languageId, sourceScript.snapshot);
+		snapshot = sourceScript.snapshot;
+	}
+	else if (cacheDocuments.has(params.textDocument.uri)) {
+		const [doc, snap] = cacheDocuments.get(params.textDocument.uri)!;
+		document = doc;
+		snapshot = snap;
+	}
+	if (!document || !snapshot) {
+		return;
+	}
+	let offset = document.offsetAt(params.position);
+	if (sourceScript?.generated) {
+		const serviceScript = sourceScript.generated.languagePlugin.typescript?.getServiceScript(sourceScript.generated.root);
+		if (!serviceScript) {
+			return;
+		}
+		const map = languageService.context.language.maps.get(serviceScript.code, sourceScript);
+		let embeddedOffset: number | undefined;
+		for (const [mapped, mapping] of map.toGeneratedLocation(offset)) {
+			if (isReferencesEnabled(mapping.data)) {
+				embeddedOffset = mapped;
+				break;
+			}
+		}
+		if (embeddedOffset === undefined) {
+			return;
+		}
+		offset = embeddedOffset;
+
+		const embeddedUri = languageService.context.encodeEmbeddedDocumentUri(sourceScript.id, serviceScript.code.id);
+		document = languageService.context.documents.get(embeddedUri, serviceScript.code.languageId, serviceScript.code.snapshot);
+		snapshot = serviceScript.code.snapshot;
+	}
+	const { languageService: tsLs, fileName } = getLanguageService(ts, snapshot, document.languageId);
+	const result = analyze(ts, tsLs, fileName, offset);
+	if (!result) {
+		return;
+	}
+	const subscribers: Range[] = [];
+	const dependencies: Range[] = [];
+	if (sourceScript?.generated) {
+		const serviceScript = sourceScript.generated.languagePlugin.typescript?.getServiceScript(sourceScript.generated.root);
+		if (!serviceScript) {
+			return;
+		}
+		const docs: DocumentsAndMap = [
+			languageService.context.documents.get(sourceScript.id, sourceScript.languageId, sourceScript.snapshot),
+			document,
+			languageService.context.language.maps.get(serviceScript.code, sourceScript),
+		];
+		for (const dependency of result.dependencies) {
+			let start = document.positionAt(dependency.getStart(result.sourceFile));
+			let end = document.positionAt(dependency.getEnd());
+			if (ts.isBlock(dependency) && dependency.statements.length) {
+				const { statements } = dependency;
+				start = document.positionAt(statements[0].getStart(result.sourceFile));
+				end = document.positionAt(statements[statements.length - 1].getEnd());
+			}
+			const sourceRange = getSourceRange(docs, { start, end });
+			if (sourceRange) {
+				dependencies.push(sourceRange);
+			}
+		}
+		for (const subscriber of result.subscribers) {
+			if (!subscriber.sideEffectInfo) {
+				continue;
+			}
+			let start = document.positionAt(subscriber.sideEffectInfo.handler.getStart(result.sourceFile));
+			let end = document.positionAt(subscriber.sideEffectInfo.handler.getEnd());
+			if (ts.isBlock(subscriber.sideEffectInfo.handler) && subscriber.sideEffectInfo.handler.statements.length) {
+				const { statements } = subscriber.sideEffectInfo.handler;
+				start = document.positionAt(statements[0].getStart(result.sourceFile));
+				end = document.positionAt(statements[statements.length - 1].getEnd());
+			}
+			const sourceRange = getSourceRange(docs, { start, end });
+			if (sourceRange) {
+				subscribers.push(sourceRange);
+			}
+		}
+	}
+	else {
+		for (const dependency of result.dependencies) {
+			let start = document.positionAt(dependency.getStart(result.sourceFile));
+			let end = document.positionAt(dependency.getEnd());
+			if (ts.isBlock(dependency) && dependency.statements.length) {
+				const { statements } = dependency;
+				start = document.positionAt(statements[0].getStart(result.sourceFile));
+				end = document.positionAt(statements[statements.length - 1].getEnd());
+			}
+			dependencies.push({ start, end });
+		}
+		for (const subscriber of result.subscribers) {
+			if (!subscriber.sideEffectInfo) {
+				continue;
+			}
+			let start = document.positionAt(subscriber.sideEffectInfo.handler.getStart(result.sourceFile));
+			let end = document.positionAt(subscriber.sideEffectInfo.handler.getEnd());
+			if (ts.isBlock(subscriber.sideEffectInfo.handler) && subscriber.sideEffectInfo.handler.statements.length) {
+				const { statements } = subscriber.sideEffectInfo.handler;
+				start = document.positionAt(statements[0].getStart(result.sourceFile));
+				end = document.positionAt(statements[statements.length - 1].getEnd());
+			}
+			subscribers.push({ start, end });
+		}
+	}
+	return {
+		subscribers,
+		dependencies,
+	};
+});

--- a/packages/language-server/lib/reactionsAnalyze.ts
+++ b/packages/language-server/lib/reactionsAnalyze.ts
@@ -1,0 +1,500 @@
+import { findBindingVars, hyphenateAttr, type TextRange } from '@vue/language-core';
+import type * as ts from 'typescript';
+
+const enum TrackKind {
+	AccessDotValue,
+	AccessAnyValue,
+	Call,
+}
+
+interface SignalNode {
+	bindingInfo?: {
+		isRef: boolean;
+		name: ts.BindingName;
+		trackKinds: TrackKind[];
+	};
+	trackInfo?: {
+		depsHandler: ts.Node;
+		needToUse: boolean;
+	};
+	sideEffectInfo?: {
+		isEffect: boolean;
+		handler: ts.Node;
+	};
+}
+
+export function analyze(
+	ts: typeof import('typescript'),
+	languageService: ts.LanguageService,
+	fileName: string,
+	position: number
+) {
+	const sourceFile = languageService.getProgram()!.getSourceFile(fileName)!;
+	const { signals, dotValueAccesses, dotAnyAccesses, functionCalls } = collect(ts, sourceFile);
+	let signal = findSignalByNamePosition(position);
+	if (!signal) {
+		signal = findEffectByEffectHandlerPosition(position);
+		if (signal?.bindingInfo) {
+			position = signal.bindingInfo.name.getStart(sourceFile);
+		}
+	}
+	if (!signal) {
+		return;
+	}
+	const subscribers = signal.bindingInfo
+		? findSubscribers(signal.bindingInfo.name, signal.bindingInfo.trackKinds)
+		: [];
+	const dependencies = signal
+		? findDependencies(signal)
+		: [];
+
+	if (
+		(!signal.sideEffectInfo?.isEffect && !subscribers.length)
+		|| (!signal.bindingInfo?.isRef && !dependencies.length)
+	) {
+		return;
+	}
+
+	return {
+		sourceFile,
+		subscribers: [...new Set(subscribers)],
+		dependencies: [...new Set(dependencies)],
+	};
+
+	function findDependencies(signal: SignalNode, visited = new Set<SignalNode>()) {
+		if (visited.has(signal)) {
+			return [];
+		}
+		visited.add(signal);
+
+		const nodes: ts.Node[] = [];
+		let hasRef = signal.bindingInfo?.isRef ?? false;
+
+		if (signal.trackInfo) {
+			const { needToUse } = signal.trackInfo;
+			visit(signal.trackInfo.depsHandler, needToUse);
+			signal.trackInfo.depsHandler.forEachChild(child => visit(child, needToUse));
+		}
+
+		if (!hasRef) {
+			return [];
+		}
+
+		return nodes;
+
+		function visit(node: ts.Node, needToUse: boolean, parentIsPropertyAccess = false) {
+			if (!needToUse) {
+				if (!parentIsPropertyAccess && ts.isIdentifier(node)) {
+					const definition = languageService.getDefinitionAtPosition(fileName, node.getStart(sourceFile));
+					for (const info of definition ?? []) {
+						if (info.fileName !== fileName) {
+							continue;
+						}
+						const signal = findSignalByNamePosition(info.textSpan.start);
+						if (!signal) {
+							continue;
+						}
+						if (signal.bindingInfo) {
+							nodes.push(signal.bindingInfo.name);
+							hasRef ||= signal.bindingInfo.isRef;
+						}
+						if (signal.sideEffectInfo) {
+							nodes.push(signal.sideEffectInfo.handler);
+						}
+						const deps = findDependencies(signal, visited);
+						nodes.push(...deps);
+						hasRef ||= deps.length > 0;
+					}
+				}
+			}
+			else if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node) || ts.isCallExpression(node)) {
+				const definition = languageService.getDefinitionAtPosition(fileName, node.expression.getStart(sourceFile));
+				for (const info of definition ?? []) {
+					if (info.fileName !== fileName) {
+						continue;
+					}
+					const signal = findSignalByNamePosition(info.textSpan.start);
+					if (!signal) {
+						continue;
+					}
+					const oldSize = nodes.length;
+					if (signal.bindingInfo) {
+						for (const trackKind of signal.bindingInfo.trackKinds) {
+							if (ts.isPropertyAccessExpression(node)) {
+								if (trackKind === TrackKind.AccessDotValue && node.name.text === 'value') {
+									nodes.push(signal.bindingInfo.name);
+									hasRef ||= signal.bindingInfo.isRef;
+								}
+								if (trackKind === TrackKind.AccessAnyValue && node.name.text !== '') {
+									nodes.push(signal.bindingInfo.name);
+									hasRef ||= signal.bindingInfo.isRef;
+								}
+							}
+							else if (ts.isElementAccessExpression(node)) {
+								if (trackKind === TrackKind.AccessAnyValue) {
+									nodes.push(signal.bindingInfo.name);
+									hasRef ||= signal.bindingInfo.isRef;
+								}
+							}
+							else if (ts.isCallExpression(node)) {
+								if (trackKind === TrackKind.Call) {
+									nodes.push(signal.bindingInfo.name);
+									hasRef ||= signal.bindingInfo.isRef;
+								}
+							}
+						}
+					}
+					const signalDetected = nodes.length > oldSize;
+					if (signalDetected) {
+						if (signal.sideEffectInfo) {
+							nodes.push(signal.sideEffectInfo.handler);
+						}
+						const deps = findDependencies(signal, visited);
+						nodes.push(...deps);
+						hasRef ||= deps.length > 0;
+					}
+				}
+			}
+			node.forEachChild(child => visit(child, needToUse, ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)));
+		};
+	}
+
+	function findSubscribers(refName: ts.BindingName, trackKinds: TrackKind[], visited = new Set<number>()) {
+		return findBindingVars(ts, refName, sourceFile)
+			.map(binding => findSubscribersWorker(binding, trackKinds, visited))
+			.flat();
+	}
+
+	function findSubscribersWorker(refName: TextRange, trackKinds: TrackKind[], visited = new Set<number>()) {
+		if (visited.has(refName.start)) {
+			return [];
+		}
+		visited.add(refName.start);
+
+		const references = languageService.findReferences(fileName, refName.start);
+		if (!references) {
+			return [];
+		}
+		const result: typeof signals = [];
+		for (const reference of references) {
+			for (const reference2 of reference.references) {
+				if (reference2.fileName !== fileName) {
+					continue;
+				}
+				const effect = findEffectByDepsHandlerPosition(reference2.textSpan.start);
+				if (effect?.trackInfo) {
+					if (effect.trackInfo.needToUse) {
+						let match = false;
+						for (const trackKind of trackKinds) {
+							if (trackKind === TrackKind.AccessAnyValue) {
+								match = dotAnyAccesses.has(reference2.textSpan.start + reference2.textSpan.length);
+							}
+							else if (trackKind === TrackKind.AccessDotValue) {
+								match = dotValueAccesses.has(reference2.textSpan.start + reference2.textSpan.length);
+							}
+							else if (trackKind === TrackKind.Call) {
+								match = functionCalls.has(reference2.textSpan.start + reference2.textSpan.length);
+							}
+							if (match) {
+								break;
+							}
+						}
+						if (!match) {
+							continue;
+						}
+					}
+					let hasEffect = effect.sideEffectInfo?.isEffect;
+					if (effect.bindingInfo) {
+						const subs = findSubscribers(effect.bindingInfo.name, effect.bindingInfo.trackKinds, visited);
+						result.push(...subs);
+						hasEffect ||= subs.length > 0;
+					}
+					if (hasEffect) {
+						result.push(effect);
+					}
+				}
+			}
+		}
+		return result;
+	}
+
+	function findSignalByNamePosition(position: number) {
+		return signals.find(ref => ref.bindingInfo && ref.bindingInfo.name.getStart(sourceFile) <= position && ref.bindingInfo.name.getEnd() >= position);
+	}
+
+	function findEffectByEffectHandlerPosition(position: number) {
+		return signals.find(ref => ref.sideEffectInfo && ref.sideEffectInfo.handler.getStart(sourceFile) <= position && ref.sideEffectInfo.handler.getEnd() >= position);
+	}
+
+	function findEffectByDepsHandlerPosition(position: number) {
+		return signals.find(ref => ref.trackInfo && ref.trackInfo.depsHandler.getStart(sourceFile) <= position && ref.trackInfo.depsHandler.getEnd() >= position);
+	}
+}
+
+function collect(ts: typeof import('typescript'), sourceFile: ts.SourceFile) {
+	const signals: SignalNode[] = [];
+	const dotValueAccesses = new Set<number>();
+	const dotAnyAccesses = new Set<number>();
+	const functionCalls = new Set<number>();
+
+	sourceFile.forEachChild(function visit(node) {
+		if (ts.isVariableDeclaration(node)) {
+			if (node.initializer && ts.isCallExpression(node.initializer)) {
+				const call = node.initializer;
+				if (ts.isIdentifier(call.expression)) {
+					const callName = call.expression.escapedText as string;
+					if (callName === 'ref' || callName === 'shallowRef' || callName === 'toRef' || callName === 'useTemplateRef' || callName === 'defineModel') {
+						signals.push({
+							bindingInfo: {
+								isRef: true,
+								name: node.name,
+								trackKinds: [TrackKind.AccessDotValue],
+							},
+						});
+					}
+					else if (callName === 'reactive' || callName === 'shallowReactive' || callName === 'defineProps' || callName === 'withDefaults') {
+						signals.push({
+							bindingInfo: {
+								isRef: true,
+								name: node.name,
+								trackKinds: [TrackKind.AccessAnyValue],
+							},
+						});
+					}
+					// TODO: toRefs
+				}
+			}
+		}
+		else if (ts.isFunctionDeclaration(node)) {
+			if (node.name && node.body) {
+				signals.push({
+					bindingInfo: {
+						isRef: false,
+						name: node.name,
+						trackKinds: [TrackKind.Call],
+					},
+					trackInfo: {
+						depsHandler: node.body,
+						needToUse: true,
+					},
+					sideEffectInfo: {
+						isEffect: false,
+						handler: node.body,
+					},
+				});
+			}
+		}
+		else if (ts.isVariableStatement(node)) {
+			for (const declaration of node.declarationList.declarations) {
+				const name = declaration.name;
+				const callback = declaration.initializer;
+				if (callback && ts.isIdentifier(name) && (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))) {
+					signals.push({
+						bindingInfo: {
+							isRef: false,
+							name: name,
+							trackKinds: [TrackKind.Call],
+						},
+						trackInfo: {
+							depsHandler: callback,
+							needToUse: true,
+						},
+						sideEffectInfo: {
+							isEffect: false,
+							handler: callback,
+						},
+					});
+				}
+			}
+		}
+		else if (ts.isParameter(node)) {
+			if (node.type && node.type && ts.isTypeReferenceNode(node.type)) {
+				const typeName = node.type.typeName.getText(sourceFile);
+				if (typeName.endsWith('Ref')) {
+					signals.push({
+						bindingInfo: {
+							isRef: true,
+							name: node.name,
+							trackKinds: [TrackKind.AccessDotValue],
+						},
+					});
+				}
+			}
+		}
+		else if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+			const call = node;
+			const callName = node.expression.escapedText as string;
+			if ((callName === 'effect' || callName === 'watchEffect') && call.arguments.length) {
+				const callback = call.arguments[0];
+				if (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback)) {
+					signals.push({
+						trackInfo: {
+							depsHandler: callback.body,
+							needToUse: true,
+						},
+						sideEffectInfo: {
+							isEffect: true,
+							handler: callback.body,
+						},
+					});
+				}
+			}
+			if (callName === 'watch' && call.arguments.length >= 2) {
+				const depsCallback = call.arguments[0];
+				const effectCallback = call.arguments[1];
+				if (ts.isArrowFunction(effectCallback) || ts.isFunctionExpression(effectCallback)) {
+					if (ts.isArrowFunction(depsCallback) || ts.isFunctionExpression(depsCallback)) {
+						signals.push({
+							trackInfo: {
+								depsHandler: depsCallback.body,
+								needToUse: true,
+							},
+							sideEffectInfo: {
+								isEffect: true,
+								handler: effectCallback.body,
+							},
+						});
+					}
+					else {
+						signals.push({
+							trackInfo: {
+								depsHandler: depsCallback,
+								needToUse: false,
+							},
+							sideEffectInfo: {
+								isEffect: true,
+								handler: effectCallback.body,
+							}
+						});
+					}
+				}
+			}
+			else if (hyphenateAttr(callName).startsWith('use-')) {
+				signals.push({
+					bindingInfo: ts.isVariableDeclaration(call.parent)
+						? {
+							isRef: true,
+							name: call.parent.name,
+							trackKinds: [TrackKind.AccessAnyValue, TrackKind.Call],
+						}
+						: undefined,
+					trackInfo: {
+						depsHandler: call,
+						needToUse: false,
+					},
+				});
+			}
+			else if ((callName === 'computed' || hyphenateAttr(callName).endsWith('-computed')) && call.arguments.length) {
+				const arg = call.arguments[0];
+				if (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)) {
+					signals.push({
+						bindingInfo: ts.isVariableDeclaration(call.parent)
+							? {
+								isRef: true,
+								name: call.parent.name,
+								trackKinds: [TrackKind.AccessDotValue],
+							}
+							: undefined,
+						trackInfo: {
+							depsHandler: arg.body,
+							needToUse: true,
+						},
+						sideEffectInfo: {
+							isEffect: true,
+							handler: arg.body,
+						},
+					});
+				}
+				else if (ts.isIdentifier(arg)) {
+					signals.push({
+						bindingInfo: ts.isVariableDeclaration(call.parent)
+							? {
+								isRef: true,
+								name: call.parent.name,
+								trackKinds: [TrackKind.AccessDotValue],
+							}
+							: undefined,
+						trackInfo: {
+							depsHandler: arg,
+							needToUse: false,
+						},
+					});
+				}
+				else if (ts.isObjectLiteralExpression(arg)) {
+					for (const prop of arg.properties) {
+						if (prop.name?.getText(sourceFile) === 'get') {
+							if (ts.isPropertyAssignment(prop)) {
+								const callback = prop.initializer;
+								if (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback)) {
+									signals.push({
+										bindingInfo: ts.isVariableDeclaration(call.parent)
+											? {
+												isRef: true,
+												name: call.parent.name,
+												trackKinds: [TrackKind.AccessDotValue],
+											}
+											: undefined,
+										trackInfo: {
+											depsHandler: callback.body,
+											needToUse: true,
+										},
+										sideEffectInfo: {
+											isEffect: true,
+											handler: callback.body,
+										},
+									});
+								}
+							}
+							else if (ts.isMethodDeclaration(prop) && prop.body) {
+								signals.push({
+									bindingInfo: ts.isVariableDeclaration(call.parent)
+										? {
+											isRef: true,
+											name: call.parent.name,
+											trackKinds: [TrackKind.AccessDotValue],
+										}
+										: undefined,
+									trackInfo: {
+										depsHandler: prop.body,
+										needToUse: true,
+									},
+									sideEffectInfo: {
+										isEffect: true,
+										handler: prop.body,
+									},
+								});
+							}
+						}
+					}
+				}
+			}
+		}
+		node.forEachChild(visit);
+	});
+
+	sourceFile.forEachChild(function visit(node) {
+		if (ts.isPropertyAccessExpression(node)) {
+			if (node.name.text === 'value') {
+				dotValueAccesses.add(node.expression.getEnd());
+				dotAnyAccesses.add(node.expression.getEnd());
+			}
+			else if (node.name.text !== '') {
+				dotAnyAccesses.add(node.expression.getEnd());
+			}
+		}
+		else if (ts.isElementAccessExpression(node)) {
+			dotAnyAccesses.add(node.expression.getEnd());
+		}
+		else if (ts.isCallExpression(node)) {
+			functionCalls.add(node.expression.getEnd());
+		}
+		node.forEachChild(visit);
+	});
+
+	return {
+		signals,
+		dotValueAccesses,
+		dotAnyAccesses,
+		functionCalls,
+	};
+}

--- a/packages/language-server/lib/reactionsAnalyzeLS.ts
+++ b/packages/language-server/lib/reactionsAnalyzeLS.ts
@@ -1,0 +1,37 @@
+import type * as ts from 'typescript';
+
+let currentProjectVersion = -1;
+let currentFileName = '';
+let currentSnapshot: ts.IScriptSnapshot | undefined;
+let languageService: ts.LanguageService | undefined;
+
+const host: ts.LanguageServiceHost = {
+	getProjectVersion: () => currentProjectVersion.toString(),
+	getScriptFileNames: () => [currentFileName],
+	getScriptVersion: () => currentProjectVersion.toString(),
+	getScriptSnapshot: fileName => fileName === currentFileName ? currentSnapshot : undefined,
+	getCompilationSettings: () => ({}),
+	getCurrentDirectory: () => '',
+	getDefaultLibFileName: () => '',
+	readFile: () => undefined,
+	fileExists: fileName => fileName === currentFileName,
+};
+
+// TODO: share with volar-service-typescript
+export function getLanguageService(ts: typeof import('typescript'), snapshot: ts.IScriptSnapshot, languageId: string) {
+	if (currentSnapshot !== snapshot) {
+		currentSnapshot = snapshot;
+		currentFileName = '/tmp.' + (
+			languageId === 'javascript' ? 'js' :
+				languageId === 'typescriptreact' ? 'tsx' :
+					languageId === 'javascriptreact' ? 'jsx' :
+						'ts'
+		);
+		currentProjectVersion++;
+	}
+	languageService ??= ts.createLanguageService(host);
+	return {
+		languageService,
+		fileName: currentFileName,
+	};
+}

--- a/packages/language-service/index.ts
+++ b/packages/language-service/index.ts
@@ -1,9 +1,11 @@
 /// <reference types="@volar/typescript" />
 
 export * from '@volar/language-service';
+// for @vue/language-server usage
+export * from '@volar/language-service/lib/utils/featureWorkers';
 
 import type { LanguageServiceContext, LanguageServicePlugin } from '@volar/language-service';
-import { parse, type VueCompilerOptions } from '@vue/language-core';
+import type { VueCompilerOptions } from '@vue/language-core';
 import type * as ts from 'typescript';
 
 import { create as createEmmetPlugin } from 'volar-service-emmet';
@@ -86,20 +88,5 @@ function getCommonLanguageServicePlugins(
 				'postcss': 'scss',
 			},
 		}),
-		{
-			name: 'vue-parse-sfc',
-			capabilities: {
-				executeCommandProvider: {
-					commands: ['vue.parseSfc'],
-				},
-			},
-			create() {
-				return {
-					executeCommand(_command, [source]) {
-						return parse(source);
-					},
-				};
-			},
-		},
 	];
 }


### PR DESCRIPTION
Move in the server code of Insiders edition features to allow integration with IDEs other than VSCode.

The current code is not neat and needs to be refactored in the next PR.