### PR TITLE
fix(language-service): do not provide semantic tokens and document highlights for non-`file` scheme files

### DIFF
--- a/packages/language-service/lib/plugins/typescript-semantic-tokens.ts
+++ b/packages/language-service/lib/plugins/typescript-semantic-tokens.ts
@@ -39,7 +39,7 @@ export function create(
 			return {
 				async provideDocumentSemanticTokens(document, range, legend) {
 					const info = resolveEmbeddedCode(context, document.uri);
-					if (info?.code.id !== 'main') {
+					if (info?.script.id.scheme !== 'file' || info.code.id !== 'main') {
 						return;
 					}
 					const start = document.offsetAt(range.start);

--- a/packages/language-service/lib/plugins/vue-document-highlights.ts
+++ b/packages/language-service/lib/plugins/vue-document-highlights.ts
@@ -14,7 +14,7 @@ export function create(
 			return {
 				async provideDocumentHighlights(document, position) {
 					const info = resolveEmbeddedCode(context, document.uri);
-					if (info?.code.id !== 'main') {
+					if (info?.script.id.scheme !== 'file' || info.code.id !== 'main') {
 						return;
 					}
 


### PR DESCRIPTION
fix #5572