### PR TITLE
fix(ci): read PR title from env in `auto-version` workflow to prevent injection

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -27,8 +27,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Bump version from PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          VERSION="${{ github.event.pull_request.title }}"
+          VERSION="$PR_TITLE"
           if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             pnpm dlx --package @lerna-lite/cli --package @lerna-lite/version \
             lerna version "$VERSION" --yes --no-push --no-git-tag-version --force-publish


### PR DESCRIPTION
I do software supply chain security work and was looking through Actions workflows for spots where untrusted input lands in a shell. Small fix for `auto-version.yml`.

The "Bump version from PR title" step does `VERSION="${{ github.event.pull_request.title }}"`. Since Actions expands `${{ }}` into the script text before bash runs, a PR title such as `v3.0.0"; id; "` gets evaluated as a shell command. The `startsWith(..., 'v3.')` job condition and the `^v[0-9]+...$` check don't prevent it: the title prefix is attacker-chosen, and the regex runs only after the assignment has already been interpolated.

Trigger here is `pull_request` (not `pull_request_target`), so for fork PRs the token is read-only and there are no secrets, which keeps the impact to code execution on the ephemeral runner rather than secret theft. Still worth closing since it is an easy foothold and the job otherwise runs with `contents: write` / `pull-requests: write` for same-repo PRs.

Fix routes the title through a `PR_TITLE` env var and assigns `VERSION="$PR_TITLE"`; env values aren't re-parsed by the shell, and the version regex still gates what reaches lerna. No change for legitimate version titles.