### PR TITLE
fix(tsc): support different extension sets across project references

### DIFF
--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -3,15 +3,15 @@ import * as core from '@vue/language-core';
 import * as path from 'node:path';
 
 const windowsPathRE = /\\/g;
+const retryToken = Symbol();
 
 export function run(tscPath?: string) {
-	let runExtensions = ['.vue'];
-	let extensionsChangedException: Error | undefined;
+	const runExtensions = new Set(['vue']);
 
 	const main = () =>
 		runTsc(
 			resolveTscPath(tscPath),
-			runExtensions,
+			[...runExtensions],
 			(ts, options) => {
 				const { configFilePath } = options.options;
 				const vueOptions = typeof configFilePath === 'string'
@@ -19,7 +19,7 @@ export function run(tscPath?: string) {
 					: core.createParsedCommandLineByJson(ts, ts.sys, (options.host ?? ts.sys).getCurrentDirectory(), {})
 						.vueOptions;
 				const allExtensions = core.getAllExtensions(vueOptions);
-				if (allExtensions.every(ext => runExtensions.includes(ext))) {
+				if (allExtensions.every(ext => runExtensions.has(ext))) {
 					const vueLanguagePlugin = core.createVueLanguagePlugin<string>(
 						ts,
 						options.options,
@@ -29,8 +29,10 @@ export function run(tscPath?: string) {
 					return { languagePlugins: [vueLanguagePlugin] };
 				}
 				else {
-					runExtensions = [...new Set([...runExtensions, ...allExtensions])];
-					throw extensionsChangedException = new Error('extensions changed');
+					for (const ext of allExtensions) {
+						runExtensions.add(ext);
+					}
+					throw retryToken;
 				}
 			},
 		);
@@ -40,7 +42,7 @@ export function run(tscPath?: string) {
 			return main();
 		}
 		catch (err) {
-			if (err !== extensionsChangedException) {
+			if (err !== retryToken) {
 				throw err;
 			}
 		}

--- a/packages/tsc/index.ts
+++ b/packages/tsc/index.ts
@@ -19,10 +19,7 @@ export function run(tscPath?: string) {
 					: core.createParsedCommandLineByJson(ts, ts.sys, (options.host ?? ts.sys).getCurrentDirectory(), {})
 						.vueOptions;
 				const allExtensions = core.getAllExtensions(vueOptions);
-				if (
-					runExtensions.length === allExtensions.length
-					&& runExtensions.every(ext => allExtensions.includes(ext))
-				) {
+				if (allExtensions.every(ext => runExtensions.includes(ext))) {
 					const vueLanguagePlugin = core.createVueLanguagePlugin<string>(
 						ts,
 						options.options,
@@ -32,21 +29,20 @@ export function run(tscPath?: string) {
 					return { languagePlugins: [vueLanguagePlugin] };
 				}
 				else {
-					runExtensions = allExtensions;
+					runExtensions = [...new Set([...runExtensions, ...allExtensions])];
 					throw extensionsChangedException = new Error('extensions changed');
 				}
 			},
 		);
 
-	try {
-		return main();
-	}
-	catch (err) {
-		if (err === extensionsChangedException) {
+	while (true) {
+		try {
 			return main();
 		}
-		else {
-			throw err;
+		catch (err) {
+			if (err !== extensionsChangedException) {
+				throw err;
+			}
 		}
 	}
 }

--- a/packages/tsc/tests/build.spec.ts
+++ b/packages/tsc/tests/build.spec.ts
@@ -1,0 +1,34 @@
+import * as path from 'node:path';
+import { expect, test } from 'vitest';
+import { run } from '..';
+
+test(`vue-tsc --build`, () => {
+	expect(runTsc).not.toThrow();
+});
+
+function runTsc() {
+	const originalConsoleLog = process.stdout.write;
+	const originalArgv = process.argv;
+	const originalExit = process.exit;
+	process.stdout.write = () => true;
+	process.argv = [
+		...originalArgv,
+		'--build',
+		path.resolve(__dirname, '../../../test-workspace/tscBuild'),
+		'--pretty',
+		'false',
+	];
+	process.exit = (() => {}) as typeof process.exit;
+	try {
+		const tscPath = require.resolve(
+			`typescript/lib/tsc`,
+			{ paths: [path.resolve(__dirname, '../../../test-workspace')] },
+		);
+		run(tscPath);
+	}
+	finally {
+		process.stdout.write = originalConsoleLog;
+		process.argv = originalArgv;
+		process.exit = originalExit;
+	}
+}

--- a/packages/tsc/tests/build.spec.ts
+++ b/packages/tsc/tests/build.spec.ts
@@ -1,6 +1,4 @@
-import * as path from 'node:path';
 import { expect, test } from 'vitest';
-import { run } from '..';
 import { runTsc } from './utils';
 
 test(`vue-tsc --build`, () => {

--- a/packages/tsc/tests/build.spec.ts
+++ b/packages/tsc/tests/build.spec.ts
@@ -1,34 +1,8 @@
 import * as path from 'node:path';
 import { expect, test } from 'vitest';
 import { run } from '..';
+import { runTsc } from './utils';
 
 test(`vue-tsc --build`, () => {
-	expect(runTsc).not.toThrow();
+	expect(() => runTsc('tscBuild')).not.toThrow();
 });
-
-function runTsc() {
-	const originalConsoleLog = process.stdout.write;
-	const originalArgv = process.argv;
-	const originalExit = process.exit;
-	process.stdout.write = () => true;
-	process.argv = [
-		...originalArgv,
-		'--build',
-		path.resolve(__dirname, '../../../test-workspace/tscBuild'),
-		'--pretty',
-		'false',
-	];
-	process.exit = (() => {}) as typeof process.exit;
-	try {
-		const tscPath = require.resolve(
-			`typescript/lib/tsc`,
-			{ paths: [path.resolve(__dirname, '../../../test-workspace')] },
-		);
-		run(tscPath);
-	}
-	finally {
-		process.stdout.write = originalConsoleLog;
-		process.argv = originalArgv;
-		process.exit = originalExit;
-	}
-}

--- a/packages/tsc/tests/typecheck.spec.ts
+++ b/packages/tsc/tests/typecheck.spec.ts
@@ -1,7 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { expect, test } from 'vitest';
-import { run } from '..';
 import { runTsc } from './utils';
 
 test(`vue-tsc`, () => {

--- a/packages/tsc/tests/typecheck.spec.ts
+++ b/packages/tsc/tests/typecheck.spec.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { expect, test } from 'vitest';
 import { run } from '..';
+import { runTsc } from './utils';
 
 test(`vue-tsc`, () => {
 	const dirPath = path.resolve(__dirname, '..', '..', '..', 'test-workspace', 'tsc');
@@ -21,7 +22,7 @@ test(`vue-tsc`, () => {
 	);
 
 	expect(
-		getTscOutput().sort(),
+		runTsc('tsc').sort(),
 	).toMatchInlineSnapshot(`
 		[
 		  "test-workspace/tsc/_failed_#3632/both.vue(3,1): error TS1109: Expression expected.",
@@ -39,31 +40,3 @@ test(`vue-tsc`, () => {
 		]
 	`);
 });
-
-function getTscOutput() {
-	const consoleOutput: string[] = [];
-	const originalConsoleLog = process.stdout.write;
-	const originalArgv = process.argv;
-	process.stdout.write = output => {
-		consoleOutput.push(String(output).trim());
-		return true;
-	};
-	process.argv = [
-		...originalArgv,
-		'--build',
-		path.resolve(__dirname, '../../../test-workspace/tsc'),
-		'--pretty',
-		'false',
-	];
-	try {
-		const tscPath = require.resolve(
-			`typescript/lib/tsc`,
-			{ paths: [path.resolve(__dirname, '../../../test-workspace')] },
-		);
-		run(tscPath);
-	}
-	catch {}
-	process.stdout.write = originalConsoleLog;
-	process.argv = originalArgv;
-	return consoleOutput;
-}

--- a/packages/tsc/tests/utils.ts
+++ b/packages/tsc/tests/utils.ts
@@ -1,0 +1,30 @@
+import * as path from 'node:path';
+import { run } from '..';
+
+export function runTsc(projectName: string) {
+	const consoleOutput: string[] = [];
+	const originalConsoleLog = process.stdout.write;
+	const originalArgv = process.argv;
+	process.stdout.write = output => {
+		consoleOutput.push(String(output).trim());
+		return true;
+	};
+	process.argv = [
+		...originalArgv,
+		'--build',
+		path.resolve(__dirname, `../../../test-workspace/${projectName}`),
+		'--pretty',
+		'false',
+	];
+	try {
+		const tscPath = require.resolve(
+			`typescript/lib/tsc`,
+			{ paths: [path.resolve(__dirname, '../../../test-workspace')] },
+		);
+		run(tscPath);
+	}
+	catch {}
+	process.stdout.write = originalConsoleLog;
+	process.argv = originalArgv;
+	return consoleOutput;
+}

--- a/test-workspace/tscBuild/petiteVue/main.html
+++ b/test-workspace/tscBuild/petiteVue/main.html
@@ -1,0 +1,5 @@
+<script type="module" lang="ts">
+const msg = 1;
+</script>
+
+{{ msg }}

--- a/test-workspace/tscBuild/petiteVue/main.vue
+++ b/test-workspace/tscBuild/petiteVue/main.vue
@@ -1,0 +1,7 @@
+<template>
+	<div>{{ msg }}</div>
+</template>
+
+<script setup lang="ts">
+const msg = 1;
+</script>

--- a/test-workspace/tscBuild/petiteVue/tsconfig.json
+++ b/test-workspace/tscBuild/petiteVue/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["**/*"],
+	"vueCompilerOptions": {
+		"petiteVueExtensions": [".html"]
+	}
+}

--- a/test-workspace/tscBuild/petiteVue/tsconfig.json
+++ b/test-workspace/tscBuild/petiteVue/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.base.json",
-	"include": ["**/*"],
 	"vueCompilerOptions": {
 		"petiteVueExtensions": [".html"]
-	}
+	},
+	"include": ["**/*"]
 }

--- a/test-workspace/tscBuild/tsconfig.json
+++ b/test-workspace/tscBuild/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"include": [],
+	"references": [
+		{
+			"path": "./vue/tsconfig.json"
+		},
+		{
+			"path": "./vitepress/tsconfig.json"
+		},
+		{
+			"path": "./petiteVue/tsconfig.json"
+		}
+	]
+}

--- a/test-workspace/tscBuild/tsconfig.json
+++ b/test-workspace/tscBuild/tsconfig.json
@@ -1,14 +1,14 @@
 {
-	"include": [],
 	"references": [
 		{
-			"path": "./vue/tsconfig.json"
+			"path": "./petiteVue/tsconfig.json"
 		},
 		{
 			"path": "./vitepress/tsconfig.json"
 		},
 		{
-			"path": "./petiteVue/tsconfig.json"
+			"path": "./vue/tsconfig.json"
 		}
-	]
+	],
+	"files": []
 }

--- a/test-workspace/tscBuild/vitepress/main.md
+++ b/test-workspace/tscBuild/vitepress/main.md
@@ -1,0 +1,7 @@
+# Title
+
+<script setup lang="ts">
+const msg = 1;
+</script>
+
+{{ msg }}

--- a/test-workspace/tscBuild/vitepress/main.vue
+++ b/test-workspace/tscBuild/vitepress/main.vue
@@ -1,0 +1,7 @@
+<template>
+	<div>{{ msg }}</div>
+</template>
+
+<script setup lang="ts">
+const msg = 1;
+</script>

--- a/test-workspace/tscBuild/vitepress/tsconfig.json
+++ b/test-workspace/tscBuild/vitepress/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["**/*"],
+	"vueCompilerOptions": {
+		"vitePressExtensions": [".md"]
+	}
+}

--- a/test-workspace/tscBuild/vitepress/tsconfig.json
+++ b/test-workspace/tscBuild/vitepress/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.base.json",
-	"include": ["**/*"],
 	"vueCompilerOptions": {
 		"vitePressExtensions": [".md"]
-	}
+	},
+	"include": ["**/*"]
 }

--- a/test-workspace/tscBuild/vue/main.vue
+++ b/test-workspace/tscBuild/vue/main.vue
@@ -1,0 +1,7 @@
+<template>
+	<div>{{ msg }}</div>
+</template>
+
+<script setup lang="ts">
+const msg = 1;
+</script>

--- a/test-workspace/tscBuild/vue/tsconfig.json
+++ b/test-workspace/tscBuild/vue/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["**/*"]
+}


### PR DESCRIPTION
When `vue-tsc -b` reaches a project whose Vue extensions differ from the ones tsc was patched with, it restarts the build. That retry only runs once, and it replaces the extension set instead of adding to it. So a build covering three different extension sets throws an uncaught `Error: extensions changed`, and two projects can flip back and forth between their sets forever.

Now the set grows into the union of everything seen so far. A project builds as soon as the current set covers it, and the build restarts until nothing asks for more. The set only grows, so the retries stop.

Fixes #6143
