### PR TITLE
fix(language-core): generate full fragment props for typecheck

### DIFF
--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -380,6 +380,7 @@ export function* generateFragment(
 	node: CompilerDOM.ElementNode,
 ): Generator<Code> {
 	const [startTagOffset] = getElementTagOffsets(node, options.template);
+	const failedPropExps: FailedPropExpressions[] = [];
 
 	// special case for <template v-for="..." :key="..." />
 	if (node.props.length) {
@@ -399,10 +400,13 @@ export function* generateFragment(
 			node,
 			node.props,
 			options.vueCompilerOptions.checkUnknownProps,
+			failedPropExps,
 		);
 		yield `}`;
 		yield boundary.end();
 		yield `)${endOfLine}`;
+
+		yield* generateFailedExpressions(options, ctx, failedPropExps);
 	}
 
 	for (const child of node.children) {

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -383,7 +383,9 @@ export function* generateFragment(
 
 	// special case for <template v-for="..." :key="..." />
 	if (node.props.length) {
-		yield `__VLS_asFunctionalElement(__VLS_intrinsics.template)(`;
+		yield `${
+			options.vueCompilerOptions.checkUnknownProps ? names.asFunctionalElement0 : names.asFunctionalElement1
+		}(${names.intrinsics}.template)(`;
 		const boundary = yield* Boundary.start(
 			'template',
 			startTagOffset,

--- a/packages/tsc/tests/typecheck.spec.ts
+++ b/packages/tsc/tests/typecheck.spec.ts
@@ -36,6 +36,8 @@ test(`vue-tsc`, () => {
 		  "test-workspace/tsc/_failed_directives/main.vue(17,2): error TS2578: Unused '@ts-expect-error' directive.",
 		  "test-workspace/tsc/_failed_directives/main.vue(20,2): error TS2578: Unused '@ts-expect-error' directive.",
 		  "test-workspace/tsc/_failed_directives/main.vue(9,6): error TS2339: Property 'notExist' does not exist on type '{ $: ComponentInternalInstance; $data: {}; $props: {}; $attrs: Data; $refs: Data; $slots: Readonly<InternalSlots>; $root: ComponentPublicInstance<...> | null; ... 9 more ...; Comp: () => void; }'.",
+		  "test-workspace/tsc/_failed_fragment_props/main.vue(12,46): error TS2339: Property 'bar' does not exist on type '{ id: number; }'.",
+		  "test-workspace/tsc/_failed_fragment_props/main.vue(12,54): error TS2339: Property 'baz' does not exist on type '{ id: number; }'.",
 		  "test-workspace/tsc/_failed_fragment_props/main.vue(6,31): error TS2322: Type '{ id: number; }' is not assignable to type 'PropertyKey | undefined'.",
 		  "test-workspace/tsc/_failed_fragment_props/main.vue(9,32): error TS2353: Object literal may only specify known properties, and 'foo' does not exist in type 'HTMLAttributes & ReservedProps'.",
 		]

--- a/packages/tsc/tests/typecheck.spec.ts
+++ b/packages/tsc/tests/typecheck.spec.ts
@@ -36,6 +36,8 @@ test(`vue-tsc`, () => {
 		  "test-workspace/tsc/_failed_directives/main.vue(17,2): error TS2578: Unused '@ts-expect-error' directive.",
 		  "test-workspace/tsc/_failed_directives/main.vue(20,2): error TS2578: Unused '@ts-expect-error' directive.",
 		  "test-workspace/tsc/_failed_directives/main.vue(9,6): error TS2339: Property 'notExist' does not exist on type '{ $: ComponentInternalInstance; $data: {}; $props: {}; $attrs: Data; $refs: Data; $slots: Readonly<InternalSlots>; $root: ComponentPublicInstance<...> | null; ... 9 more ...; Comp: () => void; }'.",
+		  "test-workspace/tsc/_failed_fragment_props/main.vue(6,31): error TS2322: Type '{ id: number; }' is not assignable to type 'PropertyKey | undefined'.",
+		  "test-workspace/tsc/_failed_fragment_props/main.vue(9,32): error TS2353: Object literal may only specify known properties, and 'foo' does not exist in type 'HTMLAttributes & ReservedProps'.",
 		]
 	`);
 });

--- a/test-workspace/tsc/_failed_fragment_props/main.vue
+++ b/test-workspace/tsc/_failed_fragment_props/main.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+const list = [{ id: 1 }];
+</script>
+
+<template>
+	<template v-for="x of list" :key="x">
+		<div>{{ x.id }}</div>
+	</template>
+	<template v-if="list.length" :foo="1">
+		<div>{{ list.length }}</div>
+	</template>
+</template>

--- a/test-workspace/tsc/_failed_fragment_props/main.vue
+++ b/test-workspace/tsc/_failed_fragment_props/main.vue
@@ -9,4 +9,7 @@ const list = [{ id: 1 }];
 	<template v-if="list.length" :foo="1">
 		<div>{{ list.length }}</div>
 	</template>
+	<template v-for="x of list" :key="x.id" @[x.bar]="x.baz()">
+		<div>{{ x.id }}</div>
+	</template>
 </template>

--- a/test-workspace/tsc/_failed_fragment_props/tsconfig.json
+++ b/test-workspace/tsc/_failed_fragment_props/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["**/*"],
+	"vueCompilerOptions": {
+		"strictTemplates": true
+	}
+}

--- a/test-workspace/tsc/tsconfig.json
+++ b/test-workspace/tsc/tsconfig.json
@@ -545,6 +545,9 @@
 			"path": "./_failed_directives/tsconfig.json"
 		},
 		{
+			"path": "./_failed_fragment_props/tsconfig.json"
+		},
+		{
 			"path": "./attrs/tsconfig.json"
 		},
 		{


### PR DESCRIPTION
Related #5769

This PR fixed expected type check for `<template>` props.

- Fixed: `__VLS_asFunctionalElement` is split since #5845
- New feature: Generate failed expressions for handling props like `@[x.bar]="x.baz()"`
