### PR TITLE
fix(language-core): wrap single expression event handlers to avoid ASI after `return`

### DIFF
--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -170,9 +170,13 @@ export function* generateEventExpression(
 			scope.declare('$event');
 			yield* ctx.generateConditionGuards();
 			if (isSingleExpression(options.typescript, ast)) {
-				yield `return `;
+				yield `return (`;
+				yield* interpolation;
+				yield `)`;
 			}
-			yield* interpolation;
+			else {
+				yield* interpolation;
+			}
 			yield endOfLine;
 			yield* scope.end();
 			yield `}`;

--- a/test-workspace/tsc/events/expression.vue
+++ b/test-workspace/tsc/events/expression.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { exactType } from '../shared';
+
 interface Props {
 	onClick?: () => number;
 }
@@ -17,4 +19,8 @@ declare const foo: unknown;
 	<template v-if="true">
 		<Comp @click="(() => 1)()" />
 	</template>
+	<!-- #6114 -->
+	<div @click="
+		typeof foo === 'string' && exactType(foo, {} as string)
+	" />
 </template>


### PR DESCRIPTION
fix #6114