### PR TITLE
chore(language-service): improve global types error message for JS projects

### DIFF
--- a/packages/language-service/lib/plugins/vue-global-types-error.ts
+++ b/packages/language-service/lib/plugins/vue-global-types-error.ts
@@ -42,7 +42,7 @@ Failed to write the global types file. Make sure that:
 1. "node_modules" directory exists.
 2. "${vueCompilerOptions.lib}" is installed as a direct dependency.
 
-Alternatively, you can manually set "vueCompilerOptions.globalTypesPath" in your "tsconfig.json" or "jsconfig.json". If creating a new config file and your project might have node_modules in the future, add "exclude": ["node_modules"] to maintain performance.
+Alternatively, you can manually set "vueCompilerOptions.globalTypesPath" in your "tsconfig.json" or "jsconfig.json". To prevent potential performance issues, consider adding \`"exclude": ["node_modules"]\` when creating a new config file.
 
 If all dependencies are installed, try running the "vue.action.restartServer" command to restart Vue and TS servers.
 						`.trim(),

--- a/packages/language-service/lib/plugins/vue-global-types-error.ts
+++ b/packages/language-service/lib/plugins/vue-global-types-error.ts
@@ -42,7 +42,7 @@ Failed to write the global types file. Make sure that:
 1. "node_modules" directory exists.
 2. "${vueCompilerOptions.lib}" is installed as a direct dependency.
 
-Alternatively, you can manually set "vueCompilerOptions.globalTypesPath" in your "tsconfig.json".
+Alternatively, you can manually set "vueCompilerOptions.globalTypesPath" in your "tsconfig.json" or "jsconfig.json". If creating a new config file and your project might have node_modules in the future, add "exclude": ["node_modules"] to maintain performance.
 
 If all dependencies are installed, try running the "vue.action.restartServer" command to restart Vue and TS servers.
 						`.trim(),


### PR DESCRIPTION
## Description

Improved the global types error message to be more inclusive and helpful for both JavaScript and TypeScript projects.

## Changes

- **Enhanced error message**: Changed from "tsconfig.json" to "tsconfig.json or jsconfig.json" to support JavaScript projects
- **Added performance guidance**: Included recommendation to add `"exclude": ["node_modules"]` when creating new config files to maintain VS Code performance
- **Better user experience**: More comprehensive guidance for developers working with both JS and TS projects

## Motivation

### Problem Background
When users are in a non-npm like environment, they may be missing both the node_modules directory and TypeScript/JavaScript configuration files. The previous error message only mentioned `tsconfig.json`, which could confuse JavaScript developers who use `jsconfig.json`.

### Performance Risk
More importantly, according to VS Code official documentation, VS Code will by default exclude the node_modules folder to optimize performance when there is no jsconfig.json in the workspace. When users create a new jsconfig.json to configure `vueCompilerOptions.globalTypesPath` following the error prompt, this changes VS Code's default behavior.

### Potential Issues
If JavaScript project users don't explicitly add `"exclude": ["node_modules"]` when creating jsconfig.json, then when they subsequently install npm dependencies, the TypeScript/JavaScript language service will scan the entire node_modules directory, which may cause performance issues.

### Solution
This improvement ensures that the prompt message is preventive and comprehensive, specifically targeting the performance risks of jsconfig.json, while maintaining unified recommendations for both types of configuration files, allowing users to solve the current problem without accidentally breaking VS Code's default performance optimization mechanism due to our suggestions.

## Testing

- Verified that the error message displays correctly

## References

- [VS Code jsconfig.json documentation](https://code.visualstudio.com/docs/languages/jsconfig)
- [TypeScript tsconfig.json exclude documentation](https://www.typescriptlang.org/tsconfig#exclude)