### PR TITLE
feat: report parsing errors in CLI mode

### DIFF
--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -86,7 +86,7 @@ function getSfcParseErrors(language: core.Language<string>, file: ts.SourceFile)
 	fillSourceFileText(language, file);
 
 	// clamp EOF error offsets to the last source character so they never point into the generated code
-	const bound = Math.max(sourceScript.snapshot.getLength() - 1, 0);
+	const bound = sourceScript.snapshot.getText(0, sourceScript.snapshot.getLength()).trimEnd().length;
 	const result: ts.DiagnosticWithLocation[] = [];
 	for (const error of root.vueSfc.errors) {
 		if (!('code' in error)) {

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -1,12 +1,16 @@
+import * as decorateProgramLib from '@volar/typescript/lib/node/decorateProgram';
 import { runTsc } from '@volar/typescript/lib/quickstart/runTsc';
 import * as core from '@vue/language-core';
 import * as path from 'node:path';
+import type * as ts from 'typescript';
 
 const windowsPathRE = /\\/g;
 
 export function run(tscPath?: string) {
 	let runExtensions = ['.vue'];
 	let extensionsChangedException: Error | undefined;
+
+	enableSfcParseErrorReporting();
 
 	const main = () =>
 		runTsc(
@@ -49,6 +53,56 @@ export function run(tscPath?: string) {
 			throw err;
 		}
 	}
+}
+
+function enableSfcParseErrorReporting() {
+	const decorateProgram = decorateProgramLib.decorateProgram;
+	(decorateProgramLib as { decorateProgram: typeof decorateProgram }).decorateProgram = (language, program) => {
+		decorateProgram(language, program);
+		const getSyntacticDiagnostics = program.getSyntacticDiagnostics;
+		program.getSyntacticDiagnostics = (sourceFile, cancellationToken) => [
+			...getSyntacticDiagnostics(sourceFile, cancellationToken),
+			...(sourceFile ? [sourceFile] : program.getSourceFiles())
+				.flatMap(file => getSfcParseErrors(language, file)),
+		];
+	};
+}
+
+function getSfcParseErrors(
+	language: core.Language<string>,
+	file: ts.SourceFile,
+): ts.DiagnosticWithLocation[] {
+	const sourceScript = language.scripts.get(file.fileName);
+	const root = sourceScript?.generated?.root;
+	if (
+		!sourceScript
+		|| !(root instanceof core.VueVirtualCode)
+		// markdown error locations don't map back to the source
+		|| root.languageId !== 'vue'
+		|| !root.vueSfc?.errors.length
+	) {
+		return [];
+	}
+
+	// clamp EOF error offsets to the last source character so they never point into the generated code
+	const bound = Math.max(sourceScript.snapshot.getLength() - 1, 0);
+	const result: ts.DiagnosticWithLocation[] = [];
+	for (const error of root.vueSfc.errors) {
+		if (!('code' in error)) {
+			continue;
+		}
+		const start = Math.min(error.loc?.start.offset ?? 0, bound);
+		const end = Math.min(error.loc?.end.offset ?? start, bound);
+		result.push({
+			file,
+			start,
+			length: end - start,
+			category: 1 satisfies ts.DiagnosticCategory.Error,
+			code: typeof error.code === 'number' ? error.code : 0,
+			messageText: error.message,
+		});
+	}
+	return result;
 }
 
 function resolveTscPath(tscPath = require.resolve('typescript/lib/tsc')) {

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -1,4 +1,5 @@
 import * as decorateProgramLib from '@volar/typescript/lib/node/decorateProgram';
+import { fillSourceFileText } from '@volar/typescript/lib/node/transform';
 import { runTsc } from '@volar/typescript/lib/quickstart/runTsc';
 import * as core from '@vue/language-core';
 import * as path from 'node:path';
@@ -83,6 +84,9 @@ function getSfcParseErrors(
 	) {
 		return [];
 	}
+
+	// fill in the source text so `--pretty` code frames can render it
+	fillSourceFileText(language, file);
 
 	// clamp EOF error offsets to the last source character so they never point into the generated code
 	const bound = Math.max(sourceScript.snapshot.getLength() - 1, 0);

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -69,10 +69,7 @@ function enableSfcParseErrorReporting() {
 	};
 }
 
-function getSfcParseErrors(
-	language: core.Language<string>,
-	file: ts.SourceFile,
-): ts.DiagnosticWithLocation[] {
+function getSfcParseErrors(language: core.Language<string>, file: ts.SourceFile): ts.DiagnosticWithLocation[] {
 	const sourceScript = language.scripts.get(file.fileName);
 	const root = sourceScript?.generated?.root;
 	if (

--- a/packages/tsc/tests/typecheck.spec.ts
+++ b/packages/tsc/tests/typecheck.spec.ts
@@ -32,6 +32,8 @@ test(`vue-tsc`, () => {
 		  "test-workspace/tsc/_failed_#5071/withScript.vue(1,19): error TS1005: ';' expected.",
 		  "test-workspace/tsc/_failed_#5071/withoutScript.vue(2,26): error TS1005: ';' expected.",
 		  "test-workspace/tsc/_failed_#5823/main.vue(6,13): error TS1109: Expression expected.",
+		  "test-workspace/tsc/_failed_#6037/main.vue(1,1): error TS24: Element is missing end tag.",
+		  "test-workspace/tsc/_failed_#6037/main.vue(3,12): error TS9: Unexpected EOF in tag.",
 		  "test-workspace/tsc/_failed_directives/main.vue(14,6): error TS2339: Property 'notExist' does not exist on type '{ $: ComponentInternalInstance; $data: {}; $props: {}; $attrs: Data; $refs: Data; $slots: Readonly<InternalSlots>; $root: ComponentPublicInstance<...> | null; ... 9 more ...; Comp: () => void; }'.",
 		  "test-workspace/tsc/_failed_directives/main.vue(17,2): error TS2578: Unused '@ts-expect-error' directive.",
 		  "test-workspace/tsc/_failed_directives/main.vue(20,2): error TS2578: Unused '@ts-expect-error' directive.",

--- a/test-workspace/tsc/_failed_#6037/main.vue
+++ b/test-workspace/tsc/_failed_#6037/main.vue
@@ -1,0 +1,3 @@
+<template>
+	<div class=">
+</template>

--- a/test-workspace/tsc/_failed_#6037/tsconfig.json
+++ b/test-workspace/tsc/_failed_#6037/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["**/*"]
+}

--- a/test-workspace/tsc/tsconfig.json
+++ b/test-workspace/tsc/tsconfig.json
@@ -542,6 +542,9 @@
 			"path": "./_failed_#5823/tsconfig.json"
 		},
 		{
+			"path": "./_failed_#6037/tsconfig.json"
+		},
+		{
 			"path": "./_failed_directives/tsconfig.json"
 		},
 		{


### PR DESCRIPTION
Resolve #6037

Parsing errors are now also reported in CLI mode. For example:

```vue
<template>
	<div class=">
</template>
```

`vue-tsc` error:

```
"main.vue(1,1): error TS24: Element is missing end tag.",
"main.vue(3,12): error TS9: Unexpected EOF in tag.",
```