### PR TITLE
feat(tsc): add vue-tsc/typescript entry for programmatic usage

### DIFF
--- a/packages/tsc/typescript.ts
+++ b/packages/tsc/typescript.ts
@@ -1,3 +1,3 @@
-import { run } from '.'
+import { run } from '.';
 
-export default run(require.resolve('typescript/lib/typescript'))
+export = run(require.resolve('typescript/lib/typescript'))

--- a/packages/tsc/typescript.ts
+++ b/packages/tsc/typescript.ts
@@ -1,0 +1,3 @@
+import { run } from '.'
+
+export deafult run(require.resolve('typescript/lib/typescript'))

--- a/packages/tsc/typescript.ts
+++ b/packages/tsc/typescript.ts
@@ -1,3 +1,3 @@
 import { run } from '.'
 
-export deafult run(require.resolve('typescript/lib/typescript'))
+export default run(require.resolve('typescript/lib/typescript'))


### PR DESCRIPTION
Moving on with https://github.com/vuejs/language-tools/pull/5517

Add `vue-tsc/typescript` entry for programmatic usage.
This change will make it possible to seamlessly use vue-tsc with
- https://github.com/typestrong/fork-ts-checker-webpack-plugin/
- https://github.com/rspack-contrib/ts-checker-rspack-plugin
- (get rid of copy-paste glue code) https://github.com/fi3ework/vite-plugin-checker/tree/main/packages/vite-plugin-checker/src/checkers/vueTsc
- any other tool that accepts path to `typescript/lib/typescript`

Not sure about file naming, but this is the least changes needed to make it work without breaking anything.