### PR TITLE
fix(language-service): prevent crash on malformed html.customData configuration

### DIFF
--- a/packages/language-service/lib/plugins/vue-template.ts
+++ b/packages/language-service/lib/plugins/vue-template.ts
@@ -867,8 +867,9 @@ export function create(
 			}
 
 			async function getCustomData() {
-			  const rawPaths = await context.env.getConfiguration?.('html.customData');
-			  const paths: string[] = Array.isArray(rawPaths) ? rawPaths.filter(Boolean) : [];
+				// Some LSP clients represent unset configuration as `[null]`
+				const raw = await context.env.getConfiguration?.('html.customData');
+				const paths: string[] = Array.isArray(raw) ? raw.filter(Boolean) : [];
 				const customData: html.IHTMLDataProvider[] = [];
 				for (const path of paths) {
 					for (const workspaceFolder of context.env.workspaceFolders) {

--- a/packages/language-service/lib/plugins/vue-template.ts
+++ b/packages/language-service/lib/plugins/vue-template.ts
@@ -867,7 +867,8 @@ export function create(
 			}
 
 			async function getCustomData() {
-				const paths: string[] = await context.env.getConfiguration?.('html.customData') ?? [];
+			  const rawPaths = await context.env.getConfiguration?.('html.customData');
+			  const paths: string[] = Array.isArray(rawPaths) ? rawPaths.filter(Boolean) : [];
 				const customData: html.IHTMLDataProvider[] = [];
 				for (const path of paths) {
 					for (const workspaceFolder of context.env.workspaceFolders) {

--- a/packages/language-service/lib/plugins/vue-template.ts
+++ b/packages/language-service/lib/plugins/vue-template.ts
@@ -867,7 +867,7 @@ export function create(
 			}
 
 			async function getCustomData() {
-				// Some LSP clients represent unset configuration as `[null]`
+				// some LSP clients represent unset configuration as `[null]`
 				const raw = await context.env.getConfiguration?.('html.customData');
 				const paths: string[] = Array.isArray(raw) ? raw.filter(Boolean) : [];
 				const customData: html.IHTMLDataProvider[] = [];


### PR DESCRIPTION
## Description
This change makes the handling of `html.customData` more defensive by validating the value returned from `getConfiguration()` before iterating over it.

Instead of assuming the returned value is always a `string[]`, the code now validates it with `Array.isArray()`, falls back to an empty array when the returned value is not an array, and filters out falsy entries before iterating over the paths.

## Background
While investigating a crash reported as

```
TypeError: paths is not iterable
```

I found that the LSP client replies to `workspace/configuration` with:

```json
[null]
```

However, inside `vue-template.ts`, `context.env.getConfiguration?.("html.customData")` unexpectedly returns an empty object (`{}`) instead of `null` or an array.

The exact source of this conversion is still under investigation, but this PR prevents the language service from crashing regardless of where the malformed value originates.

## Changes
- Validate the result using `Array.isArray()`
- Fall back to `[]` when the returned value is not an array
- Filter out falsy entries with `.filter(Boolean)` before iteration