### PR TITLE
fix(language-service): correct position calculation of twoslash queries

### DIFF
--- a/packages/language-server/index.ts
+++ b/packages/language-server/index.ts
@@ -140,7 +140,7 @@ connection.onInitialize(params => {
 				);
 			},
 			async getQuickInfoAtPosition(fileName, { line, character }) {
-				const result = await sendTsServerRequest<ts.QuickInfo>(
+				const result = await sendTsServerRequest<ts.server.protocol.QuickInfoResponseBody>(
 					'_vue:' + ts.server.protocol.CommandTypes.Quickinfo,
 					{
 						file: fileName,
@@ -148,7 +148,7 @@ connection.onInitialize(params => {
 						offset: character + 1,
 					} satisfies ts.server.protocol.FileLocationRequestArgs,
 				);
-				return ts.displayPartsToString(result?.displayParts ?? []);
+				return result?.displayString;
 			},
 		}),
 	);

--- a/packages/language-service/lib/plugins/vue-twoslash-queries.ts
+++ b/packages/language-service/lib/plugins/vue-twoslash-queries.ts
@@ -46,12 +46,13 @@ export function create(
 						]);
 					}
 
+					const sourceDocument = context.documents.get(decoded![0], sourceScript.languageId, sourceScript.snapshot);
 					for (const [pointerPosition, hoverOffset] of hoverOffsets) {
 						const map = context.language.maps.get(virtualCode, sourceScript);
 						for (const [sourceOffset] of map.toSourceLocation(hoverOffset)) {
 							const quickInfo = await tsPluginClient?.getQuickInfoAtPosition(
 								root.fileName,
-								document.positionAt(sourceOffset),
+								sourceDocument.positionAt(sourceOffset),
 							);
 							if (quickInfo) {
 								inlayHints.push({


### PR DESCRIPTION
fix #5493