### PR TITLE
fix(language-core): generate slot parameters in the same way as interpolation

### DIFF
--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -214,14 +214,17 @@ function walkIdentifiers(
 	}
 	else if (ts.isVariableDeclaration(node)) {
 		const bindingNames = collectBindingNames(ts, node.name, ast);
-
 		for (const name of bindingNames) {
 			ctx.addLocalVariable(name);
 			blockVars.push(name);
 		}
-
-		if (node.initializer) {
-			walkIdentifiers(ts, node.initializer, ast, cb, ctx, blockVars);
+		walkIdentifiersInBinding(ts, node, ast, cb, ctx, blockVars);
+	}
+	else if (ts.isArrayBindingPattern(node) || ts.isObjectBindingPattern(node)) {
+		for (const element of node.elements) {
+			if (ts.isBindingElement(element)) {
+				walkIdentifiersInBinding(ts, element, ast, cb, ctx, blockVars);
+			}
 		}
 	}
 	else if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
@@ -276,6 +279,25 @@ function walkIdentifiers(
 	}
 }
 
+function walkIdentifiersInBinding(
+	ts: typeof import('typescript'),
+	node: ts.BindingElement | ts.ParameterDeclaration | ts.VariableDeclaration,
+	ast: ts.SourceFile,
+	cb: (varNode: ts.Identifier, isShorthand: boolean) => void,
+	ctx: TemplateCodegenContext,
+	blockVars: string[],
+) {
+	if ('type' in node && node.type) {
+		walkIdentifiersInTypeNode(ts, node.type, cb);
+	}
+	if (!ts.isIdentifier(node.name)) {
+		walkIdentifiers(ts, node.name, ast, cb, ctx, blockVars);
+	}
+	if (node.initializer) {
+		walkIdentifiers(ts, node.initializer, ast, cb, ctx, blockVars);
+	}
+}
+
 function walkIdentifiersInFunction(
 	ts: typeof import('typescript'),
 	node: ts.ArrowFunction | ts.FunctionExpression | ts.AccessorDeclaration | ts.MethodDeclaration,
@@ -286,9 +308,7 @@ function walkIdentifiersInFunction(
 	const functionArgs: string[] = [];
 	for (const param of node.parameters) {
 		functionArgs.push(...collectBindingNames(ts, param.name, ast));
-		if (param.type) {
-			walkIdentifiersInTypeNode(ts, param.type, cb);
-		}
+		walkIdentifiersInBinding(ts, param, ast, cb, ctx, functionArgs);
 	}
 	for (const varName of functionArgs) {
 		ctx.addLocalVariable(varName);

--- a/packages/language-core/lib/codegen/template/vSlot.ts
+++ b/packages/language-core/lib/codegen/template/vSlot.ts
@@ -122,7 +122,7 @@ function* generateSlotParameters(
 
 	const { expression } = statement;
 	const startOffset = exp.loc.start.offset - 1;
-	const types: (Code | undefined)[] = [];
+	const types: (Code | null)[] = [];
 
 	const interpolation = [...generateInterpolation(
 		options,
@@ -152,7 +152,7 @@ function* generateSlotParameters(
 			replaceSourceRange(interpolation, 'template', startOffset + name.end, startOffset + type.end);
 		}
 		else {
-			types.push(undefined);
+			types.push(null);
 		}
 	}
 

--- a/test-workspace/tsc/passedFixtures/vue3/#5617/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#5617/main.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+declare const Comp: (props: {}, ctx: { slots: {
+	default: (props: { foo: number }) => void;
+} }) => {};
+
+const bar = ref(0);
+</script>
+
+<template>
+	<Comp v-slot="{ foo = bar + 1 }">
+		{{ foo }}
+	</Comp>
+</template>


### PR DESCRIPTION
fix #5617 