### PR TITLE
chore: dogfood typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  typescript: npm:typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+  typescript: npm:typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
 
 importers:
 
@@ -13,22 +13,22 @@ importers:
     devDependencies:
       '@tsslint/cli':
         specifier: latest
-        version: 3.1.4(@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2))(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+        version: 3.1.4(@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2))(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       '@tsslint/compat-eslint':
         specifier: latest
-        version: 3.1.4(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+        version: 3.1.4(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       '@tsslint/config':
         specifier: latest
-        version: 3.1.4(@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2))
+        version: 3.1.4(@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2))
       '@typescript-eslint/eslint-plugin':
         specifier: latest
-        version: 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2))(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+        version: 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2))(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       dprint:
         specifier: latest
         version: 0.55.2
       typescript:
-        specifier: npm:typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
-        version: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+        specifier: npm:typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
+        version: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
       vitest:
         specifier: latest
         version: 4.1.10(@types/node@26.1.1)(vite@8.1.5(@types/node@26.1.1))
@@ -84,8 +84,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       typescript:
-        specifier: npm:typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
-        version: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+        specifier: npm:typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
+        version: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
     devDependencies:
       '@types/node':
         specifier: ^26.0.1
@@ -179,8 +179,8 @@ importers:
         specifier: workspace:*
         version: link:../typescript-plugin
       typescript:
-        specifier: npm:typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
-        version: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+        specifier: npm:typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
+        version: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
       vscode-uri:
         specifier: ^3.1.0
         version: 3.1.0
@@ -242,7 +242,7 @@ importers:
         version: 1.0.3
       '@volar/kit':
         specifier: 2.4.28
-        version: 2.4.28(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+        version: 2.4.28(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       '@volar/typescript':
         specifier: 2.4.28
         version: 2.4.28
@@ -268,8 +268,8 @@ importers:
         specifier: workspace:*
         version: link:../language-core
       typescript:
-        specifier: npm:typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
-        version: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+        specifier: npm:typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
+        version: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
     devDependencies:
       '@types/node':
         specifier: ^26.0.1
@@ -306,11 +306,11 @@ importers:
   test-workspace:
     devDependencies:
       typescript:
-        specifier: npm:typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
-        version: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+        specifier: npm:typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
+        version: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
       vue:
         specifier: https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72
-        version: https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+        version: https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       vue-component-meta:
         specifier: workspace:*
         version: link:../packages/component-meta
@@ -845,38 +845,38 @@ packages:
     resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-native-bridge/darwin-arm64@6.0.3-bridge.6.tsgo.7.0.2':
-    resolution: {integrity: sha512-MDJ278AxW73T9FH/FGVozOVz3q32m3pTa9qm7Rm6XhXqMMWlsn16RdaWEAlYx3w5ka4QHeDdXt5RIA8C+JNhNA==}
+  '@typescript-native-bridge/darwin-arm64@6.0.3-bridge.8.tsgo.7.0.2':
+    resolution: {integrity: sha512-2a2DFUDCVaa6TMjEavXJvnk7vahQfeUTDc/dbN6bf16/zXqKmiOL24SUmW28A8GSDlIWyG/R+VsupvG3T8QHdQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript-native-bridge/darwin-x64@6.0.3-bridge.6.tsgo.7.0.2':
-    resolution: {integrity: sha512-VT9RtHf1MAv6jpJeTwW7CVIQn096GE/PZclU0VwJvXUOEdaiqN9w23giwvxuZl65TMFBlghBMSGSS09fhpaD1g==}
+  '@typescript-native-bridge/darwin-x64@6.0.3-bridge.8.tsgo.7.0.2':
+    resolution: {integrity: sha512-QLRJJTn/2Vx2Fz/rX91Q28WBnp5rCbZrNvhf0uoZu7wtGAx2+UeZTURikOv/TQVlzWcuceHOJhekcf/9Et+MsQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript-native-bridge/linux-arm64@6.0.3-bridge.6.tsgo.7.0.2':
-    resolution: {integrity: sha512-YTMHiU5TWRtXzPrE3WiUYAnnoTZfC8DE/R0V1rKaL0N7altt/nNkoh3bRlif0peJgQDC2suqfloNYHG8+z41bw==}
+  '@typescript-native-bridge/linux-arm64@6.0.3-bridge.8.tsgo.7.0.2':
+    resolution: {integrity: sha512-5xsz7EW60A7P8j/K5cijLFoDL89ywjIX0NDbn3b+/lt3mapEMBRa53uLJe3aFqaXkZ/KkGNkJSM0xzzqn5uaUg==}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript-native-bridge/linux-arm@6.0.3-bridge.6.tsgo.7.0.2':
-    resolution: {integrity: sha512-WdZLFuKn+ym/Zm3XjKJD306O2f4c0E3dhrm9FyF8r27q37k/BnJlyOQHCyKeJw4/lfzrqOPBJqHLXio1UXLF6Q==}
+  '@typescript-native-bridge/linux-arm@6.0.3-bridge.8.tsgo.7.0.2':
+    resolution: {integrity: sha512-EQfA7oVmeRYUSbvbaZq1RRe49Wa9WVtfggzWOPC9O6k43nEj5v8sVjJsaMnS2mA6jfsUbMdOj1jEen6lkpgPow==}
     cpu: [arm]
     os: [linux]
 
-  '@typescript-native-bridge/linux-x64@6.0.3-bridge.6.tsgo.7.0.2':
-    resolution: {integrity: sha512-IBr5p9z4pJPjYgaucQNsPt7Uv4eiZhWvE3b+vAq8RNJ4DSfLSMvjQT+9cOoEXiumAJzcGVziQzFXipfA1FmnUA==}
+  '@typescript-native-bridge/linux-x64@6.0.3-bridge.8.tsgo.7.0.2':
+    resolution: {integrity: sha512-YtQiyaUNWR6JoDN+6l5Co+13pu7NQLxCxW6kG7V9U+oAaawRRGh4C7eORN0rFSduOncf5M9ves6jZkdCzIcmsg==}
     cpu: [x64]
     os: [linux]
 
-  '@typescript-native-bridge/win32-arm64@6.0.3-bridge.6.tsgo.7.0.2':
-    resolution: {integrity: sha512-DA+1VUvNQw9IYn+Jvf36lKecZevMu++Dk6vxLWs46RB1gj7W7LnIzQ6vtA5Xh5pF6i4FnVC3GovdeMsm3EvfZQ==}
+  '@typescript-native-bridge/win32-arm64@6.0.3-bridge.8.tsgo.7.0.2':
+    resolution: {integrity: sha512-Nrh4z+q1yN752P7qq9wvgLuB2oQTd9bZnn9P3Gi07+Tadufldjm7jLQyKB0nWtylp2i7Ar6EEuDR1uiWbMJiqA==}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript-native-bridge/win32-x64@6.0.3-bridge.6.tsgo.7.0.2':
-    resolution: {integrity: sha512-n8Qpt0DrEb43fMEtLk4s7EVY1eunFp27SEib7a/xf0WMv3OVBGRDRPGm5OIxLNcppqmnJEPjg4/Fh/XainY5EA==}
+  '@typescript-native-bridge/win32-x64@6.0.3-bridge.8.tsgo.7.0.2':
+    resolution: {integrity: sha512-veGVsQc540fuXZQH1xsTrg2GoTGnu9yFGEpDjIw+q1tDMpCutMlUuDE4htv7+9+8N/RapD911SJrcpjFL83FCg==}
     cpu: [x64]
     os: [win32]
 
@@ -1554,8 +1554,8 @@ packages:
   typescript-auto-import-cache@0.3.6:
     resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
 
-  typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2:
-    resolution: {integrity: sha512-I8zP90Yds3EVWC0TtQdyZ0vSydsmenoGlUa0tggwYOB/KxWZGdOvfBdE9m6a0tXnyDbEZUP+kOFtooZwn8Gk+g==}
+  typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2:
+    resolution: {integrity: sha512-scQFdHBhpFVsr9xmHDos+CCSQHcS0yVjL/4+RaUnfeQRJvrYtSsEpfyiseUmSmSdeKuVLPyQZDO+TcjdsOEsFQ==}
     engines: {node: '>=20.19'}
     hasBin: true
 
@@ -2058,32 +2058,32 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tsslint/cli@3.1.4(@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2))(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)':
+  '@tsslint/cli@3.1.4(@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2))(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)':
     dependencies:
-      '@tsslint/config': 3.1.4(@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2))
+      '@tsslint/config': 3.1.4(@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2))
       '@tsslint/core': 3.1.4
       '@tsslint/types': 3.1.4
       '@volar/language-core': 2.4.28
       '@volar/language-hub': 0.0.1
       '@volar/typescript': 2.4.28
       minimatch: 10.2.5
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
     transitivePeerDependencies:
       - '@tsslint/compat-eslint'
       - tsl
 
-  '@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)':
+  '@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)':
     dependencies:
       '@tsslint/types': 3.1.4
       esquery: 1.7.0
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
 
-  '@tsslint/config@3.1.4(@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2))':
+  '@tsslint/config@3.1.4(@tsslint/compat-eslint@3.1.4(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2))':
     dependencies:
       '@tsslint/types': 3.1.4
       minimatch: 10.2.5
     optionalDependencies:
-      '@tsslint/compat-eslint': 3.1.4(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+      '@tsslint/compat-eslint': 3.1.4(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
 
   '@tsslint/core@3.1.4':
     dependencies:
@@ -2120,40 +2120,40 @@ snapshots:
 
   '@types/vscode@1.88.0': {}
 
-  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2))(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2))(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/type-utils': 8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+      '@typescript-eslint/type-utils': 8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       '@typescript-eslint/visitor-keys': 8.65.0
       eslint: 10.7.0
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      ts-api-utils: 2.5.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)':
+  '@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
       eslint: 10.7.0
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.65.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)':
+  '@typescript-eslint/project-service@8.65.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       '@typescript-eslint/types': 8.65.0
       debug: 4.4.3
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2162,47 +2162,47 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
 
-  '@typescript-eslint/tsconfig-utils@8.65.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)':
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)':
     dependencies:
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
 
-  '@typescript-eslint/type-utils@8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)':
+  '@typescript-eslint/type-utils@8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       debug: 4.4.3
       eslint: 10.7.0
-      ts-api-utils: 2.5.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      ts-api-utils: 2.5.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/typescript-estree@8.65.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)':
+  '@typescript-eslint/typescript-estree@8.65.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.65.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+      '@typescript-eslint/project-service': 8.65.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      ts-api-utils: 2.5.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)':
+  '@typescript-eslint/utils@8.65.0(eslint@10.7.0)(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
       eslint: 10.7.0
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2211,25 +2211,25 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
 
-  '@typescript-native-bridge/darwin-arm64@6.0.3-bridge.6.tsgo.7.0.2':
+  '@typescript-native-bridge/darwin-arm64@6.0.3-bridge.8.tsgo.7.0.2':
     optional: true
 
-  '@typescript-native-bridge/darwin-x64@6.0.3-bridge.6.tsgo.7.0.2':
+  '@typescript-native-bridge/darwin-x64@6.0.3-bridge.8.tsgo.7.0.2':
     optional: true
 
-  '@typescript-native-bridge/linux-arm64@6.0.3-bridge.6.tsgo.7.0.2':
+  '@typescript-native-bridge/linux-arm64@6.0.3-bridge.8.tsgo.7.0.2':
     optional: true
 
-  '@typescript-native-bridge/linux-arm@6.0.3-bridge.6.tsgo.7.0.2':
+  '@typescript-native-bridge/linux-arm@6.0.3-bridge.8.tsgo.7.0.2':
     optional: true
 
-  '@typescript-native-bridge/linux-x64@6.0.3-bridge.6.tsgo.7.0.2':
+  '@typescript-native-bridge/linux-x64@6.0.3-bridge.8.tsgo.7.0.2':
     optional: true
 
-  '@typescript-native-bridge/win32-arm64@6.0.3-bridge.6.tsgo.7.0.2':
+  '@typescript-native-bridge/win32-arm64@6.0.3-bridge.8.tsgo.7.0.2':
     optional: true
 
-  '@typescript-native-bridge/win32-x64@6.0.3-bridge.6.tsgo.7.0.2':
+  '@typescript-native-bridge/win32-x64@6.0.3-bridge.8.tsgo.7.0.2':
     optional: true
 
   '@typescript/server-harness@0.3.6': {}
@@ -2275,12 +2275,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@volar/kit@2.4.28(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)':
+  '@volar/kit@2.4.28(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)':
     dependencies:
       '@volar/language-service': 2.4.28
       '@volar/typescript': 2.4.28
       typesafe-path: 0.2.2
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -2426,11 +2426,11 @@ snapshots:
       '@vue/shared': https://pkg.pr.new/vuejs/core/@vue/shared@e1bc0eb02e22bc0c236e1471c11d96a368764b72
       csstype: 3.2.3
 
-  '@vue/server-renderer@https://pkg.pr.new/vuejs/core/@vue/server-renderer@e1bc0eb02e22bc0c236e1471c11d96a368764b72(vue@https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2))':
+  '@vue/server-renderer@https://pkg.pr.new/vuejs/core/@vue/server-renderer@e1bc0eb02e22bc0c236e1471c11d96a368764b72(vue@https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2))':
     dependencies:
       '@vue/compiler-ssr': https://pkg.pr.new/vuejs/core/@vue/compiler-ssr@e1bc0eb02e22bc0c236e1471c11d96a368764b72
       '@vue/shared': https://pkg.pr.new/vuejs/core/@vue/shared@e1bc0eb02e22bc0c236e1471c11d96a368764b72
-      vue: https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2)
+      vue: https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2)
 
   '@vue/shared@3.5.40': {}
 
@@ -2941,9 +2941,9 @@ snapshots:
 
   token-stream@1.0.0: {}
 
-  ts-api-utils@2.5.0(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2):
+  ts-api-utils@2.5.0(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2):
     dependencies:
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
 
   tslib@2.8.1:
     optional: true
@@ -2958,15 +2958,15 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2:
+  typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2:
     optionalDependencies:
-      '@typescript-native-bridge/darwin-arm64': 6.0.3-bridge.6.tsgo.7.0.2
-      '@typescript-native-bridge/darwin-x64': 6.0.3-bridge.6.tsgo.7.0.2
-      '@typescript-native-bridge/linux-arm': 6.0.3-bridge.6.tsgo.7.0.2
-      '@typescript-native-bridge/linux-arm64': 6.0.3-bridge.6.tsgo.7.0.2
-      '@typescript-native-bridge/linux-x64': 6.0.3-bridge.6.tsgo.7.0.2
-      '@typescript-native-bridge/win32-arm64': 6.0.3-bridge.6.tsgo.7.0.2
-      '@typescript-native-bridge/win32-x64': 6.0.3-bridge.6.tsgo.7.0.2
+      '@typescript-native-bridge/darwin-arm64': 6.0.3-bridge.8.tsgo.7.0.2
+      '@typescript-native-bridge/darwin-x64': 6.0.3-bridge.8.tsgo.7.0.2
+      '@typescript-native-bridge/linux-arm': 6.0.3-bridge.8.tsgo.7.0.2
+      '@typescript-native-bridge/linux-arm64': 6.0.3-bridge.8.tsgo.7.0.2
+      '@typescript-native-bridge/linux-x64': 6.0.3-bridge.8.tsgo.7.0.2
+      '@typescript-native-bridge/win32-arm64': 6.0.3-bridge.8.tsgo.7.0.2
+      '@typescript-native-bridge/win32-x64': 6.0.3-bridge.8.tsgo.7.0.2
 
   undici-types@8.3.0: {}
 
@@ -3131,15 +3131,15 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue@https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2):
+  vue@https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2):
     dependencies:
       '@vue/compiler-dom': https://pkg.pr.new/vuejs/core/@vue/compiler-dom@e1bc0eb02e22bc0c236e1471c11d96a368764b72
       '@vue/compiler-sfc': https://pkg.pr.new/vuejs/core/@vue/compiler-sfc@e1bc0eb02e22bc0c236e1471c11d96a368764b72
       '@vue/runtime-dom': https://pkg.pr.new/vuejs/core/@vue/runtime-dom@e1bc0eb02e22bc0c236e1471c11d96a368764b72
-      '@vue/server-renderer': https://pkg.pr.new/vuejs/core/@vue/server-renderer@e1bc0eb02e22bc0c236e1471c11d96a368764b72(vue@https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2))
+      '@vue/server-renderer': https://pkg.pr.new/vuejs/core/@vue/server-renderer@e1bc0eb02e22bc0c236e1471c11d96a368764b72(vue@https://pkg.pr.new/vue@e1bc0eb02e22bc0c236e1471c11d96a368764b72(typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2))
       '@vue/shared': https://pkg.pr.new/vuejs/core/@vue/shared@e1bc0eb02e22bc0c236e1471c11d96a368764b72
     optionalDependencies:
-      typescript: typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+      typescript: typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2
 
   which@2.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,4 +21,4 @@ allowBuilds:
   keytar: true
 
 overrides:
-  typescript: npm:typescript-native-bridge@6.0.3-bridge.6.tsgo.7.0.2
+  typescript: npm:typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2


### PR DESCRIPTION
Publish-day dogfood bump: override `typescript` → `npm:typescript-native-bridge@6.0.3-bridge.8.tsgo.7.0.2`.

bridge.8 highlights: tsserver memory ~2× → **1.19× stock** (#41: lazy virtual-file ASTs, idle eviction of scan-materialized files, cross-generation index idle-drain), deterministic whole-program diagnostics (#42), win32 tsserver-under-VS-Code load fix (#44), astro/svelte ambient-root persistence (#38/#46).

Local: `pnpm install` clean, full suite **205 passed | 4 skipped**.