### PR TITLE
fix(language-core): deduplicate vueCompilerOptions.plugins on resolve

### DIFF
--- a/packages/language-core/lib/compilerOptions.ts
+++ b/packages/language-core/lib/compilerOptions.ts
@@ -115,7 +115,7 @@ export class CompilerOptionsResolver {
 	options: Omit<RawVueCompilerOptions, 'target' | 'strictTemplates' | 'typesRoot' | 'plugins'> = {};
 	target: number | undefined;
 	typesRoot: string | undefined;
-	plugins: VueLanguagePlugin[] = [];
+	pluginModules = new Map<string, VueLanguagePlugin>();
 
 	constructor(
 		public ts: typeof import('typescript'),
@@ -162,7 +162,7 @@ export class CompilerOptionsResolver {
 								const plugins = Array.isArray(plugin) ? plugin : [plugin];
 								for (const plugin of plugins) {
 									plugin.__moduleConfig = raw;
-									this.plugins.push(plugin);
+									this.pluginModules.set(raw.name, plugin);
 								}
 							}
 							else {
@@ -196,7 +196,7 @@ export class CompilerOptionsResolver {
 		const resolvedOptions: VueCompilerOptions = {
 			...defaults,
 			...this.options,
-			plugins: this.plugins,
+			plugins: [...this.pluginModules.values()],
 			macros: {
 				...defaults.macros,
 				...this.options.macros,

--- a/packages/language-core/tests/compilerOptions.spec.ts
+++ b/packages/language-core/tests/compilerOptions.spec.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as ts from 'typescript';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CompilerOptionsResolver } from '../lib/compilerOptions';
+import { createPlugins } from '../lib/plugins';
+
+const PLUGIN_NAME = '@fixture/vue-language-plugin-pug';
+
+function writePluginPackage(rootDir: string, tag: string) {
+	const packageDir = path.join(rootDir, 'node_modules', PLUGIN_NAME);
+	fs.mkdirSync(packageDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(packageDir, 'package.json'),
+		JSON.stringify({ name: PLUGIN_NAME, main: 'index.js' }),
+	);
+	fs.writeFileSync(
+		path.join(packageDir, 'index.js'),
+		`module.exports = () => ({
+			name: ${JSON.stringify(PLUGIN_NAME)},
+			version: 2.2,
+			compileSFCTemplate(lang) {
+				if (lang === 'pug') {
+					return {
+						ast: { tag: ${JSON.stringify(tag)} },
+						code: '',
+						preamble: '',
+					};
+				}
+			},
+		});`,
+	);
+}
+
+describe('CompilerOptionsResolver', () => {
+	let tmpDir = '';
+
+	afterEach(() => {
+		if (tmpDir) {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+			tmpDir = '';
+		}
+	});
+
+	it('deduplicates vueCompilerOptions.plugins by package name; last config wins', () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vue-plugin-dedupe-'));
+		const layerDir = path.join(tmpDir, 'layer');
+		const clientDir = path.join(tmpDir, 'client');
+		fs.mkdirSync(layerDir);
+		fs.mkdirSync(clientDir);
+
+		writePluginPackage(layerDir, 'base');
+		writePluginPackage(clientDir, 'client');
+
+		const resolver = new CompilerOptionsResolver(ts, () => undefined);
+		resolver.addConfig({ plugins: [PLUGIN_NAME] }, layerDir);
+		resolver.addConfig({ plugins: [PLUGIN_NAME] }, clientDir);
+
+		const vueCompilerOptions = resolver.build();
+		expect(vueCompilerOptions.plugins).toHaveLength(1);
+
+		const instances = createPlugins({
+			modules: {
+				'@vue/compiler-dom': {} as any,
+				'@vue/language-core': {} as any,
+				typescript: ts,
+			},
+			compilerOptions: {},
+			vueCompilerOptions,
+			config: {},
+		});
+		const pugPlugin = instances.find(plugin => plugin.name === PLUGIN_NAME);
+
+		expect(pugPlugin?.compileSFCTemplate?.('pug', '', {})).toEqual({
+			ast: { tag: 'client' },
+			code: '',
+			preamble: '',
+		});
+	});
+});


### PR DESCRIPTION
## Problem

When `tsconfig` files form an `extends` chain (common in Nuxt monorepos with shared layers), the same entry in `vueCompilerOptions.plugins` can be registered multiple times.

`CompilerOptionsResolver.addConfig()` currently **appends** every resolved plugin module. Later, `virtualCode/ir.ts` iterates plugins and uses the **first** `compileSFCTemplate()` result that returns a value.

If the first resolved copy points to an older workspace installation (e.g. `@vue/language-plugin-pug@3.2.x` nested in a layer while the app resolves `3.3.x`), Pug templates with `v-for` may not get a proper `FOR` AST node. Template codegen then references `__VLS_ctx.<alias>` instead of the loop variable, producing many false-positive TS errors.

Relevant snippet in `ir.ts`:

```ts
for (const plugin of plugins) {
  const result = plugin.compileSFCTemplate?.(base.lang, base.content, options);
  if (result) {
    return { ... result ... };
  }
}
```

Real-world repro: a monorepo with the plugin declared in a base layer, a shared layer, and the app tsconfig — HTML templates typecheck fine, Pug templates fail with hundreds of TS2339/TS2551 on loop variables.

## Solution

Deduplicate resolved plugins **by package name** in `CompilerOptionsResolver`. When the same plugin name appears again in a more specific config, the later resolution replaces the previous one.

This matches how most other `vueCompilerOptions` fields merge across `extends` (scalar options use last-write-wins via `this.options[key] = options[key]`), and matches the documented setup for `@vue/language-plugin-pug` (register once in `tsconfig.json`).

## Design rationale (why this should not break intentional setups)

**Not a documented feature today.** The Pug plugin README shows a single `"plugins": ["@vue/language-plugin-pug"]` entry. There is no guidance to repeat the same plugin in every extended tsconfig.

**Duplicate registration is accidental in practice.** It happens when each layer copies the same `vueCompilerOptions` block — the resolver currently concatenates them instead of merging.

**Unchanged: different plugins for different languages.** Deduplication is keyed by npm package name (`raw.name`). Two plugins with different names (e.g. a custom plugin plus `@vue/language-plugin-pug`) are unaffected.

**Unchanged: built-in language-core plugins.** User plugins from `vueCompilerOptions.plugins` are appended after built-ins in `createPlugins()`; this PR only affects how user plugin modules are collected during config resolution.

**Edge cases (theoretical, low risk):**

| Scenario | Before | After |
|----------|--------|-------|
| Same plugin repeated across `extends` (typical monorepo mistake) | Multiple copies; first `compileSFCTemplate` wins (often wrong version) | One copy; last config wins |
| Same package twice in one `plugins: [...]` array with different inline configs | Both registered | Last entry wins |
| One npm package exporting an array of plugin factories | All pushed (rare) | Last factory from that package wins |

> This only deduplicates by package name when the same plugin is registered multiple times across `extends`. Deliberately registering two different plugins under different package names is unchanged.

## Test plan

- [x] Added `packages/language-core/tests/compilerOptions.spec.ts`
- [x] `pnpm exec vitest run packages/language-core/tests/compilerOptions.spec.ts`
- [x] `pnpm run build`

The test creates two temporary `node_modules` trees exporting the same package name with different `compileSFCTemplate` behavior and asserts that only one plugin remains and the client config wins.

## Notes

- Minimal change: only `compilerOptions.ts` plus a unit test; no changes to `ir.js` or `@vue/language-plugin-pug`.
- Downstream workaround until merge: register language plugins once in the root layer config instead of repeating them in every extended tsconfig.
- Related but separate issues: #4626, #5905 (Pug offset mapping).
