### PR TITLE
fix(vscode): pass typescript plugin path via env

### DIFF
--- a/extensions/vscode/scripts/write-plugins.ts
+++ b/extensions/vscode/scripts/write-plugins.ts
@@ -16,8 +16,6 @@ write(
 function write(name: string, specifier: string, pathEnvName?: string) {
 	const dir = path.join(import.meta.dirname, `../node_modules/vue-${name}-pack`);
 	fs.mkdirSync(dir, { recursive: true });
-	const moduleExports = pathEnvName
-		? `process.env.${pathEnvName} ? require(process.env.${pathEnvName}) : require('${specifier}')`
-		: `require('${specifier}')`;
-	fs.writeFileSync(path.join(dir, `index.js`), `module.exports = ${moduleExports};\n`);
+	const requirePath = pathEnvName ? `process.env.${pathEnvName} || '${specifier}'` : `'${specifier}'`;
+	fs.writeFileSync(path.join(dir, `index.js`), `module.exports = require(${requirePath});\n`);
 }

--- a/extensions/vscode/scripts/write-plugins.ts
+++ b/extensions/vscode/scripts/write-plugins.ts
@@ -16,6 +16,6 @@ write(
 function write(name: string, specifier: string, pathEnvName?: string) {
 	const dir = path.join(import.meta.dirname, `../node_modules/vue-${name}-pack`);
 	fs.mkdirSync(dir, { recursive: true });
-	const requirePath = pathEnvName ? `process.env.${pathEnvName} || '${specifier}'` : `'${specifier}'`;
-	fs.writeFileSync(path.join(dir, `index.js`), `module.exports = require(${requirePath});\n`);
+	const requireId = pathEnvName ? `process.env.${pathEnvName} || '${specifier}'` : `'${specifier}'`;
+	fs.writeFileSync(path.join(dir, `index.js`), `module.exports = require(${requireId});\n`);
 }

--- a/extensions/vscode/scripts/write-plugins.ts
+++ b/extensions/vscode/scripts/write-plugins.ts
@@ -6,14 +6,18 @@ const isDev = process.argv.includes('--dev');
 write(
 	'typescript-plugin',
 	isDev ? '@vue/typescript-plugin' : '../../dist/typescript-plugin.js',
+	'VUE_TYPESCRIPT_PLUGIN_PATH',
 );
 write(
 	'reactivity-analysis-plugin',
 	isDev ? '../../out/reactivityAnalysisPlugin.js' : '../../dist/reactivity-analysis-plugin.js',
 );
 
-function write(name: string, specifier: string) {
+function write(name: string, specifier: string, pathEnvName?: string) {
 	const dir = path.join(import.meta.dirname, `../node_modules/vue-${name}-pack`);
 	fs.mkdirSync(dir, { recursive: true });
-	fs.writeFileSync(path.join(dir, `index.js`), `module.exports = require('${specifier}');\n`);
+	const moduleExports = pathEnvName
+		? `process.env.${pathEnvName} ? require(process.env.${pathEnvName}) : require('${specifier}')`
+		: `require('${specifier}')`;
+	fs.writeFileSync(path.join(dir, `index.js`), `module.exports = ${moduleExports};\n`);
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -261,6 +261,7 @@ function resolveServerPath() {
 		try {
 			const entryFile = require.resolve('./index.js', { paths: [serverPath] });
 			const tsPluginPath = require.resolve('@vue/typescript-plugin', { paths: [path.dirname(entryFile)] });
+			// allow tsserver inherit the per-window path without mutating the shared plugin shim
 			process.env.VUE_TYPESCRIPT_PLUGIN_PATH = tsPluginPath;
 			return entryFile;
 		}

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -247,8 +247,6 @@ function resolveTsdkPath() {
 }
 
 function resolveServerPath() {
-	const tsPluginEntry = path.join(__dirname, '..', 'node_modules', 'vue-typescript-plugin-pack', 'index.js');
-
 	if (!config.server.path) {
 		return;
 	}
@@ -263,8 +261,7 @@ function resolveServerPath() {
 		try {
 			const entryFile = require.resolve('./index.js', { paths: [serverPath] });
 			const tsPluginPath = require.resolve('@vue/typescript-plugin', { paths: [path.dirname(entryFile)] });
-			// FIXME: cannot work on read-only file system
-			fs.writeFileSync(tsPluginEntry, `module.exports = require(${JSON.stringify(tsPluginPath)});`);
+			process.env.VUE_TYPESCRIPT_PLUGIN_PATH = tsPluginPath;
 			return entryFile;
 		}
 		catch {}


### PR DESCRIPTION
Fix #6098

Passing the custom `@vue/typescript-plugin` path to tsserver via a per-window environment variable instead of rewriting the plugin shim in the shared extension install directory, which leaked one profile's plugin into every other window and profile.
