### PR TITLE
fix(language-core): camelize slot props regardless of `htmlAttributes` option

### DIFF
--- a/packages/language-core/lib/codegen/template/elementProps.ts
+++ b/packages/language-core/lib/codegen/template/elementProps.ts
@@ -311,7 +311,10 @@ function getShouldCamelize(
 		|| prop.arg?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION && prop.arg.isStatic
 	)
 		&& hyphenateAttr(propName) === propName
-		&& !options.vueCompilerOptions.htmlAttributes.some(pattern => isMatch(propName, pattern));
+		&& (
+			node.tagType === CompilerDOM.ElementTypes.SLOT
+			|| !options.vueCompilerOptions.htmlAttributes.some(pattern => isMatch(propName, pattern))
+		);
 }
 
 function getPropsCodeFeatures(checkUnknownProps: boolean): VueCodeInformation {

--- a/test-workspace/tsc/#6084/main.vue
+++ b/test-workspace/tsc/#6084/main.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineSlots<{
+	default?: (props: { ariaDescribedby: string }) => any;
+}>()
+</script>
+
+<template>
+	<slot aria-describedby="bar" />
+</template>

--- a/test-workspace/tsc/#6084/tsconfig.json
+++ b/test-workspace/tsc/#6084/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["**/*"]
+}

--- a/test-workspace/tsc/tsconfig.json
+++ b/test-workspace/tsc/tsconfig.json
@@ -518,6 +518,9 @@
 			"path": "./#5986/tsconfig.json"
 		},
 		{
+			"path": "./#6084/tsconfig.json"
+		},
+		{
 			"path": "./#625/tsconfig.json"
 		},
 		{


### PR DESCRIPTION
fix #6084