### PR TITLE
chore(vscode): update display name "Vue.js"

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -14,7 +14,7 @@
 		"url": "https://github.com/sponsors/johnsoncodehk"
 	},
 	"icon": "icon.png",
-	"displayName": "Vue (Official)",
+	"displayName": "Vue.js",
 	"description": "Language Support for Vue",
 	"author": "johnsoncodehk",
 	"publisher": "Vue",


### PR DESCRIPTION
I really wanted to avoid constantly changing the extension name, but unfortunately it's happening again.

### Why?

This IDE extension started as my personal project, and it was named "Volar" after my favorite song.

After "Volar" became an official Vue project, I've been wanting to give this extension a more first-party-looking display name. However, we couldn't simply name it "Vue" as that would conflict with many other Vue extensions in the Marketplace.

We've previously used "Vue Language Features" (v1), "Vue - Official" (v2), and "Vue (Official)" (v3). For some reason, we never thought of using "Vue.js" - this name isn't taken in the Marketplace and wouldn't cause any confusion. Most importantly, "Vue.js" looks better than all our previous choices, and we should have gone with it from the beginning.

Since v3 is the last major version, we can't postpone this rename to v4. To minimize the inevitable confusion caused by this change (for which I apologize!), this change should be implemented as soon as possible in 3.0.6.