### PR TITLE
fix(language-core): remove the non-strict `configFileName` default value

### DIFF
--- a/packages/language-core/lib/utils/ts.ts
+++ b/packages/language-core/lib/utils/ts.ts
@@ -17,7 +17,7 @@ export function createParsedCommandLineByJson(
 	},
 	rootDir: string,
 	json: any,
-	configFileName = rootDir + '/jsconfig.json',
+	configFileName?: string,
 ): ParsedCommandLine {
 	const proxyHost = proxyParseConfigHostForExtendConfigPaths(parseConfigHost);
 	ts.parseJsonConfigFileContent(json, proxyHost.host, rootDir, {}, configFileName);


### PR DESCRIPTION
When `rootDir` is passed as `/`, the default value of `configFileName` is simply concatenated into an invalid `//jsconfig.json`, which causes the TS `parseJsonConfigFileContent` method to perform file searches with incorrect parameters, coincidentally making it impossible to reproduce issue #5598 in posix path systems.

After this PR, I was able to reproduce #5598 on OSX.

It should be noted that for files not included in the tsconfig, `rootDir` should fall back to the workspace root directory rather than `/`, which requires investigation in VSCode.