### PR TITLE
fix(language-core): prevent template token boundary double-mapping

### DIFF
--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -46,6 +46,7 @@ export function* generateInterpolation(
 				block.name,
 				start + prevEnd,
 				data,
+				prevEnd > 0,
 			);
 			yield `: `;
 		}
@@ -55,6 +56,7 @@ export function* generateInterpolation(
 				block.name,
 				start + prevEnd,
 				data,
+				prevEnd > 0,
 			);
 		}
 
@@ -103,6 +105,7 @@ export function* generateInterpolation(
 			block.name,
 			start + prevEnd,
 			data,
+			prevEnd > 0,
 		);
 	}
 
@@ -124,8 +127,13 @@ function* generateNonIdentifierCode(
 	source: string,
 	offset: number,
 	data: VueCodeInformation,
+	shouldCut = true,
 ): Generator<Code> {
 	if (!code.length) {
+		return;
+	}
+	if (!shouldCut) {
+		yield [code, source, offset, data];
 		return;
 	}
 	yield [code.slice(0, 1), source, offset, { verification: data.verification }];

--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -55,6 +55,7 @@ export function* generateInterpolation(
 				block.name,
 				start + prevEnd,
 				data,
+				true,
 			);
 		}
 
@@ -112,25 +113,34 @@ export function* generateInterpolation(
 }
 
 /**
- * Yield a code chunk, cutting the first character off as verification-only.
+ * Yield a code chunk, cutting the boundary character off as verification-only.
  *
  * Adjacent mappings share the boundary offset (closed interval), so both the
- * previous token's end and this chunk's start claim the same source offset.
- * Downgrading the first character to verification-only keeps content-sensitive
- * features (rename / navigation) from firing on the following chunk's boundary.
+ * neighbouring token's end and this chunk's start claim the same source offset.
+ * Downgrading the boundary character to verification-only keeps content-sensitive
+ * features (rename / navigation) from firing on the neighbouring chunk.
  */
 function* generateNonIdentifierCode(
 	code: string,
 	source: string,
 	offset: number,
 	data: VueCodeInformation,
+	cutLast = false,
 ): Generator<Code> {
 	if (!code.length) {
 		return;
 	}
-	yield [code.slice(0, 1), source, offset, { verification: data.verification }];
-	if (code.length > 1) {
-		yield [code.slice(1), source, offset + 1, data];
+	if (cutLast) {
+		if (code.length > 1) {
+			yield [code.slice(0, -1), source, offset, data];
+		}
+		yield [code.slice(-1), source, offset + code.length - 1, { verification: data.verification }];
+	}
+	else {
+		yield [code.slice(0, 1), source, offset, { verification: data.verification }];
+		if (code.length > 1) {
+			yield [code.slice(1), source, offset + 1, data];
+		}
 	}
 }
 

--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -41,7 +41,7 @@ export function* generateInterpolation(
 		)
 	) {
 		if (isShorthand) {
-			yield* yieldNonIdentifierCode(
+			yield* generateNonIdentifierCode(
 				code.slice(prevEnd, offset + name.length),
 				block.name,
 				start + prevEnd,
@@ -50,7 +50,7 @@ export function* generateInterpolation(
 			yield `: `;
 		}
 		else if (prevEnd < offset) {
-			yield* yieldNonIdentifierCode(
+			yield* generateNonIdentifierCode(
 				code.slice(prevEnd, offset),
 				block.name,
 				start + prevEnd,
@@ -98,7 +98,7 @@ export function* generateInterpolation(
 	}
 
 	if (prevEnd < code.length) {
-		yield* yieldNonIdentifierCode(
+		yield* generateNonIdentifierCode(
 			code.slice(prevEnd),
 			block.name,
 			start + prevEnd,
@@ -119,7 +119,7 @@ export function* generateInterpolation(
  * Downgrading the first character to verification-only keeps content-sensitive
  * features (rename / navigation) from firing on the following chunk's boundary.
  */
-function* yieldNonIdentifierCode(
+function* generateNonIdentifierCode(
 	code: string,
 	source: string,
 	offset: number,

--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -55,7 +55,6 @@ export function* generateInterpolation(
 				block.name,
 				start + prevEnd,
 				data,
-				true,
 			);
 		}
 
@@ -125,22 +124,13 @@ function* generateNonIdentifierCode(
 	source: string,
 	offset: number,
 	data: VueCodeInformation,
-	cutLast = false,
 ): Generator<Code> {
 	if (!code.length) {
 		return;
 	}
-	if (cutLast) {
-		if (code.length > 1) {
-			yield [code.slice(0, -1), source, offset, data];
-		}
-		yield [code.slice(-1), source, offset + code.length - 1, { verification: data.verification }];
-	}
-	else {
-		yield [code.slice(0, 1), source, offset, { verification: data.verification }];
-		if (code.length > 1) {
-			yield [code.slice(1), source, offset + 1, data];
-		}
+	yield [code.slice(0, 1), source, offset, { verification: data.verification }];
+	if (code.length > 1) {
+		yield [code.slice(1), source, offset + 1, data];
 	}
 }
 

--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -41,21 +41,21 @@ export function* generateInterpolation(
 		)
 	) {
 		if (isShorthand) {
-			yield [
+			yield* yieldNonIdentifierCode(
 				code.slice(prevEnd, offset + name.length),
 				block.name,
 				start + prevEnd,
 				data,
-			];
+			);
 			yield `: `;
 		}
 		else if (prevEnd < offset) {
-			yield [
+			yield* yieldNonIdentifierCode(
 				code.slice(prevEnd, offset),
 				block.name,
 				start + prevEnd,
 				data,
-			];
+			);
 		}
 
 		if (setupRefs.has(name)) {
@@ -98,16 +98,39 @@ export function* generateInterpolation(
 	}
 
 	if (prevEnd < code.length) {
-		yield [
+		yield* yieldNonIdentifierCode(
 			code.slice(prevEnd),
 			block.name,
 			start + prevEnd,
 			data,
-		];
+		);
 	}
 
 	if (suffix) {
 		yield suffix;
+	}
+}
+
+/**
+ * Yield a code chunk, cutting the first character off as verification-only.
+ *
+ * Adjacent mappings share the boundary offset (closed interval), so both the
+ * previous token's end and this chunk's start claim the same source offset.
+ * Downgrading the first character to verification-only keeps content-sensitive
+ * features (rename / navigation) from firing on the following chunk's boundary.
+ */
+function* yieldNonIdentifierCode(
+	code: string,
+	source: string,
+	offset: number,
+	data: VueCodeInformation,
+): Generator<Code> {
+	if (!code.length) {
+		return;
+	}
+	yield [code.slice(0, 1), source, offset, { verification: data.verification }];
+	if (code.length > 1) {
+		yield [code.slice(1), source, offset + 1, data];
 	}
 }
 

--- a/packages/language-server/tests/hover.spec.ts
+++ b/packages/language-server/tests/hover.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'vitest';
+import { URI } from 'vscode-uri';
+import { getLanguageServer, testWorkspacePath } from './server';
+
+test('global at leading code is not cut', async () => {
+	const content = `<template>
+	{{Math.max(foo)}}
+</template>
+
+<script setup lang="ts">
+const foo = 1;
+</script>`;
+	const offset = content.indexOf('Math');
+
+	const server = await getLanguageServer();
+	const document = await server.open(URI.file(`${testWorkspacePath}/tsconfigProject/fixture.vue`).toString(), 'vue', content);
+
+	const res = await server.tsserver.message({
+		seq: server.nextSeq(),
+		command: 'quickinfo',
+		arguments: {
+			file: URI.parse(document.uri).fsPath,
+			position: offset,
+		},
+	});
+
+	await server.close(document.uri);
+
+	expect(res.success).toBe(true);
+	expect(res.body?.displayString).toBe('var Math: Math');
+});

--- a/packages/language-server/tests/hover.spec.ts
+++ b/packages/language-server/tests/hover.spec.ts
@@ -13,7 +13,11 @@ const foo = 1;
 	const offset = content.indexOf('Math');
 
 	const server = await getLanguageServer();
-	const document = await server.open(URI.file(`${testWorkspacePath}/tsconfigProject/fixture.vue`).toString(), 'vue', content);
+	const document = await server.open(
+		URI.file(`${testWorkspacePath}/tsconfigProject/fixture.vue`).toString(),
+		'vue',
+		content,
+	);
 
 	const res = await server.tsserver.message({
 		seq: server.nextSeq(),


### PR DESCRIPTION
Closes #6176

## Problem

Renaming `foo` at the `foo`/`]` boundary of `:[foo]` (with `useTemplateRef('foo')`) also renamed the synthesized `.value`, producing a spurious `Ref.value` reference in `@vue/reactivity`.

## Why

`foo` is a ref, so the template compiles `foo` to `foo.value` (`.value` is synthesized, no source mapping).

Rename requires a **unique** source→generated mapping — each source position maps to exactly one generated position. The `.value` gap breaks that: the cursor at `:[foo|]` maps to two generated positions, and rename runs at both:

```
[foo|.value]    → renames "foo"
[foo.value|]    → renames "value"   (spurious Ref.value)
```

## Fix

Rename is content-sensitive, so it must only fire on a **contiguous** mapped range (volarjs/volar.js#243); error mapping is position-based and may span discontiguous mappings. The synthesized `.value` is an unmapped gap that breaks that contiguity (and the uniqueness above), so the boundary character is downgraded to verification-only — it keeps error mapping but stops claiming the boundary for rename:

```ts
yield [code.slice(0, 1), source, offset, { verification: data.verification }];
```

The cut only happens where a previous token exists (`shouldCut = prevEnd > 0`), so the expression's leading character is preserved. `foo.bar` is unaffected — only the leading `.` is cut, `bar` stays renameable.

## After

Renaming `foo` now returns only `foo` (template + script).
