### PR TITLE
test(language-server): add #6176 rename test

### DIFF
--- a/packages/language-server/tests/renaming.spec.ts
+++ b/packages/language-server/tests/renaming.spec.ts
@@ -647,6 +647,72 @@ test('Component dynamic props', async () => {
 	`);
 });
 
+test('#6176', async () => {
+	expect(
+		await requestRenameToTsServer(
+			'tsconfigProject/fixture.vue',
+			'vue',
+			`
+			<template>
+				<div :[foo|]="123"></div>
+			</template>
+
+			<script lang="ts" setup>
+			import { useTemplateRef } from 'vue';
+			const foo = useTemplateRef('foo');
+			</script>
+		`,
+		),
+	).toMatchInlineSnapshot(`
+		{
+		  "info": {
+		    "canRename": true,
+		    "displayName": "foo",
+		    "fullDisplayName": "foo",
+		    "kind": "const",
+		    "kindModifiers": "",
+		    "triggerSpan": {
+		      "end": {
+		        "line": 3,
+		        "offset": 15,
+		      },
+		      "start": {
+		        "line": 3,
+		        "offset": 12,
+		      },
+		    },
+		  },
+		  "locs": [
+		    {
+		      "file": "\${testWorkspacePath}/tsconfigProject/fixture.vue",
+		      "locs": [
+		        {
+		          "end": {
+		            "line": 3,
+		            "offset": 15,
+		          },
+		          "start": {
+		            "line": 3,
+		            "offset": 12,
+		          },
+		        },
+		        {
+		          "end": {
+		            "line": 8,
+		            "offset": 13,
+		          },
+		          "start": {
+		            "line": 8,
+		            "offset": 10,
+		          },
+		        },
+		      ],
+		    },
+		  ],
+		}
+	`);
+});
+
 test('Component returns', async () => {
 	expect(
 		await requestRenameToTsServer(


### PR DESCRIPTION
## Summary

Adds a failing test for #6176: renaming a `useTemplateRef` binding used as a dynamic prop name (`:[foo]`) also renames the synthesized `.value`.

The test documents the expected behavior — only the `foo` binding should be renamed — and currently fails because the rename also reports `Ref.value` from `@vue/reactivity`.

## Why test-only

No fix is included here; the intent is to capture the bug first so a future fix has a red test to turn green.
