### PR TITLE
refactor(tsc): return the result of runTsc

### DIFF
--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -44,11 +44,11 @@ export function run(tscPath = require.resolve('typescript/lib/tsc')) {
 		);
 
 	try {
-		main();
+		return main();
 	}
 	catch (err) {
 		if (err === extensionsChangedException) {
-			main();
+			return main();
 		}
 		else {
 			throw err;


### PR DESCRIPTION
Hello, I tried to find a way to use `vue-tsc` programmatically to pass it into tools like `webpack/rspack-ts-checker`, but it is currently designed to simply invoke only `tsc` cli.
This PR in combination with [a same change on `volar` side](https://github.com/volarjs/volar.js/pull/279) will allow to make use of not just `lib/tsc`, but also `lib/typescript` and pass it to any tool that expects the typescript API as simply as

```js
// vue-typescript.js
module.exports = require('vue-tsc').runTsc(require.resolve('typescript'))
```

```js
...
someCheckerPlugin({
  typescript: require.resolve('./vue-typescript')
})
...
```
