### PR TITLE
feat(component-meta): expose runtime values of enum members in schema

### DIFF
--- a/packages/component-meta/lib/schemaResolvers.ts
+++ b/packages/component-meta/lib/schemaResolvers.ts
@@ -335,11 +335,14 @@ export function createSchemaResolvers(
 			// enum members stringify to their qualified name (e.g. "MyEnum.Small"), which
 			// hides the runtime value from consumers such as docs generators; expose the
 			// value alongside, printed like any other literal
-			return {
-				kind: 'literal',
-				type,
-				value: typeof subtype.value === 'string' ? `"${subtype.value}"` : String(subtype.value),
-			};
+			const { value } = subtype;
+			if (typeof value === 'string' || typeof value === 'number') {
+				return {
+					kind: 'literal',
+					type,
+					value: typeof value === 'string' ? `"${value}"` : String(value),
+				};
+			}
 		}
 
 		return type;

--- a/packages/component-meta/lib/schemaResolvers.ts
+++ b/packages/component-meta/lib/schemaResolvers.ts
@@ -331,6 +331,16 @@ export function createSchemaResolvers(
 		else if (subtype.getCallSignatures().length === 1) {
 			return resolveCallbackSchema(subtype.getCallSignatures()[0]!);
 		}
+		else if (subtype.flags & ts.TypeFlags.EnumLiteral && subtype.isLiteral()) {
+			// enum members stringify to their qualified name (e.g. "MyEnum.Small"), which
+			// hides the runtime value from consumers such as docs generators; expose the
+			// value alongside, printed like any other literal
+			return {
+				kind: 'literal',
+				type,
+				value: typeof subtype.value === 'string' ? `"${subtype.value}"` : String(subtype.value),
+			};
+		}
 
 		return type;
 	}

--- a/packages/component-meta/lib/schemaResolvers.ts
+++ b/packages/component-meta/lib/schemaResolvers.ts
@@ -340,7 +340,7 @@ export function createSchemaResolvers(
 				return {
 					kind: 'literal',
 					type,
-					value: typeof value === 'string' ? `"${value}"` : String(value),
+					value: JSON.stringify(value),
 				};
 			}
 		}

--- a/packages/component-meta/lib/types.ts
+++ b/packages/component-meta/lib/types.ts
@@ -101,6 +101,7 @@ export interface ExposeMeta {
 
 export type PropertyMetaSchema =
 	| string
+	| { kind: 'literal'; type: string; value: string }
 	| { kind: 'enum'; type: string; schema?: PropertyMetaSchema[] }
 	| { kind: 'array'; type: string; schema?: PropertyMetaSchema[] }
 	| { kind: 'event'; type: string; schema?: PropertyMetaSchema[] }

--- a/packages/component-meta/tests/index.spec.ts
+++ b/packages/component-meta/tests/index.spec.ts
@@ -612,14 +612,64 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 				  "schema": {
 				    "kind": "enum",
 				    "schema": [
-				      "MyEnum.Small",
-				      "MyEnum.Medium",
-				      "MyEnum.Large",
+				      {
+				        "kind": "literal",
+				        "type": "MyEnum.Small",
+				        "value": "0",
+				      },
+				      {
+				        "kind": "literal",
+				        "type": "MyEnum.Medium",
+				        "value": "1",
+				      },
+				      {
+				        "kind": "literal",
+				        "type": "MyEnum.Large",
+				        "value": "2",
+				      },
 				    ],
 				    "type": "MyEnum",
 				  },
 				  "tags": [],
 				  "type": "MyEnum",
+				}
+			`);
+
+			const stringEnumValue = meta.props.find(prop => prop.name === 'stringEnumValue');
+			expect(stringEnumValue).toMatchInlineSnapshot(`
+				{
+				  "declarations": [],
+				  "default": undefined,
+				  "description": "string enum value",
+				  "getDeclarations": [Function],
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "stringEnumValue",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      {
+				        "kind": "literal",
+				        "type": "MyStringEnum.Small",
+				        "value": ""small"",
+				      },
+				      {
+				        "kind": "literal",
+				        "type": "MyStringEnum.Medium",
+				        "value": ""medium"",
+				      },
+				      {
+				        "kind": "literal",
+				        "type": "MyStringEnum.Large",
+				        "value": ""large"",
+				      },
+				    ],
+				    "type": "MyStringEnum",
+				  },
+				  "tags": [],
+				  "type": "MyStringEnum",
 				}
 			`);
 

--- a/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -753,6 +753,11 @@ declare enum MyEnum {
     Medium = 1,
     Large = 2
 }
+declare enum MyStringEnum {
+    Small = "small",
+    Medium = "medium",
+    Large = "large"
+}
 declare namespace MyNamespace {
     type MyType = {};
 }
@@ -818,6 +823,10 @@ export interface MyProps {
      * enum value
      */
     enumValue: MyEnum;
+    /**
+     * string enum value
+     */
+    stringEnumValue: MyStringEnum;
     /**
      * namespace type
      */

--- a/test-workspace/component-meta/reference-type-props/my-props.ts
+++ b/test-workspace/component-meta/reference-type-props/my-props.ts
@@ -19,6 +19,12 @@ enum MyEnum {
 	Large,
 }
 
+enum MyStringEnum {
+	Small = 'small',
+	Medium = 'medium',
+	Large = 'large',
+}
+
 namespace MyNamespace {
 	export type MyType = {};
 }
@@ -94,6 +100,10 @@ export interface MyProps {
 	 * enum value
 	 */
 	enumValue: MyEnum;
+	/**
+	 * string enum value
+	 */
+	stringEnumValue: MyStringEnum;
 	/**
 	 * namespace type
 	 */


### PR DESCRIPTION
TS enum members currently resolve to their qualified name only (`"MyEnum.Small"`), because `resolveSchema` falls through to `typeToString`. The runtime value is lost, even though the type checker has it at that exact spot (`subtype.value` on the literal type).

Consumers cannot recover the values without running their own type checker over the user's project. For docs tooling this matters: Storybook, for example, generates a select control from enum schemas, and with only the member names available it either injects the literal string `"MyEnum.Small"` into the component (wrong value) or has to drop the control entirely (storybookjs/storybook#35565).

This PR adds a `literal` schema node for enum member types:

```ts
// enum MyStringEnum { Small = 'small', ... }  →  prop: MyStringEnum
{
  kind: 'enum',
  type: 'MyStringEnum',
  schema: [
    { kind: 'literal', type: 'MyStringEnum.Small', value: '"small"' },
    { kind: 'literal', type: 'MyStringEnum.Medium', value: '"medium"' },
    { kind: 'literal', type: 'MyStringEnum.Large', value: '"large"' },
  ],
}
```

- `value` is printed like literal-union members already are: strings quoted, numbers bare.
- Scoped to `TypeFlags.EnumLiteral` literal types only: Plain literal unions (`'a' | 'b'`) keep their existing string form, so existing consumers are unaffected there.
- `PropertyMetaSchema` gains one variant: `{ kind: 'literal'; type: string; value: string }`.
- Tests: string enum added to the `reference-type-props` fixture with a new assertion; the numeric enum snapshot and the tsc dts snapshot are updated accordingly.
