### PR TITLE
fix(language-core): resolve `v-for` item type over generic sources

### DIFF
--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -101,8 +101,8 @@ declare global {
 
 	function __VLS_vFor<const T>(source: T): T extends number ? [number, number][]
 		: T extends string ? [string, number][]
-		: T extends readonly (infer U)[] ? [U, number][]
-		: T extends Iterable<infer V> ? [V, number][]
+		: T extends readonly any[] ? (T extends readonly (infer U)[] ? [U, number] : never)[]
+		: T extends Iterable<any> ? (T extends Iterable<infer V> ? [V, number] : never)[]
 		: [T[keyof T], keyof T extends string ? keyof T : `${keyof T & (string | number)}`, number][];
 	function __VLS_vSlot<S, D extends S>(slot: S, decl?: D): D extends (...args: infer P) => any ? P : any[];
 	function __VLS_asFunctionalDirective<T, ObjectDirective>(

--- a/test-workspace/tsc/#6040/main.vue
+++ b/test-workspace/tsc/#6040/main.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts" generic="TGroup extends {}, TGroups extends Record<string, TGroup> = Record<string, TGroup>">
+import { exactType } from "../shared";
+
+const props = defineProps<{
+  groups: TGroups;
+}>();
+
+for (const [type, group] of Object.entries(props.groups)) {
+	exactType(group, {} as TGroup);
+	exactType(type, {} as string);
+}
+</script>
+
+<template>
+	<template v-for="(group, type) of groups" :key="type">
+     	{{ exactType(group, {} as TGroup) }}
+     	{{ exactType(type, {} as string) }}
+	</template>
+</template>

--- a/test-workspace/tsc/#6040/main.vue
+++ b/test-workspace/tsc/#6040/main.vue
@@ -2,7 +2,7 @@
 import { exactType } from "../shared";
 
 const props = defineProps<{
-  groups: TGroups;
+	groups: TGroups;
 }>();
 
 for (const [type, group] of Object.entries(props.groups)) {
@@ -13,7 +13,7 @@ for (const [type, group] of Object.entries(props.groups)) {
 
 <template>
 	<template v-for="(group, type) of groups" :key="type">
-     	{{ exactType(group, {} as TGroup) }}
-     	{{ exactType(type, {} as string) }}
+		{{ exactType(group, {} as TGroup) }}
+		{{ exactType(type, {} as string) }}
 	</template>
 </template>

--- a/test-workspace/tsc/#6040/tsconfig.json
+++ b/test-workspace/tsc/#6040/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["**/*"]
+}

--- a/test-workspace/tsc/tsconfig.json
+++ b/test-workspace/tsc/tsconfig.json
@@ -518,6 +518,9 @@
 			"path": "./#5986/tsconfig.json"
 		},
 		{
+			"path": "./#6040/tsconfig.json"
+		},
+		{
 			"path": "./#6084/tsconfig.json"
 		},
 		{

--- a/test-workspace/tsc/v-for/generic.vue
+++ b/test-workspace/tsc/v-for/generic.vue
@@ -3,8 +3,16 @@
 		{{ exactType(val, {} as string | boolean) }}
 		{{ exactType(key, {} as string | number) }}
 	</div>
+	<div v-for="(val, key) in ({} as TArr)">
+		{{ exactType(val, {} as number) }}
+		{{ exactType(key, {} as number) }}
+	</div>
+	<div v-for="(val, key) in ({} as TIter)">
+		{{ exactType(val, {} as string) }}
+		{{ exactType(key, {} as number) }}
+	</div>
 </template>
 
-<script lang="ts" setup generic="T extends Record<string, string> | boolean[]">
+<script lang="ts" setup generic="T extends Record<string, string> | boolean[], TArr extends number[], TIter extends Iterable<string>">
 import { exactType } from '../shared';
 </script>

--- a/test-workspace/tsc/v-for/generic.vue
+++ b/test-workspace/tsc/v-for/generic.vue
@@ -13,6 +13,14 @@
 	</div>
 </template>
 
-<script lang="ts" setup generic="T extends Record<string, string> | boolean[], TArr extends number[], TIter extends Iterable<string>">
+<script
+	setup
+	lang="ts"
+	generic="
+		T extends Record<string, string> | boolean[],
+		TArr extends number[],
+		TIter extends Iterable<string>,
+	"
+>
 import { exactType } from '../shared';
 </script>


### PR DESCRIPTION
Fix #6040 

In a generic `v-for`, the item was inferred as `unknown` because TS incorrectly matched `__VLS_vFor`’s array/iterable branches in the deferred conditional type's constraint, where `infer V` falls back to `unknown`.

This PR re-checks `T` so those invalid branches resolve to `never`, and the item is inferred as the correct `TGroup`.

<img width="635" height="367" alt="image" src="https://github.com/user-attachments/assets/aa63357d-7e04-4cb2-bfce-b89cb49526fa" />
