### PR TITLE
fix(language-core): only exclude already-set props from inherited attrs when `checkRequiredFallthroughAttributes` is enabled

### DIFF
--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -262,9 +262,14 @@ export function* generateComponent(
 	}
 
 	if (shouldInheritAttrs) {
-		const restsVar = ctx.getInternalVariable();
-		yield `var ${restsVar} = ${names.omit}(${getPropsVar()}, {\n${propsStr}})${endOfLine}`;
-		ctx.inheritedAttrVars.add(restsVar);
+		if (options.vueCompilerOptions.checkRequiredFallthroughAttributes) {
+			const restsVar = ctx.getInternalVariable();
+			yield `var ${restsVar} = ${names.omit}(${getPropsVar()}, {\n${propsStr}})${endOfLine}`;
+			ctx.inheritedAttrVars.add(restsVar);
+		}
+		else {
+			ctx.inheritedAttrVars.add(getPropsVar());
+		}
 	}
 
 	yield* generateStyleScopedClassReferences(options, node);


### PR DESCRIPTION
fix #6082