### PR TITLE
fix(language-core): generate `modelModifiers` for explicitly declared default model name

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -509,7 +509,7 @@ function* generateComponentProps(
 			yield `,${newLine}`;
 
 			if (defineModel.modifierType) {
-				const modifierName = `${defineModel.name ? propName : 'model'}Modifiers`;
+				const modifierName = `${propName === 'modelValue' ? 'model' : propName}Modifiers`;
 				const modifierType = getRangeText(scriptSetup, defineModel.modifierType);
 				yield `'${modifierName}'?: Partial<Record<${modifierType}, true>>,${newLine}`;
 			}


### PR DESCRIPTION
fix #5482