### PR TITLE
fix(language-core): remove calculation logic of element inner loc

### DIFF
--- a/packages/language-core/lib/codegen/template/vSlot.ts
+++ b/packages/language-core/lib/codegen/template/vSlot.ts
@@ -50,10 +50,9 @@ export function* generateVSlot(
 			}
 		} else {
 			// #932: reference for implicit default slot
-			const { start, end } = getElementInnerLoc(options, node);
 			yield* wrapWith(
-				start,
-				end,
+				node.loc.start.offset,
+				node.loc.end.offset,
 				ctx.codeFeatures.navigation,
 				`default`,
 			);
@@ -78,11 +77,10 @@ export function* generateVSlot(
 	}
 
 	if (options.vueCompilerOptions.strictSlotChildren && node.children.length) {
-		const { start, end } = getElementInnerLoc(options, node);
 		yield `(): __VLS_NormalizeSlotReturns<typeof ${slotVar}> => (`;
 		yield* wrapWith(
-			start,
-			end,
+			node.loc.start.offset,
+			node.loc.end.offset,
 			ctx.codeFeatures.verification,
 			`{} as [`,
 			...ctx.currentComponent.childTypes.map(name => `${name}, `),
@@ -178,30 +176,5 @@ function* generateSlotParameters(
 			startOffset + start,
 			ctx.codeFeatures.all,
 		];
-	}
-}
-
-function getElementInnerLoc(
-	options: TemplateCodegenOptions,
-	node: CompilerDOM.ElementNode,
-) {
-	if (node.children.length) {
-		let start = node.children[0].loc.start.offset;
-		let end = node.children.at(-1)!.loc.end.offset;
-		while (options.template.content[start - 1] !== '>') {
-			start--;
-		}
-		while (options.template.content[end] !== '<' && end < node.loc.end.offset) {
-			end++;
-		}
-		return {
-			start,
-			end,
-		};
-	} else {
-		return {
-			start: node.loc.start.offset,
-			end: node.loc.end.offset,
-		};
 	}
 }

--- a/packages/language-server/tests/references.spec.ts
+++ b/packages/language-server/tests/references.spec.ts
@@ -49,7 +49,7 @@ test('Default slot', async () => {
 		    {
 		      "end": {
 		        "line": 9,
-		        "offset": 4,
+		        "offset": 14,
 		      },
 		      "file": "\${testWorkspacePath}/tsconfigProject/foo.vue",
 		      "isDefinition": false,
@@ -57,7 +57,7 @@ test('Default slot', async () => {
 		      "lineText": "			<Fixture>",
 		      "start": {
 		        "line": 7,
-		        "offset": 13,
+		        "offset": 4,
 		      },
 		    },
 		  ],


### PR DESCRIPTION
fix #5458

The inner loc calculation logic based on angle bracket search is not elegant and will cause errors in languages that need to be converted, such as pug. We temporarily use the start and end offsets of the entire node instead and consider implementing the inner loc calculation in the compiler core.