### PR TITLE
feat(vscode): make welcome page configurable (#6164)

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -253,10 +253,10 @@
 			"type": "object",
 			"title": "Vue",
 			"properties": {
-				"vue.showWelcome": {
+				"vue.welcome.show": {
 					"type": "boolean",
 					"default": true,
-					"markdownDescription": "%configuration.showWelcome%"
+					"markdownDescription": "%configuration.welcome.show%"
 				},
 				"vue.trace.server": {
 					"scope": "window",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -253,6 +253,11 @@
 			"type": "object",
 			"title": "Vue",
 			"properties": {
+				"vue.showWelcome": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "%configuration.showWelcome%"
+				},
 				"vue.trace.server": {
 					"scope": "window",
 					"type": "string",

--- a/extensions/vscode/package.nls.ja.json
+++ b/extensions/vscode/package.nls.ja.json
@@ -1,4 +1,5 @@
 {
+	"configuration.showWelcome": "Vue のウェルカムページを表示します。",
 	"configuration.trace.server": "VS Code と Vue 言語サーバー間の通信をトレースします。",
 	"configuration.server.path": "`@vue/language-server` モジュールへのパス。設定しない場合、拡張機能にバンドルされたサーバーが読み込まれます。",
 	"configuration.server.includeLanguages": "拡張機能を有効にする言語を指定します。",

--- a/extensions/vscode/package.nls.ja.json
+++ b/extensions/vscode/package.nls.ja.json
@@ -1,5 +1,5 @@
 {
-	"configuration.showWelcome": "Vue のウェルカムページを表示します。",
+	"configuration.welcome.show": "Vue のウェルカムページを表示します。",
 	"configuration.trace.server": "VS Code と Vue 言語サーバー間の通信をトレースします。",
 	"configuration.server.path": "`@vue/language-server` モジュールへのパス。設定しない場合、拡張機能にバンドルされたサーバーが読み込まれます。",
 	"configuration.server.includeLanguages": "拡張機能を有効にする言語を指定します。",

--- a/extensions/vscode/package.nls.json
+++ b/extensions/vscode/package.nls.json
@@ -1,5 +1,5 @@
 {
-	"configuration.showWelcome": "Show the Vue welcome page.",
+	"configuration.welcome.show": "Show the Vue welcome page.",
 	"configuration.trace.server": "Traces the communication between VS Code and the language server.",
 	"configuration.server.path": "Path to the `@vue/language-server` module. If not set, the server will be loaded from the extension's bundled.",
 	"configuration.server.includeLanguages": "Configure the languages for which the extension should be activated.",

--- a/extensions/vscode/package.nls.json
+++ b/extensions/vscode/package.nls.json
@@ -1,4 +1,5 @@
 {
+	"configuration.showWelcome": "Show the Vue welcome page.",
 	"configuration.trace.server": "Traces the communication between VS Code and the language server.",
 	"configuration.server.path": "Path to the `@vue/language-server` module. If not set, the server will be loaded from the extension's bundled.",
 	"configuration.server.includeLanguages": "Configure the languages for which the extension should be activated.",

--- a/extensions/vscode/package.nls.ru.json
+++ b/extensions/vscode/package.nls.ru.json
@@ -1,5 +1,5 @@
 {
-	"configuration.showWelcome": "Показывать приветственную страницу Vue.",
+	"configuration.welcome.show": "Показывать приветственную страницу Vue.",
 	"configuration.trace.server": "Отслеживать коммуникацию между VS Code и языковым сервером Vue.",
 	"configuration.server.path": "Путь к модулю `@vue/language-server`. Если не установлен, сервер будет загружен из пакета расширения.",
 	"configuration.server.includeLanguages": "Языки, для которых будет включено расширение.",

--- a/extensions/vscode/package.nls.ru.json
+++ b/extensions/vscode/package.nls.ru.json
@@ -1,4 +1,5 @@
 {
+	"configuration.showWelcome": "Показывать приветственную страницу Vue.",
 	"configuration.trace.server": "Отслеживать коммуникацию между VS Code и языковым сервером Vue.",
 	"configuration.server.path": "Путь к модулю `@vue/language-server`. Если не установлен, сервер будет загружен из пакета расширения.",
 	"configuration.server.includeLanguages": "Языки, для которых будет включено расширение.",

--- a/extensions/vscode/package.nls.zh-CN.json
+++ b/extensions/vscode/package.nls.zh-CN.json
@@ -1,4 +1,5 @@
 {
+	"configuration.showWelcome": "显示 Vue 欢迎页面。",
 	"configuration.trace.server": "跟踪 VS Code 和 Vue 语言服务器之间的通信。",
 	"configuration.server.path": "`@vue/language-server` 模块的路径。如果未设置，服务器将从扩展的捆绑包中加载。",
 	"configuration.server.includeLanguages": "配置扩展需要激活的语言类型。",

--- a/extensions/vscode/package.nls.zh-CN.json
+++ b/extensions/vscode/package.nls.zh-CN.json
@@ -1,5 +1,5 @@
 {
-	"configuration.showWelcome": "显示 Vue 欢迎页面。",
+	"configuration.welcome.show": "显示 Vue 欢迎页面。",
 	"configuration.trace.server": "跟踪 VS Code 和 Vue 语言服务器之间的通信。",
 	"configuration.server.path": "`@vue/language-server` 模块的路径。如果未设置，服务器将从扩展的捆绑包中加载。",
 	"configuration.server.includeLanguages": "配置扩展需要激活的语言类型。",

--- a/extensions/vscode/package.nls.zh-TW.json
+++ b/extensions/vscode/package.nls.zh-TW.json
@@ -1,5 +1,5 @@
 {
-	"configuration.showWelcome": "顯示 Vue 歡迎頁面。",
+	"configuration.welcome.show": "顯示 Vue 歡迎頁面。",
 	"configuration.trace.server": "追蹤 VS Code 和 Vue 語言伺服器之間的通訊。",
 	"configuration.server.path": "`@vue/language-server` 模組的路徑。如果未設定，伺服器將從擴充功能的捆綁包中載入。",
 	"configuration.server.includeLanguages": "配置擴充功能應該啟動的語言類型。",

--- a/extensions/vscode/package.nls.zh-TW.json
+++ b/extensions/vscode/package.nls.zh-TW.json
@@ -1,4 +1,5 @@
 {
+	"configuration.showWelcome": "顯示 Vue 歡迎頁面。",
 	"configuration.trace.server": "追蹤 VS Code 和 Vue 語言伺服器之間的通訊。",
 	"configuration.server.path": "`@vue/language-server` 模組的路徑。如果未設定，伺服器將從擴充功能的捆綁包中載入。",
 	"configuration.server.includeLanguages": "配置擴充功能應該啟動的語言類型。",

--- a/extensions/vscode/src/welcome.ts
+++ b/extensions/vscode/src/welcome.ts
@@ -6,7 +6,8 @@ let panel: vscode.WebviewPanel | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
 	if (
-		context.globalState.get<boolean>('vue.showUpdates', true)
+		vscode.workspace.getConfiguration('vue').get<boolean>('showWelcome')
+		&& context.globalState.get<boolean>('vue.showUpdates', true)
 		&& context.globalState.get('vue.welcome') !== popVersion
 	) {
 		context.globalState.update('vue.welcome', popVersion);


### PR DESCRIPTION
## Summary

Add a `vue.welcome.show` setting to allow users to disable the Vue welcome page.

The setting defaults to `true` to preserve the existing behavior.

Closes #6164