### PR TITLE
fix(language-core): make generic component internal context inference type-safe across `.d.ts` boundary

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -121,7 +121,7 @@ export function* generateGeneric(
 	yield `	emit: ${emitTypes.length ? emitTypes.join(` & `) : `{}`}${endOfLine}`;
 	yield `}${endOfLine}`;
 	yield `})(),${newLine}`; // __VLS_setup = (async () => {
-	yield `) => ({} as import('${vueCompilerOptions.lib}').VNode & { __ctx?: Awaited<typeof ${names.setup}> }))${endOfLine}`;
+	yield `) => ({} as import('${vueCompilerOptions.lib}').VNode & { __ctx?: NonNullable<Awaited<typeof ${names.setup}>> }))${endOfLine}`;
 }
 
 export function* generateSetupFunction(

--- a/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -188,7 +188,7 @@ exports[`Input: generic/component.vue, Output: generic/component.vue.d.ts 1`] = 
     };
     emit: ((e: "bar", data: number) => void) & ((event: "update:title", value: string | undefined) => void);
 }>) => import("vue").VNode & {
-    __ctx?: Awaited<typeof __VLS_setup>;
+    __ctx?: NonNullable<Awaited<typeof __VLS_setup>>;
 };
 declare const _default: typeof __VLS_export;
 export default _default;
@@ -223,7 +223,7 @@ exports[`Input: generic/custom-extension-component.cext, Output: generic/custom-
     };
     emit: ((e: "bar", data: number) => void) & ((event: "update:title", value: string | undefined) => void);
 }>) => import("vue").VNode & {
-    __ctx?: Awaited<typeof __VLS_setup>;
+    __ctx?: NonNullable<Awaited<typeof __VLS_setup>>;
 };
 declare const _default: typeof __VLS_export;
 export default _default;


### PR DESCRIPTION
## What

In `generateGeneric` (`packages/language-core/lib/codegen/script/scriptSetup.ts`), the emitted return type of a generic component uses `__ctx?: Awaited<typeof __VLS_setup>` without a `NonNullable` wrapper, while the `props`, `ctx` and `exposed` parameter positions already wrap it as `NonNullable<Awaited<typeof __VLS_setup>>`. This wraps `__ctx` to match.

```diff
- { __ctx?: Awaited<typeof __VLS_setup> }
+ { __ctx?: NonNullable<Awaited<typeof __VLS_setup>> }
```

## Why

Event-handler parameters on a generic component are typed as implicit `any` (TS7006 under `noImplicitAny`) in a consumer **when the component is consumed across the emitted `.d.ts` boundary** (a built package / Nuxt layer), even though slot props are inferred correctly.

In the live virtual code `__VLS_setup` is a parameter **with a default value**, so `typeof __VLS_setup` has no `undefined`. On declaration emit, TypeScript turns the defaulted parameter into an optional one (`__VLS_setup?: Promise<…>`), so `typeof __VLS_setup` now includes `undefined`, and `Awaited<Promise<Setup> | undefined>` becomes `Setup | undefined`. The consumer helper `__VLS_FunctionalComponentProps` extracts props via a single-step nested inference `K extends { __ctx?: { props?: infer P } }`, which cannot infer `P` through the inner `| undefined`, so props resolves to `never`. With `never` props, `__VLS_NormalizeComponentEvent` falls back and the event handler loses its contextual type → implicit `any`.

Slot props are unaffected because they go through `__VLS_FunctionalComponentCtx`, which infers the whole `__ctx` and applies `NonNullable` to it. This change makes the return-type `__ctx` consistent with the parameter positions and with that helper.

This completes #4577, which added the same `NonNullable` wrapping to the parameter positions but left the return-type `__ctx`.

## Reproduction

Reproduces only across the emitted `.d.ts` boundary (a same-project live-source test does not trigger it):

1. A `<script setup generic="T">` component with `defineEmits<{ change: [e: SomeType] }>()`.
2. Emit its declaration (`vue-tsc --declaration --emitDeclarationOnly --noCheck`).
3. A consumer that imports the **emitted** `.d.ts` and writes `@change="(e) => …"`.
4. `vue-tsc --noEmit` under `noImplicitAny` reports TS7006 on `e` without this change, and is clean with it.

No runtime impact: in the live (non-emitted) path the wrapper is a no-op because `typeof __VLS_setup` has no `undefined`.