### PR TITLE
fix(language-core): use component instance props as fallthrough attributes

### DIFF
--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -265,7 +265,9 @@ export function* generateComponent(
 
 	if (hasVBindAttrs(options, ctx, node)) {
 		const attrsVar = ctx.getInternalVariable();
-		yield `var ${attrsVar}!: Parameters<typeof ${componentFunctionalVar}>[0]${endOfLine}`;
+		ctx.currentComponent.used = true;
+
+		yield `var ${attrsVar}!: NonNullable<typeof ${componentCtxVar}['props']>${endOfLine}`;
 		ctx.inheritedAttrVars.add(attrsVar);
 	}
 

--- a/test-workspace/tsc/passedFixtures/fallthroughAttributes_strictTemplate/generic/basic.vue
+++ b/test-workspace/tsc/passedFixtures/fallthroughAttributes_strictTemplate/generic/basic.vue
@@ -7,5 +7,5 @@ defineProps<{
 </script>
 
 <template>
-	<child foo="..." />
+	<child :foo="bar" />
 </template>

--- a/test-workspace/tsc/passedFixtures/fallthroughAttributes_strictTemplate/generic/basic.vue
+++ b/test-workspace/tsc/passedFixtures/fallthroughAttributes_strictTemplate/generic/basic.vue
@@ -2,10 +2,10 @@
 import child from './child.vue';
 
 defineProps<{
-	foo?: T;
+	bar?: T;
 }>();
 </script>
 
 <template>
-	<child />
+	<child foo="..." />
 </template>

--- a/test-workspace/tsc/passedFixtures/fallthroughAttributes_strictTemplate/generic/child.vue
+++ b/test-workspace/tsc/passedFixtures/fallthroughAttributes_strictTemplate/generic/child.vue
@@ -1,5 +1,8 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 defineProps<{
-	bar?: string;
+	foo?: T;
+}>();
+defineEmits<{
+	foo: [T];
 }>();
 </script>

--- a/test-workspace/tsc/passedFixtures/fallthroughAttributes_strictTemplate/generic/main.vue
+++ b/test-workspace/tsc/passedFixtures/fallthroughAttributes_strictTemplate/generic/main.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
+import { exactType } from '../../shared';
 import basic from './basic.vue';
 </script>
 
 <template>
-	<basic bar="..."/>
+	<basic bar="..." @foo="e => exactType(e, {} as string)"/>
 </template>


### PR DESCRIPTION
fix #5684