### PR TITLE
fix(language-service): invalidate tag/attr casing detection cache on template change

### DIFF
--- a/packages/language-service/lib/nameCasing.ts
+++ b/packages/language-service/lib/nameCasing.ts
@@ -1,12 +1,13 @@
-import type { LanguageServiceContext, VirtualCode } from '@volar/language-service';
+import type { LanguageServiceContext } from '@volar/language-service';
 import type { NodeTypes } from '@vue/compiler-dom';
 import type * as CompilerDOM from '@vue/compiler-dom';
 import { forEachElementNode, hyphenateTag, VueVirtualCode } from '@vue/language-core';
 import type { URI } from 'vscode-uri';
 
 type CollectResult = Map<string, [tagType: CompilerDOM.ElementTypes, attrs: string[]]>;
+type TemplateBlock = NonNullable<VueVirtualCode['ir']['template']>;
 
-const collectCache = new WeakMap<VirtualCode, CollectResult>();
+const collectCache = new WeakMap<TemplateBlock, [version: string, CollectResult]>();
 
 export const enum TagNameCasing {
 	Kebab,
@@ -114,14 +115,17 @@ function detectTagCasing(code: VueVirtualCode): TagNameCasing[] {
 	return [...result];
 }
 
-function collectTagsWithCache(code: VueVirtualCode) {
-	let cache = collectCache.get(code);
-	if (!cache) {
-		const ast = code.ir.template?.ast;
-		cache = ast ? collectTags(ast) : new Map();
-		collectCache.set(code, cache);
+function collectTagsWithCache(code: VueVirtualCode): CollectResult {
+	const { template } = code.ir;
+	if (!template) {
+		return new Map();
 	}
-	return cache;
+	let cache = collectCache.get(template);
+	if (!cache || cache[0] !== template.content) {
+		const ast = template.ast;
+		collectCache.set(template, cache = [template.content, ast ? collectTags(ast) : new Map()]);
+	}
+	return cache[1];
 }
 
 function collectTags(ast: CompilerDOM.RootNode) {

--- a/packages/language-service/tests/nameCasing.spec.ts
+++ b/packages/language-service/tests/nameCasing.spec.ts
@@ -1,0 +1,66 @@
+import { createUriMap, type LanguageServiceContext } from '@volar/language-service';
+import { createLanguage, createVueLanguagePlugin, getDefaultCompilerOptions } from '@vue/language-core';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { URI } from 'vscode-uri';
+import { getAttrNameCasing, getTagNameCasing } from '../lib/nameCasing';
+import type { AttrNameCasing, TagNameCasing } from '../lib/nameCasing';
+
+const vueLanguagePlugin = createVueLanguagePlugin<URI>(
+	ts,
+	{},
+	getDefaultCompilerOptions(),
+	uri => uri.path,
+);
+
+function createTestContext() {
+	const language = createLanguage<URI>(
+		[vueLanguagePlugin],
+		createUriMap(false),
+		() => {},
+	);
+	const context = {
+		language,
+		env: {},
+	} as LanguageServiceContext;
+	return { language, context };
+}
+
+describe('nameCasing detection', () => {
+	it('tag casing follows template edits', async () => {
+		const { language, context } = createTestContext();
+		const uri = URI.parse('file:///tagCasing.vue');
+
+		language.scripts.set(uri, ts.ScriptSnapshot.fromString(`<template><MyComp /></template>`), 'vue');
+		expect(await getTagNameCasing(context, uri)).toBe(1 satisfies TagNameCasing.Pascal);
+
+		language.scripts.set(uri, ts.ScriptSnapshot.fromString(`<template><my-comp /></template>`), 'vue');
+		expect(await getTagNameCasing(context, uri)).toBe(0 satisfies TagNameCasing.Kebab);
+	});
+
+	it('attr casing follows template edits', async () => {
+		const { language, context } = createTestContext();
+		const uri = URI.parse('file:///attrCasing.vue');
+
+		language.scripts.set(uri, ts.ScriptSnapshot.fromString(`<template><MyComp :fooBar="1" /></template>`), 'vue');
+		expect(await getAttrNameCasing(context, uri)).toBe(1 satisfies AttrNameCasing.Camel);
+
+		language.scripts.set(uri, ts.ScriptSnapshot.fromString(`<template><MyComp :foo-bar="1" /></template>`), 'vue');
+		expect(await getAttrNameCasing(context, uri)).toBe(0 satisfies AttrNameCasing.Kebab);
+	});
+
+	it('detection recovers after the first query saw no template block', async () => {
+		const { language, context } = createTestContext();
+		const uri = URI.parse('file:///noTemplate.vue');
+
+		language.scripts.set(uri, ts.ScriptSnapshot.fromString(`<script setup lang="ts">const a = 1;</script>`), 'vue');
+		expect(await getTagNameCasing(context, uri)).toBe(1 satisfies TagNameCasing.Pascal);
+
+		language.scripts.set(
+			uri,
+			ts.ScriptSnapshot.fromString(`<template><my-comp /></template><script setup lang="ts">const a = 1;</script>`),
+			'vue',
+		);
+		expect(await getTagNameCasing(context, uri)).toBe(0 satisfies TagNameCasing.Kebab);
+	});
+});


### PR DESCRIPTION
Fix #6171

https://github.com/user-attachments/assets/487ba8f4-cb8d-4339-8b53-fc3b32a231fe