### PR TITLE
feat(language-core): add context interface to allow plugins to augment it easily

### DIFF
--- a/packages/language-core/lib/codegen/script/template.ts
+++ b/packages/language-core/lib/codegen/script/template.ts
@@ -69,6 +69,10 @@ function* generateTemplateCtx(
 		exps.push([`{} as ${propTypes.join(` & `)}`]);
 	}
 
+	// allow plugins to augment the context type easily
+	yield `interface __VLS_Context {}${newLine}`;
+	exps.push([`{} as __VLS_Context`]);
+
 	if (ctx.generatedTypes.has(names.SetupExposed)) {
 		exps.push([`{} as ${names.SetupExposed}`]);
 	}


### PR DESCRIPTION
Example:

```ts
import type { VueLanguagePlugin } from "@vue/language-core";

const plugin: VueLanguagePlugin = () => {
  return {
    version: 2.1,
    resolveEmbeddedCode(fileName, sfc, embeddedCode) {
      if (!embeddedCode.id.startsWith("script_")) {
        return;
      }
      embeddedCode.content.push(`interface __VLS_Context { $route: ... }`);
    },
  };
};

export default plugin;
```