### PR TITLE
fix(language-core): eliminate unmapped codegen diagnostics

### DIFF
--- a/packages/language-core/lib/codegen/localTypes.ts
+++ b/packages/language-core/lib/codegen/localTypes.ts
@@ -1,40 +1,56 @@
 import type { VueCompilerOptions } from '../types';
-import { endOfLine } from './utils';
+import { endOfLine, isTsLang, newLine } from './utils';
 
-export function getLocalTypesGenerator(vueCompilerOptions: VueCompilerOptions) {
+export function getLocalTypesGenerator(vueCompilerOptions: VueCompilerOptions, lang: string) {
 	const used = new Set<string>();
+	const isTs = isTsLang(lang);
 
 	const WithDefaults = defineHelper(
 		`__VLS_WithDefaults`,
 		() =>
-			`
+			isTs
+				? `
 type __VLS_WithDefaults<P, D> = {
 	[K in keyof Pick<P, keyof P>]: K extends keyof D
 		? ${PrettifyLocal.name}<P[K] & { default: D[K] }>
 		: P[K]
 };
-`.trimStart(),
+`.trimStart()
+				: jsTypedef(
+					`P, D`,
+					`__VLS_WithDefaults`,
+					`{ [K in keyof Pick<P, keyof P>]: K extends keyof D ? ${PrettifyLocal.name}<P[K] & { default: D[K] }> : P[K] }`,
+				),
 	);
 	const PrettifyLocal = defineHelper(
 		`__VLS_PrettifyLocal`,
 		() =>
-			`type __VLS_PrettifyLocal<T> = (T extends any ? { [K in keyof T]: T[K]; } : { [K in keyof T as K]: T[K]; }) & {}${endOfLine}`,
+			isTs
+				? `type __VLS_PrettifyLocal<T> = (T extends any ? { [K in keyof T]: T[K]; } : { [K in keyof T as K]: T[K]; }) & {}${endOfLine}`
+				: jsTypedef(
+					`T`,
+					`__VLS_PrettifyLocal`,
+					`(T extends any ? { [K in keyof T]: T[K]; } : { [K in keyof T as K]: T[K]; }) & {}`,
+				),
 	);
 	const WithSlots = defineHelper(
 		`__VLS_WithSlots`,
 		() =>
-			`
+			isTs
+				? `
 type __VLS_WithSlots<T, S> = T & {
 	new(): {
 		$slots: S;
 	}
 };
-`.trimStart(),
+`.trimStart()
+				: jsTypedef(`T, S`, `__VLS_WithSlots`, `T & { new(): { $slots: S; } }`),
 	);
 	const PropsChildren = defineHelper(
 		`__VLS_PropsChildren`,
 		() =>
-			`
+			isTs
+				? `
 type __VLS_PropsChildren<S> = {
 	[K in keyof (
 		boolean extends (
@@ -48,23 +64,38 @@ type __VLS_PropsChildren<S> = {
 			: JSX.ElementChildrenAttribute
 	)]?: S;
 };
-`.trimStart(),
+`.trimStart()
+				// The single-line form lets the preceding @ts-ignore cover the whole typedef,
+				// mirroring the inline @ts-ignore guards of the TS form.
+				: `// @ts-ignore${newLine}/** @template S @typedef {{ [K in keyof (boolean extends (JSX.ElementChildrenAttribute extends never ? true : false) ? never : JSX.ElementChildrenAttribute)]?: S; }} __VLS_PropsChildren */${newLine}`,
 	);
 	const TypePropsToOption = defineHelper(
 		`__VLS_TypePropsToOption`,
 		() =>
-			`
+			isTs
+				? `
 type __VLS_TypePropsToOption<T> = {
 	[K in keyof T]-?: {} extends Pick<T, K>
 		? { type: import('${vueCompilerOptions.lib}').PropType<Required<T>[K]> }
 		: { type: import('${vueCompilerOptions.lib}').PropType<T[K]>, required: true }
 };
-`.trimStart(),
+`.trimStart()
+				: jsTypedef(
+					`T`,
+					`__VLS_TypePropsToOption`,
+					`{ [K in keyof T]-?: {} extends Pick<T, K> ? { type: import('${vueCompilerOptions.lib}').PropType<Required<T>[K]> } : { type: import('${vueCompilerOptions.lib}').PropType<T[K]>, required: true } }`,
+				),
 	);
 	const OmitIndexSignature = defineHelper(
 		`__VLS_OmitIndexSignature`,
 		() =>
-			`type __VLS_OmitIndexSignature<T> = { [K in keyof T as {} extends Record<K, unknown> ? never : K]: T[K]; }${endOfLine}`,
+			isTs
+				? `type __VLS_OmitIndexSignature<T> = { [K in keyof T as {} extends Record<K, unknown> ? never : K]: T[K]; }${endOfLine}`
+				: jsTypedef(
+					`T`,
+					`__VLS_OmitIndexSignature`,
+					`{ [K in keyof T as {} extends Record<K, unknown> ? never : K]: T[K] }`,
+				),
 	);
 	const helpers = {
 		[PrettifyLocal.name]: PrettifyLocal,
@@ -103,6 +134,10 @@ type __VLS_TypePropsToOption<T> = {
 			yield helpers[name]!.generate();
 		}
 		used.clear();
+	}
+
+	function jsTypedef(params: string, name: string, body: string) {
+		return `/**${newLine} * @template ${params}${newLine} * @typedef {${body}} ${name}${newLine} */${newLine}`;
 	}
 
 	function defineHelper(name: string, generate: () => string) {

--- a/packages/language-core/lib/codegen/names.ts
+++ b/packages/language-core/lib/codegen/names.ts
@@ -45,6 +45,7 @@ const raw = {
 	asFunctionalSlot: '',
 	directiveBindingRestFields: '',
 	functionalComponentArgsRest: '',
+	nonNull: '',
 	omit: '',
 	tryAsConstant: '',
 	unwrap: '',

--- a/packages/language-core/lib/codegen/script/component.ts
+++ b/packages/language-core/lib/codegen/script/component.ts
@@ -28,14 +28,14 @@ export function* generateComponent(
 		&& options.vueCompilerOptions.inferComponentDollarRefs
 		&& options.templateAndStyleTypes.has(names.TemplateRefs)
 	) {
-		yield `__typeRefs: ${asType('{}', names.TemplateRefs, options.scriptLang)},${newLine}`;
+		yield `__typeRefs: ${asType(names.TemplateRefs, options.scriptLang)},${newLine}`;
 	}
 	if (
 		options.vueCompilerOptions.target >= 3.5
 		&& options.vueCompilerOptions.inferComponentDollarEl
 		&& options.templateAndStyleTypes.has(names.RootEl)
 	) {
-		yield `__typeEl: ${asType('{}', names.RootEl, options.scriptLang)},${newLine}`;
+		yield `__typeEl: ${asType(names.RootEl, options.scriptLang)},${newLine}`;
 	}
 	yield `})`;
 }
@@ -53,7 +53,7 @@ function* generateEmitsOption(
 		: [];
 
 	if (typeCodes.length) {
-		yield `__typeEmits: ${asType('{}', typeCodes.join(` & `), options.scriptLang)},${newLine}`;
+		yield `__typeEmits: ${asType(typeCodes.join(` & `), options.scriptLang)},${newLine}`;
 	}
 	else if (runtimeCodes.length) {
 		yield `emits: `;
@@ -76,11 +76,10 @@ function* generateRuntimeEmitsOption(
 	scriptSetupRanges: ScriptSetupRanges,
 ): Generator<string> {
 	if (scriptSetupRanges.defineModel.length) {
-		yield asType('{}', `${names.NormalizeEmits}<typeof ${names.modelEmit}>`, options.scriptLang);
+		yield asType(`${names.NormalizeEmits}<typeof ${names.modelEmit}>`, options.scriptLang);
 	}
 	if (scriptSetupRanges.defineEmits) {
 		yield asType(
-			'{}',
 			`${names.NormalizeEmits}<typeof ${scriptSetupRanges.defineEmits.name ?? names.emit}>`,
 			options.scriptLang,
 		);
@@ -126,10 +125,10 @@ function* generateTypePropsOption(
 		const attrsType = hasEmitsOption
 			? `Omit<${names.InheritedAttrs}, keyof ${names.EmitProps}>`
 			: names.InheritedAttrs;
-		yield asType('{}', attrsType, options.scriptLang);
+		yield asType(attrsType, options.scriptLang);
 	}
 	if (ctx.generatedTypes.has(names.PublicProps)) {
-		yield asType('{}', names.PublicProps, options.scriptLang);
+		yield asType(names.PublicProps, options.scriptLang);
 	}
 }
 
@@ -146,14 +145,14 @@ function* generateRuntimePropsOption(
 			: names.InheritedAttrs;
 		const propsType =
 			`${ctx.localTypes.TypePropsToOption}<${names.PickNotAny}<${ctx.localTypes.OmitIndexSignature}<${attrsType}>, {}>>`;
-		yield asType('{}', propsType, options.scriptLang);
+		yield asType(propsType, options.scriptLang);
 	}
 	if (ctx.generatedTypes.has(names.PublicProps) && options.vueCompilerOptions.target < 3.6) {
 		let propsType = `${ctx.localTypes.TypePropsToOption}<${names.PublicProps}>`;
 		if (scriptSetupRanges.withDefaults?.arg) {
 			propsType = `${ctx.localTypes.WithDefaults}<${propsType}, typeof ${names.defaults}>`;
 		}
-		yield asType('{}', propsType, options.scriptLang);
+		yield asType(propsType, options.scriptLang);
 	}
 	if (scriptSetupRanges.defineProps?.arg) {
 		const { arg } = scriptSetupRanges.defineProps;

--- a/packages/language-core/lib/codegen/script/component.ts
+++ b/packages/language-core/lib/codegen/script/component.ts
@@ -2,8 +2,8 @@ import type { ScriptSetupRanges } from '../../parsers/scriptSetupRanges';
 import type { Code, IRScriptSetup } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { generateSfcBlockSection, newLine } from '../utils';
-import { generateIntersectMerge, generateSpreadMerge } from '../utils/merge';
+import { asType, generateSfcBlockSection, newLine } from '../utils';
+import { generateSpreadMerge } from '../utils/merge';
 import type { ScriptCodegenContext } from './context';
 import type { ScriptCodegenOptions } from './index';
 
@@ -28,14 +28,14 @@ export function* generateComponent(
 		&& options.vueCompilerOptions.inferComponentDollarRefs
 		&& options.templateAndStyleTypes.has(names.TemplateRefs)
 	) {
-		yield `__typeRefs: {} as ${names.TemplateRefs},${newLine}`;
+		yield `__typeRefs: ${asType('{}', names.TemplateRefs, options.scriptLang)},${newLine}`;
 	}
 	if (
 		options.vueCompilerOptions.target >= 3.5
 		&& options.vueCompilerOptions.inferComponentDollarEl
 		&& options.templateAndStyleTypes.has(names.RootEl)
 	) {
-		yield `__typeEl: {} as ${names.RootEl},${newLine}`;
+		yield `__typeEl: ${asType('{}', names.RootEl, options.scriptLang)},${newLine}`;
 	}
 	yield `})`;
 }
@@ -49,13 +49,11 @@ function* generateEmitsOption(
 		: [];
 
 	const runtimeCodes = !typeCodes.length
-		? [...generateRuntimeEmitsOption(scriptSetupRanges)]
+		? [...generateRuntimeEmitsOption(options, scriptSetupRanges)]
 		: [];
 
 	if (typeCodes.length) {
-		yield `__typeEmits: {} as `;
-		yield* generateIntersectMerge(...typeCodes);
-		yield `,${newLine}`;
+		yield `__typeEmits: ${asType('{}', typeCodes.join(` & `), options.scriptLang)},${newLine}`;
 	}
 	else if (runtimeCodes.length) {
 		yield `emits: `;
@@ -73,12 +71,19 @@ function* generateTypeEmitsOption(scriptSetupRanges: ScriptSetupRanges): Generat
 	}
 }
 
-function* generateRuntimeEmitsOption(scriptSetupRanges: ScriptSetupRanges): Generator<string> {
+function* generateRuntimeEmitsOption(
+	options: ScriptCodegenOptions,
+	scriptSetupRanges: ScriptSetupRanges,
+): Generator<string> {
 	if (scriptSetupRanges.defineModel.length) {
-		yield `{} as ${names.NormalizeEmits}<typeof ${names.modelEmit}>`;
+		yield asType('{}', `${names.NormalizeEmits}<typeof ${names.modelEmit}>`, options.scriptLang);
 	}
 	if (scriptSetupRanges.defineEmits) {
-		yield `{} as ${names.NormalizeEmits}<typeof ${scriptSetupRanges.defineEmits.name ?? names.emit}>`;
+		yield asType(
+			'{}',
+			`${names.NormalizeEmits}<typeof ${scriptSetupRanges.defineEmits.name ?? names.emit}>`,
+			options.scriptLang,
+		);
 	}
 }
 
@@ -121,10 +126,10 @@ function* generateTypePropsOption(
 		const attrsType = hasEmitsOption
 			? `Omit<${names.InheritedAttrs}, keyof ${names.EmitProps}>`
 			: names.InheritedAttrs;
-		yield `{} as ${attrsType}`;
+		yield asType('{}', attrsType, options.scriptLang);
 	}
 	if (ctx.generatedTypes.has(names.PublicProps)) {
-		yield `{} as ${names.PublicProps}`;
+		yield asType('{}', names.PublicProps, options.scriptLang);
 	}
 }
 
@@ -141,14 +146,14 @@ function* generateRuntimePropsOption(
 			: names.InheritedAttrs;
 		const propsType =
 			`${ctx.localTypes.TypePropsToOption}<${names.PickNotAny}<${ctx.localTypes.OmitIndexSignature}<${attrsType}>, {}>>`;
-		yield `{} as ${propsType}`;
+		yield asType('{}', propsType, options.scriptLang);
 	}
 	if (ctx.generatedTypes.has(names.PublicProps) && options.vueCompilerOptions.target < 3.6) {
 		let propsType = `${ctx.localTypes.TypePropsToOption}<${names.PublicProps}>`;
 		if (scriptSetupRanges.withDefaults?.arg) {
 			propsType = `${ctx.localTypes.WithDefaults}<${propsType}, typeof ${names.defaults}>`;
 		}
-		yield `{} as ${propsType}`;
+		yield asType('{}', propsType, options.scriptLang);
 	}
 	if (scriptSetupRanges.defineProps?.arg) {
 		const { arg } = scriptSetupRanges.defineProps;

--- a/packages/language-core/lib/codegen/script/context.ts
+++ b/packages/language-core/lib/codegen/script/context.ts
@@ -5,7 +5,7 @@ import type { ScriptCodegenOptions } from './index';
 export type ScriptCodegenContext = ReturnType<typeof createScriptCodegenContext>;
 
 export function createScriptCodegenContext(options: ScriptCodegenOptions) {
-	const localTypes = getLocalTypesGenerator(options.vueCompilerOptions);
+	const localTypes = getLocalTypesGenerator(options.vueCompilerOptions, options.scriptLang);
 	const inlayHints: InlayHintInfo[] = [];
 
 	return {

--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -39,7 +39,7 @@ function* generateWorker(
 	ctx: ScriptCodegenContext,
 ): Generator<Code> {
 	const { script, scriptRanges, scriptSetup, scriptSetupRanges, vueCompilerOptions, fileName } = options;
-	const exportExpression = asType('{}', `typeof ${names.export}`, options.scriptLang);
+	const exportExpression = asType(`typeof ${names.export}`, options.scriptLang);
 
 	yield* generateGlobalTypesReference(vueCompilerOptions, fileName);
 

--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -4,19 +4,18 @@ import type { ScriptSetupRanges } from '../../parsers/scriptSetupRanges';
 import type { Code, IRBlock, IRScript, IRScriptSetup, VueCompilerOptions } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { endOfLine, generateSfcBlockSection, newLine } from '../utils';
+import { asType, endOfLine, generateSfcBlockSection, newLine } from '../utils';
 import { Boundary } from '../utils/boundary';
 import { createScriptCodegenContext, type ScriptCodegenContext } from './context';
-import { generateGeneric, generateScriptSetupImports, generateSetupFunction } from './scriptSetup';
+import { generateGeneric, generateMacros, generateScriptSetupImports, generateSetupFunction } from './scriptSetup';
 import { generateTemplate } from './template';
-
-const exportExpression = `{} as typeof ${names.export}`;
 
 export interface ScriptCodegenOptions {
 	vueCompilerOptions: VueCompilerOptions;
 	script: IRScript | undefined;
 	scriptSetup: IRScriptSetup | undefined;
 	fileName: string;
+	scriptLang: string;
 	scriptRanges: ScriptRanges | undefined;
 	scriptSetupRanges: ScriptSetupRanges | undefined;
 	templateAndStyleTypes: Set<string>;
@@ -40,6 +39,7 @@ function* generateWorker(
 	ctx: ScriptCodegenContext,
 ): Generator<Code> {
 	const { script, scriptRanges, scriptSetup, scriptSetupRanges, vueCompilerOptions, fileName } = options;
+	const exportExpression = asType('{}', `typeof ${names.export}`, options.scriptLang);
 
 	yield* generateGlobalTypesReference(vueCompilerOptions, fileName);
 
@@ -88,6 +88,7 @@ function* generateWorker(
 				exportDefault,
 				vueCompilerOptions,
 				selfType = names.self,
+				exportExpression,
 			);
 		}
 		else {
@@ -171,6 +172,7 @@ function* generateWorker(
 				exportDefault,
 				vueCompilerOptions,
 				names.export,
+				exportExpression,
 				generateTemplate(options, names.export),
 			);
 		}
@@ -184,6 +186,10 @@ function* generateWorker(
 	}
 
 	yield* ctx.localTypes.generate();
+
+	if (scriptSetup && scriptSetupRanges) {
+		yield* generateMacros(options);
+	}
 }
 
 function* generateScriptWithExportDefault(
@@ -193,6 +199,7 @@ function* generateScriptWithExportDefault(
 	exportDefault: NonNullable<ScriptRanges['exportDefault']>,
 	vueCompilerOptions: VueCompilerOptions,
 	varName: string,
+	exportExpression: string,
 	templateGenerator?: Generator<Code>,
 ): Generator<Code> {
 	const componentOptions = scriptRanges.exportDefault?.options;

--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -187,7 +187,9 @@ function* generateWorker(
 
 	yield* ctx.localTypes.generate();
 
-	if (scriptSetup && scriptSetupRanges) {
+	// The <script src> branch never embeds the script setup content, so no
+	// macro references can appear and the import would be unused.
+	if (scriptSetup && scriptSetupRanges && typeof script?.src !== 'object') {
 		yield* generateMacros(options);
 	}
 }

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -355,7 +355,6 @@ export function* generateSetupFunction(
 			yield* output;
 			yield* generateComponent(options, ctx, scriptSetup, scriptSetupRanges);
 			yield endOfLine;
-			yield `void ${names.export}${endOfLine}`;
 		}
 	}
 }

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -307,6 +307,7 @@ export function* generateSetupFunction(
 			yield* output;
 			yield* generateComponent(options, ctx, scriptSetup, scriptSetupRanges);
 			yield endOfLine;
+			yield `void ${names.export}${endOfLine}`;
 		}
 	}
 }

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -3,7 +3,16 @@ import type { ScriptSetupRanges } from '../../parsers/scriptSetupRanges';
 import type { Code, IRScriptSetup, TextRange } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { endOfLine, generateSfcBlockSection, identifierRE, newLine } from '../utils';
+import {
+	asType,
+	endOfLine,
+	generateSfcBlockSection,
+	generateTypeAlias,
+	generateTypedVar,
+	identifierRE,
+	isTsLang,
+	newLine,
+} from '../utils';
 import { Boundary } from '../utils/boundary';
 import { generateCamelized } from '../utils/camelized';
 import { type CodeTransform, generateCodeWithTransforms, insert, replace } from '../utils/transform';
@@ -201,57 +210,77 @@ export function* generateSetupFunction(
 	}
 	if (options.vueCompilerOptions.inferTemplateDollarAttrs) {
 		for (const { callExp } of scriptSetupRanges.useAttrs) {
+			const type = `typeof ${names.dollars}.$attrs`;
 			transforms.push(
 				insert(callExp.start, function*() {
-					yield `(`;
+					yield isTsLang(options.scriptLang) ? `(` : `/** @type {${type}} */ (`;
 				}),
 				insert(callExp.end, function*() {
-					yield ` as typeof ${names.dollars}.$attrs)`;
+					yield isTsLang(options.scriptLang) ? ` as ${type})` : `)`;
 				}),
 			);
 		}
 	}
 	for (const { callExp, exp, arg } of scriptSetupRanges.useCssModule) {
-		transforms.push(
-			insert(callExp.start, function*() {
-				yield `(`;
-			}),
-		);
 		const type = options.templateAndStyleTypes.has(names.StyleModules)
 			? names.StyleModules
 			: `{}`;
 		if (arg) {
 			transforms.push(
+				insert(callExp.start, function*() {
+					if (isTsLang(options.scriptLang)) {
+						yield `(`;
+					}
+					else {
+						yield `/** @type {Omit<${type}, '$style'>[`;
+						yield* generateSfcBlockSection(scriptSetup, arg.start, arg.end, codeFeatures.withoutSemantic);
+						yield `]} */ (`;
+					}
+				}),
 				insert(callExp.end, function*() {
-					yield ` as Omit<${type}, '$style'>[`;
-					yield* generateSfcBlockSection(scriptSetup, arg.start, arg.end, codeFeatures.withoutSemantic);
-					yield `])`;
+					if (isTsLang(options.scriptLang)) {
+						yield ` as Omit<${type}, '$style'>[`;
+						yield* generateSfcBlockSection(scriptSetup, arg.start, arg.end, codeFeatures.withoutSemantic);
+						yield `])`;
+					}
+					else {
+						yield `)`;
+					}
 				}),
 				replace(arg.start, arg.end, function*() {
-					yield `{} as any`;
+					yield asType('{}', 'any', options.scriptLang);
 				}),
 			);
 		}
 		else {
 			transforms.push(
+				insert(callExp.start, function*() {
+					yield isTsLang(options.scriptLang) ? `(` : `/** @type {${type}['$style']} */ (`;
+				}),
 				insert(callExp.end, function*() {
-					yield ` as ${type}[`;
-					const boundary = yield* Boundary.start(scriptSetup.name, exp.start, exp.end, codeFeatures.verification);
-					yield `'$style'`;
-					yield boundary.end();
-					yield `])`;
+					if (isTsLang(options.scriptLang)) {
+						yield ` as ${type}[`;
+						const boundary = yield* Boundary.start(scriptSetup.name, exp.start, exp.end, codeFeatures.verification);
+						yield `'$style'`;
+						yield boundary.end();
+						yield `])`;
+					}
+					else {
+						yield `)`;
+					}
 				}),
 			);
 		}
 	}
 	if (options.vueCompilerOptions.inferTemplateDollarSlots) {
 		for (const { callExp } of scriptSetupRanges.useSlots) {
+			const type = `typeof ${names.dollars}.$slots`;
 			transforms.push(
 				insert(callExp.start, function*() {
-					yield `(`;
+					yield isTsLang(options.scriptLang) ? `(` : `/** @type {${type}} */ (`;
 				}),
 				insert(callExp.end, function*() {
-					yield ` as typeof ${names.dollars}.$slots)`;
+					yield isTsLang(options.scriptLang) ? ` as ${type})` : `)`;
 				}),
 			);
 		}
@@ -259,10 +288,11 @@ export function* generateSetupFunction(
 	for (const { callExp, arg } of scriptSetupRanges.useTemplateRef) {
 		transforms.push(
 			insert(callExp.start, function*() {
-				yield `(`;
-			}),
-			insert(callExp.end, function*() {
-				yield ` as Readonly<import('${options.vueCompilerOptions.lib}').ShallowRef<`;
+				if (isTsLang(options.scriptLang)) {
+					yield `(`;
+					return;
+				}
+				yield `/** @type {Readonly<import('${options.vueCompilerOptions.lib}').ShallowRef<`;
 				if (arg) {
 					yield names.TemplateRefs;
 					yield `[`;
@@ -272,13 +302,31 @@ export function* generateSetupFunction(
 				else {
 					yield `unknown`;
 				}
-				yield ` | null>>)`;
+				yield ` | null>>} */ (`;
+			}),
+			insert(callExp.end, function*() {
+				if (isTsLang(options.scriptLang)) {
+					yield ` as Readonly<import('${options.vueCompilerOptions.lib}').ShallowRef<`;
+					if (arg) {
+						yield names.TemplateRefs;
+						yield `[`;
+						yield* generateSfcBlockSection(scriptSetup, arg.start, arg.end, codeFeatures.withoutSemantic);
+						yield `]`;
+					}
+					else {
+						yield `unknown`;
+					}
+					yield ` | null>>)`;
+				}
+				else {
+					yield `)`;
+				}
 			}),
 		);
 		if (arg) {
 			transforms.push(
 				replace(arg.start, arg.end, function*() {
-					yield `{} as any`;
+					yield asType('{}', 'any', options.scriptLang);
 				}),
 			);
 		}
@@ -290,8 +338,7 @@ export function* generateSetupFunction(
 		transforms,
 		(start, end) => generateSfcBlockSection(scriptSetup, start, end, codeFeatures.all),
 	);
-	yield* generateMacros(options);
-	yield* generateModels(scriptSetup, scriptSetupRanges);
+	yield* generateModels(options, scriptSetup, scriptSetupRanges);
 	yield* generatePublicProps(options, ctx, scriptSetup, scriptSetupRanges);
 	yield* body;
 
@@ -301,7 +348,8 @@ export function* generateSetupFunction(
 			yield* generateComponent(options, ctx, scriptSetup, scriptSetupRanges);
 			yield endOfLine;
 			yield* output;
-			yield `{} as ${ctx.localTypes.WithSlots}<typeof ${names.base}, ${names.Slots}>${endOfLine}`;
+			yield asType('{}', `${ctx.localTypes.WithSlots}<typeof ${names.base}, ${names.Slots}>`, options.scriptLang);
+			yield endOfLine;
 		}
 		else {
 			yield* output;
@@ -312,16 +360,25 @@ export function* generateSetupFunction(
 	}
 }
 
-function* generateMacros(options: ScriptCodegenOptions): Generator<Code> {
+// An `import` (rather than `declare const`) keeps the macros resolvable in JS
+// virtual files, where type-only declarations are syntax errors. Imports hoist,
+// so this can be emitted after all user content: leading directives stay ahead
+// of any statement, and the import-section/content junction stays intact.
+export function* generateMacros(options: ScriptCodegenOptions): Generator<Code> {
 	if (options.vueCompilerOptions.target >= 3.3) {
-		yield `// @ts-ignore${newLine}`;
-		yield `declare const { `;
+		let emitted = false;
 		for (const macro of Object.keys(options.vueCompilerOptions.macros)) {
 			if (!options.setupBindings.has(macro)) {
+				if (!emitted) {
+					yield `// @ts-ignore${newLine}import { `;
+					emitted = true;
+				}
 				yield `${macro}, `;
 			}
 		}
-		yield `}: typeof import('${options.vueCompilerOptions.lib}')${endOfLine}`;
+		if (emitted) {
+			yield `} from '${options.vueCompilerOptions.lib}'${endOfLine}`;
+		}
 	}
 }
 
@@ -417,7 +474,9 @@ function* generatePublicProps(
 		|| target < 3.6
 		|| (target >= 3.5 && !scriptSetupRanges.defineProps?.arg);
 	if (propTypes.length && used) {
-		yield `type ${names.PublicProps} = ${propTypes.join(` & `)}${endOfLine}`;
+		yield* generateTypeAlias(names.PublicProps, options.scriptLang, function*() {
+			yield propTypes.join(` & `);
+		});
 		ctx.generatedTypes.add(names.PublicProps);
 	}
 }
@@ -430,6 +489,7 @@ function hasSlotsType(options: ScriptCodegenOptions): boolean {
 }
 
 function* generateModels(
+	options: ScriptCodegenOptions,
 	scriptSetup: IRScriptSetup,
 	scriptSetupRanges: ScriptSetupRanges,
 ): Generator<Code> {
@@ -469,7 +529,7 @@ function* generateModels(
 			);
 		}
 
-		propCodes.push(generateModelProp(scriptSetup, defineModel, propName, modelType));
+		propCodes.push(generateModelProp(options, scriptSetup, defineModel, propName, modelType));
 		emitCodes.push(generateModelEmit(defineModel, propName, modelType));
 	}
 
@@ -480,29 +540,38 @@ function* generateModels(
 		yield `void ${names.defaultModels}${endOfLine}`;
 	}
 
-	yield `type ${names.ModelProps} = {${newLine}`;
-	for (const codes of propCodes) {
-		yield* codes;
-	}
-	yield `}${endOfLine}`;
+	yield* generateTypeAlias(names.ModelProps, options.scriptLang, function*() {
+		yield `{${newLine}`;
+		for (const codes of propCodes) {
+			yield* codes;
+		}
+		yield `}`;
+	});
 
-	yield `type ${names.ModelEmit} = {${newLine}`;
-	for (const codes of emitCodes) {
-		yield* codes;
-	}
-	yield `}${endOfLine}`;
+	yield* generateTypeAlias(names.ModelEmit, options.scriptLang, function*() {
+		yield `{${newLine}`;
+		for (const codes of emitCodes) {
+			yield* codes;
+		}
+		yield `}`;
+	});
 
 	// avoid `defineModel<...>()` to prevent JS AST issues
-	yield `let ${names.modelEmit}!: ${names.ShortEmits}<${names.ModelEmit}>${endOfLine}`;
+	yield* generateTypedVar('let', names.modelEmit, options.scriptLang, function*() {
+		yield `${names.ShortEmits}<${names.ModelEmit}>`;
+	});
 }
 
 function* generateModelProp(
+	options: ScriptCodegenOptions,
 	scriptSetup: IRScriptSetup,
 	defineModel: ScriptSetupRanges['defineModel'][number],
 	propName: string,
 	modelType: string,
 ): Generator<Code> {
-	if (defineModel.comments) {
+	// In JS the alias body lives inside a JSDoc comment; user comments could
+	// contain `*/` and terminate it early, so they are dropped.
+	if (defineModel.comments && isTsLang(options.scriptLang)) {
 		yield scriptSetup.content.slice(defineModel.comments.start, defineModel.comments.end);
 		yield newLine;
 	}

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -159,6 +159,11 @@ export function* generateSetupFunction(
 		transforms.push(
 			...generateDefineWithTypeTransforms(scriptSetup, statement, callExp, typeArg, name, names.slots, names.Slots),
 		);
+		if (!name) {
+			transforms.push(insert(statement.end, function*() {
+				yield `${newLine}void ${names.slots}${endOfLine}`;
+			}));
+		}
 	}
 	if (scriptSetupRanges.defineExpose) {
 		const { callExp, arg, typeArg } = scriptSetupRanges.defineExpose;

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -248,7 +248,7 @@ export function* generateSetupFunction(
 					}
 				}),
 				replace(arg.start, arg.end, function*() {
-					yield asType('{}', 'any', options.scriptLang);
+					yield asType('any', options.scriptLang);
 				}),
 			);
 		}
@@ -326,7 +326,7 @@ export function* generateSetupFunction(
 		if (arg) {
 			transforms.push(
 				replace(arg.start, arg.end, function*() {
-					yield asType('{}', 'any', options.scriptLang);
+					yield asType('any', options.scriptLang);
 				}),
 			);
 		}
@@ -348,7 +348,7 @@ export function* generateSetupFunction(
 			yield* generateComponent(options, ctx, scriptSetup, scriptSetupRanges);
 			yield endOfLine;
 			yield* output;
-			yield asType('{}', `${ctx.localTypes.WithSlots}<typeof ${names.base}, ${names.Slots}>`, options.scriptLang);
+			yield asType(`${ctx.localTypes.WithSlots}<typeof ${names.base}, ${names.Slots}>`, options.scriptLang);
 			yield endOfLine;
 		}
 		else {

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -412,7 +412,12 @@ function* generatePublicProps(
 	if (scriptSetupRanges.defineModel.length) {
 		propTypes.push(names.ModelProps);
 	}
-	if (propTypes.length) {
+	const target = options.vueCompilerOptions.target;
+	const used =
+		!!scriptSetup.generic
+		|| target < 3.6
+		|| (target >= 3.5 && !scriptSetupRanges.defineProps?.arg);
+	if (propTypes.length && used) {
 		yield `type ${names.PublicProps} = ${propTypes.join(` & `)}${endOfLine}`;
 		ctx.generatedTypes.add(names.PublicProps);
 	}

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -393,6 +393,7 @@ function* generatePublicProps(
 			codeFeatures.navigation,
 		);
 		yield endOfLine;
+		yield `void ${names.defaults}${endOfLine}`;
 	}
 
 	const propTypes: string[] = [];
@@ -466,6 +467,7 @@ function* generateModels(
 		yield `const ${names.defaultModels} = {${newLine}`;
 		yield* defaultCodes;
 		yield `}${endOfLine}`;
+		yield `void ${names.defaultModels}${endOfLine}`;
 	}
 
 	yield `type ${names.ModelProps} = {${newLine}`;

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -413,8 +413,7 @@ function* generatePublicProps(
 		propTypes.push(names.ModelProps);
 	}
 	const target = options.vueCompilerOptions.target;
-	const used =
-		!!scriptSetup.generic
+	const used = !!scriptSetup.generic
 		|| target < 3.6
 		|| (target >= 3.5 && !scriptSetupRanges.defineProps?.arg);
 	if (propTypes.length && used) {

--- a/packages/language-core/lib/codegen/script/template.ts
+++ b/packages/language-core/lib/codegen/script/template.ts
@@ -1,7 +1,15 @@
 import type { Code } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { endOfLine, generateSfcBlockSection, getRefBrandArgument, newLine } from '../utils';
+import {
+	asType,
+	endOfLine,
+	generateSfcBlockSection,
+	generateTypeAlias,
+	generateTypedVar,
+	getRefBrandArgument,
+	newLine,
+} from '../utils';
 import { generateSpreadMerge } from '../utils/merge';
 import type { ScriptCodegenOptions } from './index';
 
@@ -17,7 +25,9 @@ export function* generateTemplate(
 
 	for (const name of options.dotValueBindings) {
 		yield `// @ts-ignore${newLine}`;
-		yield `${names.withDotValue}(${name}, ${getRefBrandArgument(options.vueCompilerOptions)})${endOfLine}`;
+		yield `${names.withDotValue}(${name}, ${
+			getRefBrandArgument(options.vueCompilerOptions, options.scriptLang)
+		})${endOfLine}`;
 	}
 
 	if (options.templateAndStyleCodes.length) {
@@ -26,7 +36,7 @@ export function* generateTemplate(
 }
 
 function* generateTemplateCtx(
-	{ vueCompilerOptions, templateAndStyleTypes, scriptSetupRanges, fileName }: ScriptCodegenOptions,
+	{ vueCompilerOptions, templateAndStyleTypes, scriptSetupRanges, fileName, scriptLang }: ScriptCodegenOptions,
 	selfType: string | undefined,
 ): Generator<Code> {
 	const exps: Code[] = [];
@@ -37,13 +47,13 @@ function* generateTemplateCtx(
 		exps.push(`globalThis`);
 	}
 	if (selfType) {
-		exps.push(`{} as InstanceType<${names.PickNotAny}<typeof ${selfType}, new () => {}>>`);
+		exps.push(asType('{}', `InstanceType<${names.PickNotAny}<typeof ${selfType}, new () => {}>>`, scriptLang));
 	}
 	else {
-		exps.push(`{} as import('${vueCompilerOptions.lib}').ComponentPublicInstance`);
+		exps.push(asType('{}', `import('${vueCompilerOptions.lib}').ComponentPublicInstance`, scriptLang));
 	}
 	if (templateAndStyleTypes.has(names.StyleModules)) {
-		exps.push(`{} as ${names.StyleModules}`);
+		exps.push(asType('{}', names.StyleModules, scriptLang));
 	}
 
 	if (scriptSetupRanges?.defineEmits) {
@@ -53,10 +63,10 @@ function* generateTemplateCtx(
 		emitTypes.push(`typeof ${names.modelEmit}`);
 	}
 	if (emitTypes.length) {
-		yield `type ${names.EmitProps} = ${names.EmitsToProps}<${names.NormalizeEmits}<${
-			emitTypes.join(` & `)
-		}>>${endOfLine}`;
-		exps.push(`{} as { $emit: ${emitTypes.join(` & `)} }`);
+		yield* generateTypeAlias(names.EmitProps, scriptLang, function*() {
+			yield `${names.EmitsToProps}<${names.NormalizeEmits}<${emitTypes.join(` & `)}>>`;
+		});
+		exps.push(asType('{}', `{ $emit: ${emitTypes.join(` & `)} }`, scriptLang));
 	}
 
 	if (scriptSetupRanges?.defineProps) {
@@ -69,8 +79,8 @@ function* generateTemplateCtx(
 		propTypes.push(names.EmitProps);
 	}
 	if (propTypes.length) {
-		exps.push(`{} as { $props: ${propTypes.join(` & `)} }`);
-		exps.push(`{} as ${propTypes.join(` & `)}`);
+		exps.push(asType('{}', `{ $props: ${propTypes.join(` & `)} }`, scriptLang));
+		exps.push(asType('{}', propTypes.join(` & `), scriptLang));
 	}
 
 	yield `const ${names.ctx} = `;
@@ -79,7 +89,7 @@ function* generateTemplateCtx(
 }
 
 function* generateTemplateComponents(
-	{ vueCompilerOptions, script, scriptRanges, localComponents }: ScriptCodegenOptions,
+	{ vueCompilerOptions, script, scriptRanges, localComponents, scriptLang }: ScriptCodegenOptions,
 ): Generator<Code> {
 	const types: string[] = [];
 
@@ -99,22 +109,26 @@ function* generateTemplateComponents(
 		types.push(`typeof ${names.componentsOption}`);
 	}
 
-	yield `type ${names.LocalComponents} = ${types.length ? types.join(` & `) : `{}`}${endOfLine}`;
-	yield `type ${names.GlobalComponents} = ${
-		vueCompilerOptions.target >= 3.5
+	yield* generateTypeAlias(names.LocalComponents, scriptLang, function*() {
+		yield types.length ? types.join(` & `) : `{}`;
+	});
+	yield* generateTypeAlias(names.GlobalComponents, scriptLang, function*() {
+		yield vueCompilerOptions.target >= 3.5
 			? `import('${vueCompilerOptions.lib}').GlobalComponents`
-			: `import('${vueCompilerOptions.lib}').GlobalComponents & Pick<typeof import('${vueCompilerOptions.lib}'), 'Transition' | 'TransitionGroup' | 'KeepAlive' | 'Suspense' | 'Teleport'>`
-	}${endOfLine}`;
-	yield `let ${names.components}!: ${names.LocalComponents} & ${names.GlobalComponents}${endOfLine}`;
-	yield `let ${names.intrinsics}!: ${
-		vueCompilerOptions.target >= 3.3
+			: `import('${vueCompilerOptions.lib}').GlobalComponents & Pick<typeof import('${vueCompilerOptions.lib}'), 'Transition' | 'TransitionGroup' | 'KeepAlive' | 'Suspense' | 'Teleport'>`;
+	});
+	yield* generateTypedVar('let', names.components, scriptLang, function*() {
+		yield `${names.LocalComponents} & ${names.GlobalComponents}`;
+	});
+	yield* generateTypedVar('let', names.intrinsics, scriptLang, function*() {
+		yield vueCompilerOptions.target >= 3.3
 			? `import('${vueCompilerOptions.lib}/jsx-runtime').JSX.IntrinsicElements`
-			: `globalThis.JSX.IntrinsicElements`
-	}${endOfLine}`;
+			: `globalThis.JSX.IntrinsicElements`;
+	});
 }
 
 function* generateTemplateDirectives(
-	{ vueCompilerOptions, script, scriptRanges, localDirectives }: ScriptCodegenOptions,
+	{ vueCompilerOptions, script, scriptRanges, localDirectives, scriptLang }: ScriptCodegenOptions,
 ): Generator<Code> {
 	const types: string[] = [];
 
@@ -134,8 +148,12 @@ function* generateTemplateDirectives(
 		types.push(`${names.ResolveDirectives}<typeof ${names.directivesOption}>`);
 	}
 
-	yield `type ${names.LocalDirectives} = ${types.length ? types.join(` & `) : `{}`}${endOfLine}`;
-	yield `let ${names.directives}!: ${names.LocalDirectives} & import('${vueCompilerOptions.lib}').GlobalDirectives${endOfLine}`;
+	yield* generateTypeAlias(names.LocalDirectives, scriptLang, function*() {
+		yield types.length ? types.join(` & `) : `{}`;
+	});
+	yield* generateTypedVar('let', names.directives, scriptLang, function*() {
+		yield `${names.LocalDirectives} & import('${vueCompilerOptions.lib}').GlobalDirectives`;
+	});
 }
 
 function generateExposedType(lib: string, bindings: Set<string>): string {

--- a/packages/language-core/lib/codegen/script/template.ts
+++ b/packages/language-core/lib/codegen/script/template.ts
@@ -47,13 +47,13 @@ function* generateTemplateCtx(
 		exps.push(`globalThis`);
 	}
 	if (selfType) {
-		exps.push(asType('{}', `InstanceType<${names.PickNotAny}<typeof ${selfType}, new () => {}>>`, scriptLang));
+		exps.push(asType(`InstanceType<${names.PickNotAny}<typeof ${selfType}, new () => {}>>`, scriptLang));
 	}
 	else {
-		exps.push(asType('{}', `import('${vueCompilerOptions.lib}').ComponentPublicInstance`, scriptLang));
+		exps.push(asType(`import('${vueCompilerOptions.lib}').ComponentPublicInstance`, scriptLang));
 	}
 	if (templateAndStyleTypes.has(names.StyleModules)) {
-		exps.push(asType('{}', names.StyleModules, scriptLang));
+		exps.push(asType(names.StyleModules, scriptLang));
 	}
 
 	if (scriptSetupRanges?.defineEmits) {
@@ -66,7 +66,7 @@ function* generateTemplateCtx(
 		yield* generateTypeAlias(names.EmitProps, scriptLang, function*() {
 			yield `${names.EmitsToProps}<${names.NormalizeEmits}<${emitTypes.join(` & `)}>>`;
 		});
-		exps.push(asType('{}', `{ $emit: ${emitTypes.join(` & `)} }`, scriptLang));
+		exps.push(asType(`{ $emit: ${emitTypes.join(` & `)} }`, scriptLang));
 	}
 
 	if (scriptSetupRanges?.defineProps) {
@@ -79,8 +79,8 @@ function* generateTemplateCtx(
 		propTypes.push(names.EmitProps);
 	}
 	if (propTypes.length) {
-		exps.push(asType('{}', `{ $props: ${propTypes.join(` & `)} }`, scriptLang));
-		exps.push(asType('{}', propTypes.join(` & `), scriptLang));
+		exps.push(asType(`{ $props: ${propTypes.join(` & `)} }`, scriptLang));
+		exps.push(asType(propTypes.join(` & `), scriptLang));
 	}
 
 	yield `const ${names.ctx} = `;

--- a/packages/language-core/lib/codegen/script/template.ts
+++ b/packages/language-core/lib/codegen/script/template.ts
@@ -13,6 +13,8 @@ export function* generateTemplate(
 	yield* generateTemplateComponents(options);
 	yield* generateTemplateDirectives(options);
 
+	yield `void ${names.ctx}, ${names.components}, ${names.intrinsics}, ${names.directives}${endOfLine}`;
+
 	for (const name of options.withDotValueBindings) {
 		yield `${names.withDotValue}(${name}, {} as import('${options.vueCompilerOptions.lib}').Ref)${endOfLine}`;
 	}

--- a/packages/language-core/lib/codegen/script/template.ts
+++ b/packages/language-core/lib/codegen/script/template.ts
@@ -1,7 +1,7 @@
 import type { Code } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { endOfLine, generateSfcBlockSection } from '../utils';
+import { endOfLine, generateSfcBlockSection, newLine } from '../utils';
 import { generateSpreadMerge } from '../utils/merge';
 import type { ScriptCodegenOptions } from './index';
 
@@ -16,6 +16,7 @@ export function* generateTemplate(
 	yield `void ${names.ctx}, ${names.components}, ${names.intrinsics}, ${names.directives}${endOfLine}`;
 
 	for (const name of options.withDotValueBindings) {
+		yield `// @ts-ignore${newLine}`;
 		yield `${names.withDotValue}(${name}, {} as import('${options.vueCompilerOptions.lib}').Ref<unknown>)${endOfLine}`;
 	}
 

--- a/packages/language-core/lib/codegen/style/index.ts
+++ b/packages/language-core/lib/codegen/style/index.ts
@@ -11,6 +11,7 @@ export interface StyleCodegenOptions {
 	typescript: typeof import('typescript');
 	vueCompilerOptions: VueCompilerOptions;
 	styles: readonly IRStyle[];
+	scriptLang: string;
 	destructuredProps: Set<string>;
 	importedComponents: Set<string>;
 	setupRefs: Set<string>;

--- a/packages/language-core/lib/codegen/style/modules.ts
+++ b/packages/language-core/lib/codegen/style/modules.ts
@@ -2,12 +2,12 @@ import type { Code } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
 import type { TemplateCodegenContext } from '../template/context';
-import { endOfLine, newLine } from '../utils';
+import { endOfLine, generateTypeAlias, newLine } from '../utils';
 import type { StyleCodegenOptions } from '.';
 import { generateClassProperty, generateStyleImports } from './common';
 
 export function* generateStyleModules(
-	{ vueCompilerOptions, styles }: StyleCodegenOptions,
+	{ vueCompilerOptions, styles, scriptLang }: StyleCodegenOptions,
 	ctx: TemplateCodegenContext,
 ): Generator<Code> {
 	const styleModules = styles.filter(style => style.module);
@@ -16,37 +16,39 @@ export function* generateStyleModules(
 	}
 	ctx.generatedTypes.add(names.StyleModules);
 
-	yield `type ${names.StyleModules} = {${newLine}`;
-	for (const style of styleModules) {
-		if (style.module === true) {
-			yield `$style`;
+	yield* generateTypeAlias(names.StyleModules, scriptLang, function*() {
+		yield `{${newLine}`;
+		for (const style of styleModules) {
+			if (style.module === true) {
+				yield `$style`;
+			}
+			else {
+				const { text, offset } = style.module!;
+				yield [
+					text,
+					'main',
+					offset,
+					codeFeatures.navigation,
+				];
+			}
+			yield `: `;
+			if (!vueCompilerOptions.strictCssModules) {
+				yield `Record<string, string> & `;
+			}
+			yield `${names.PrettifyGlobal}<{}`;
+			if (vueCompilerOptions.resolveStyleImports) {
+				yield* generateStyleImports(style);
+			}
+			for (const className of style.classNames) {
+				yield* generateClassProperty(
+					style.name,
+					className.text,
+					className.offset,
+					'string',
+				);
+			}
+			yield `>${endOfLine}`;
 		}
-		else {
-			const { text, offset } = style.module!;
-			yield [
-				text,
-				'main',
-				offset,
-				codeFeatures.navigation,
-			];
-		}
-		yield `: `;
-		if (!vueCompilerOptions.strictCssModules) {
-			yield `Record<string, string> & `;
-		}
-		yield `${names.PrettifyGlobal}<{}`;
-		if (vueCompilerOptions.resolveStyleImports) {
-			yield* generateStyleImports(style);
-		}
-		for (const className of style.classNames) {
-			yield* generateClassProperty(
-				style.name,
-				className.text,
-				className.offset,
-				'string',
-			);
-		}
-		yield `>${endOfLine}`;
-	}
-	yield `}${endOfLine}`;
+		yield `}`;
+	});
 }

--- a/packages/language-core/lib/codegen/style/scopedClasses.ts
+++ b/packages/language-core/lib/codegen/style/scopedClasses.ts
@@ -2,7 +2,7 @@ import type { Code } from '../../types';
 import { names } from '../names';
 import type { TemplateCodegenContext } from '../template/context';
 import { generateStyleScopedClassReference } from '../template/styleScopedClasses';
-import { endOfLine } from '../utils';
+import { endOfLine, newLine } from '../utils';
 import type { StyleCodegenOptions } from '.';
 import { generateClassProperty, generateStyleImports } from './common';
 
@@ -22,6 +22,7 @@ export function* generateStyleScopedClasses(
 
 	const visited = new Set<string>();
 	const deferredGenerates: Generator<Code>[] = [];
+	yield `// @ts-ignore${newLine}`;
 	yield `type ${names.StyleScopedClasses} = {}`;
 	for (const style of scopedStyles) {
 		if (resolveStyleImports) {

--- a/packages/language-core/lib/codegen/style/scopedClasses.ts
+++ b/packages/language-core/lib/codegen/style/scopedClasses.ts
@@ -2,12 +2,12 @@ import type { Code } from '../../types';
 import { names } from '../names';
 import type { TemplateCodegenContext } from '../template/context';
 import { generateStyleScopedClassReference } from '../template/styleScopedClasses';
-import { endOfLine, newLine } from '../utils';
+import { generateTypeAlias, newLine } from '../utils';
 import type { StyleCodegenOptions } from '.';
 import { generateClassProperty, generateStyleImports } from './common';
 
 export function* generateStyleScopedClasses(
-	{ vueCompilerOptions, styles }: StyleCodegenOptions,
+	{ vueCompilerOptions, styles, scriptLang }: StyleCodegenOptions,
 	ctx: TemplateCodegenContext,
 ): Generator<Code> {
 	const { resolveStyleClassNames, resolveStyleImports } = vueCompilerOptions;
@@ -23,24 +23,25 @@ export function* generateStyleScopedClasses(
 	const visited = new Set<string>();
 	const deferredGenerates: Generator<Code>[] = [];
 	yield `// @ts-ignore${newLine}`;
-	yield `type ${names.StyleScopedClasses} = {}`;
-	for (const style of scopedStyles) {
-		if (resolveStyleImports) {
-			yield* generateStyleImports(style);
-		}
-		for (const className of style.classNames) {
-			if (!visited.has(className.text)) {
-				visited.add(className.text);
-				yield* generateClassProperty(style.name, className.text, className.offset, 'boolean');
+	yield* generateTypeAlias(names.StyleScopedClasses, scriptLang, function*() {
+		yield `{}`;
+		for (const style of scopedStyles) {
+			if (resolveStyleImports) {
+				yield* generateStyleImports(style);
 			}
-			else {
-				deferredGenerates.push(
-					generateStyleScopedClassReference(style, className.text.slice(1), className.offset + 1),
-				);
+			for (const className of style.classNames) {
+				if (!visited.has(className.text)) {
+					visited.add(className.text);
+					yield* generateClassProperty(style.name, className.text, className.offset, 'boolean');
+				}
+				else {
+					deferredGenerates.push(
+						generateStyleScopedClassReference(style, className.text.slice(1), className.offset + 1),
+					);
+				}
 			}
 		}
-	}
-	yield endOfLine;
+	});
 
 	for (const generate of deferredGenerates) {
 		yield* generate;

--- a/packages/language-core/lib/codegen/template/context.ts
+++ b/packages/language-core/lib/codegen/template/context.ts
@@ -10,6 +10,59 @@ export type TemplateCodegenContext = ReturnType<typeof createTemplateCodegenCont
 
 const directiveCommentRE = /^<!--\s*@vue-(?<name>[-\w]+)\b(?<content>[\s\S]*)-->$/;
 
+// Reserved words can never be auto-imported bindings, and emitting them as
+// bare array elements is a syntax error (#5267: `[class,]`).
+const reservedWords = new Set([
+	'arguments',
+	'await',
+	'break',
+	'case',
+	'catch',
+	'class',
+	'const',
+	'continue',
+	'debugger',
+	'default',
+	'delete',
+	'do',
+	'else',
+	'enum',
+	'eval',
+	'export',
+	'extends',
+	'false',
+	'finally',
+	'for',
+	'function',
+	'if',
+	'implements',
+	'import',
+	'in',
+	'instanceof',
+	'interface',
+	'let',
+	'new',
+	'null',
+	'package',
+	'private',
+	'protected',
+	'public',
+	'return',
+	'static',
+	'super',
+	'switch',
+	'this',
+	'throw',
+	'true',
+	'try',
+	'typeof',
+	'var',
+	'void',
+	'while',
+	'with',
+	'yield',
+]);
+
 export function createTemplateCodegenContext() {
 	// directive comments ---------------------------------------------------------
 
@@ -194,9 +247,11 @@ export function createTemplateCodegenContext() {
 		yield `[`;
 		for (const [varName, map] of all) {
 			for (const [source, offsets] of map) {
-				for (const offset of offsets) {
-					yield [varName, source, offset, codeFeatures.importCompletionOnly];
-					yield `,`;
+				if (!reservedWords.has(varName)) {
+					for (const offset of offsets) {
+						yield [varName, source, offset, codeFeatures.importCompletionOnly];
+						yield `,`;
+					}
 				}
 				offsets.clear();
 			}

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -255,8 +255,9 @@ export function* generateComponent(
 	const templateRef = getTemplateRef(node);
 	const isSingleRoot = ctx.singleRootNodes.has(node)
 		&& !options.vueCompilerOptions.fallthroughComponentNames.includes(hyphenateTag(tag));
+	const inferRootEl = ctx.dollarVars.has('$el') || options.vueCompilerOptions.inferComponentDollarEl;
 
-	if (templateRef || isSingleRoot) {
+	if (templateRef || (isSingleRoot && inferRootEl)) {
 		const componentInstanceVar = ctx.getInternalVariable();
 		yield `var ${componentInstanceVar}!: Parameters<NonNullable<typeof ${getCtxVar()}['expose']>>[0]`;
 		yield endOfLine;
@@ -268,7 +269,7 @@ export function* generateComponent(
 			}
 			ctx.addTemplateRef(templateRef[0], typeExp, templateRef[1]);
 		}
-		if (isSingleRoot) {
+		if (isSingleRoot && inferRootEl) {
 			ctx.singleRootElTypes.add(`NonNullable<typeof ${componentInstanceVar}>['$el']`);
 		}
 	}

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -193,7 +193,7 @@ export function* generateComponent(
 		options.vueCompilerOptions.checkUnknownProps ? names.asFunctionalComponent0 : names.asFunctionalComponent1
 	}(${componentVar}, new ${componentVar}({${newLine}`;
 	yield `// @ts-ignore${newLine}`;
-	yield propsStr;
+	yield propsStr.replace(/\n/g, ' ');
 	yield `}))${endOfLine}`;
 
 	yield `const `;

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -192,6 +192,7 @@ export function* generateComponent(
 	yield `const ${functionalVar} = ${
 		options.vueCompilerOptions.checkUnknownProps ? names.asFunctionalComponent0 : names.asFunctionalComponent1
 	}(${componentVar}, new ${componentVar}({${newLine}`;
+	yield `// @ts-ignore${newLine}`;
 	yield propsStr;
 	yield `}))${endOfLine}`;
 

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -239,6 +239,7 @@ export function* generateComponent(
 	yield `}`;
 	yield boundary2.end();
 	yield `, ...${names.functionalComponentArgsRest}(${functionalVar}))${endOfLine}`;
+	yield `void ${vnodeVar}${endOfLine}`;
 
 	yield* generateFailedExpressions(options, ctx, failedPropExps);
 	yield* generateElementEvents(

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -6,7 +6,7 @@ import { getElementTagOffsets, hyphenateTag, normalizeAttributeValue } from '../
 import { codeFeatures } from '../codeFeatures';
 import { createVBindShorthandInlayHintInfo } from '../inlayHints';
 import { names } from '../names';
-import { endOfLine, identifierRE, newLine } from '../utils';
+import { endOfLine, generateTypedVar, identifierRE, newLine } from '../utils';
 import { Boundary } from '../utils/boundary';
 import { generateCamelized } from '../utils/camelized';
 import { generateStringLiteralKey } from '../utils/stringLiteralKey';
@@ -118,25 +118,27 @@ export function* generateComponent(
 			yield endOfLine;
 		}
 		else {
-			yield `let ${componentVar}!: ${names.WithComponent}<'${tag}', ${names.LocalComponents}, ${names.GlobalComponents}`;
-			yield originalNames.has(options.componentName)
-				? `, typeof ${names.export}`
-				: `, void`;
-			for (const name of originalNames) {
-				yield `, '${name}'`;
-			}
-			yield `>[`;
-			yield* generateStringLiteralKey(
-				tag,
-				startTagOffset,
-				{
-					...codeFeatures.semanticWithoutHighlight,
-					...options.vueCompilerOptions.checkUnknownComponents
-						? codeFeatures.verification
-						: codeFeatures.doNotReportTs2339AndTs2551,
-				},
-			);
-			yield `]${endOfLine}`;
+			yield* generateTypedVar('let', componentVar, options.scriptLang, function*() {
+				yield `${names.WithComponent}<'${tag}', ${names.LocalComponents}, ${names.GlobalComponents}`;
+				yield originalNames.has(options.componentName)
+					? `, typeof ${names.export}`
+					: `, void`;
+				for (const name of originalNames) {
+					yield `, '${name}'`;
+				}
+				yield `>[`;
+				yield* generateStringLiteralKey(
+					tag,
+					startTagOffset,
+					{
+						...codeFeatures.semanticWithoutHighlight,
+						...options.vueCompilerOptions.checkUnknownComponents
+							? codeFeatures.verification
+							: codeFeatures.doNotReportTs2339AndTs2551,
+					},
+				);
+				yield `]`;
+			});
 
 			if (identifierRE.test(camelize(tag))) {
 				// navigation support
@@ -260,8 +262,9 @@ export function* generateComponent(
 
 	if (templateRef || (isSingleRoot && inferRootEl)) {
 		const componentInstanceVar = ctx.getInternalVariable();
-		yield `var ${componentInstanceVar}!: Parameters<NonNullable<typeof ${getCtxVar()}['expose']>>[0]`;
-		yield endOfLine;
+		yield* generateTypedVar('var', componentInstanceVar, options.scriptLang, function*() {
+			yield `Parameters<NonNullable<typeof ${getCtxVar()}['expose']>>[0]`;
+		});
 
 		if (templateRef) {
 			let typeExp = `typeof ${ctx.getHoistVariable(componentInstanceVar)} | null`;
@@ -294,10 +297,14 @@ export function* generateComponent(
 	}
 
 	if (isCtxVarUsed) {
-		yield `var ${ctxVar}!: ${names.ExtractComponentContext}<typeof ${componentVar}, typeof ${vnodeVar}>${endOfLine}`;
+		yield* generateTypedVar('var', ctxVar, options.scriptLang, function*() {
+			yield `${names.ExtractComponentContext}<typeof ${componentVar}, typeof ${vnodeVar}>`;
+		});
 	}
 	if (isPropsVarUsed) {
-		yield `var ${propsVar}!: ${names.ExtractComponentProps}<typeof ${componentVar}, typeof ${vnodeVar}>${endOfLine}`;
+		yield* generateTypedVar('var', propsVar, options.scriptLang, function*() {
+			yield `${names.ExtractComponentProps}<typeof ${componentVar}, typeof ${vnodeVar}>`;
+		});
 	}
 	ctx.components.pop();
 }

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -242,7 +242,6 @@ export function* generateComponent(
 	yield `}`;
 	yield boundary2.end();
 	yield `, ...${names.functionalComponentArgsRest}(${functionalVar}))${endOfLine}`;
-	yield `void ${vnodeVar}${endOfLine}`;
 
 	yield* generateFailedExpressions(options, ctx, failedPropExps);
 	yield* generateElementEvents(

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -361,7 +361,7 @@ export function* generateElement(
 		}
 		ctx.addTemplateRef(templateRef[0], typeExp, templateRef[1]);
 	}
-	if (ctx.singleRootNodes.has(node)) {
+	if (ctx.singleRootNodes.has(node) && (ctx.dollarVars.has('$el') || options.vueCompilerOptions.inferComponentDollarEl)) {
 		ctx.singleRootElTypes.add(`${names.Elements}['${node.tag}']`);
 	}
 

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -361,7 +361,9 @@ export function* generateElement(
 		}
 		ctx.addTemplateRef(templateRef[0], typeExp, templateRef[1]);
 	}
-	if (ctx.singleRootNodes.has(node) && (ctx.dollarVars.has('$el') || options.vueCompilerOptions.inferComponentDollarEl)) {
+	if (
+		ctx.singleRootNodes.has(node) && (ctx.dollarVars.has('$el') || options.vueCompilerOptions.inferComponentDollarEl)
+	) {
 		ctx.singleRootElTypes.add(`${names.Elements}['${node.tag}']`);
 	}
 

--- a/packages/language-core/lib/codegen/template/elementDirectives.ts
+++ b/packages/language-core/lib/codegen/template/elementDirectives.ts
@@ -3,7 +3,7 @@ import { camelize, isBuiltInDirective } from '@vue/shared';
 import type { Code } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { endOfLine } from '../utils';
+import { endOfLine, newLine } from '../utils';
 import { Boundary } from '../utils/boundary';
 import { generateCamelized } from '../utils/camelized';
 import { generateStringLiteralKey } from '../utils/stringLiteralKey';
@@ -50,7 +50,11 @@ export function* generateElementDirectives(
 			yield* generateArg(options, ctx, prop);
 			yield* generateModifiers(options, ctx, prop);
 			yield* generateValue(options, ctx, prop);
-			yield `}, null!, null!)`;
+			// Vue invokes hooks with all four arguments regardless of the declared
+			// arity. The excess-argument error (TS2554) lands on the first extra
+			// argument, so the synthetic trailing args get their own @ts-ignore'd
+			// line; when the arity matches, the binding above is checked as usual.
+			yield `},${newLine}// @ts-ignore${newLine}null!, null!)`;
 		}
 		yield boundary.end();
 		yield endOfLine;

--- a/packages/language-core/lib/codegen/template/elementDirectives.ts
+++ b/packages/language-core/lib/codegen/template/elementDirectives.ts
@@ -56,7 +56,7 @@ export function* generateElementDirectives(
 			// arity. The excess-argument error (TS2554) lands on the first extra
 			// argument, so the synthetic trailing args get their own @ts-ignore'd
 			// line; when the arity matches, the binding above is checked as usual.
-			yield `},${newLine}// @ts-ignore${newLine}${names.nonNull}(null), ${names.nonNull}(null))`;
+			yield `},${newLine}// @ts-ignore${newLine}null, null)`;
 		}
 		yield boundary.end();
 		yield endOfLine;

--- a/packages/language-core/lib/codegen/template/elementDirectives.ts
+++ b/packages/language-core/lib/codegen/template/elementDirectives.ts
@@ -47,7 +47,7 @@ export function* generateElementDirectives(
 			yield `${names.asFunctionalDirective}(`;
 			yield* generateIdentifier(options, ctx, prop);
 			yield `, ${
-				asType('{}', `import('${options.vueCompilerOptions.lib}').ObjectDirective`, options.scriptLang)
+				asType(`import('${options.vueCompilerOptions.lib}').ObjectDirective`, options.scriptLang)
 			})(${names.nonNull}(null), { ...${names.directiveBindingRestFields}, `;
 			yield* generateArg(options, ctx, prop);
 			yield* generateModifiers(options, ctx, prop);

--- a/packages/language-core/lib/codegen/template/elementDirectives.ts
+++ b/packages/language-core/lib/codegen/template/elementDirectives.ts
@@ -3,7 +3,7 @@ import { camelize, isBuiltInDirective } from '@vue/shared';
 import type { Code } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { endOfLine, newLine } from '../utils';
+import { asType, endOfLine, newLine } from '../utils';
 import { Boundary } from '../utils/boundary';
 import { generateCamelized } from '../utils/camelized';
 import { generateStringLiteralKey } from '../utils/stringLiteralKey';
@@ -37,7 +37,7 @@ export function* generateElementDirectives(
 		if (options.isVapor && !isBuiltInDirective(prop.name)) {
 			// vapor custom directives receive a value getter instead of a vdom binding object
 			yield* generateIdentifier(options, ctx, prop);
-			yield `(null!, `;
+			yield `(${names.nonNull}(null), `;
 			yield* generateValue(options, ctx, prop, false);
 			yield* generateArg(options, ctx, prop, false);
 			yield* generateModifiers(options, ctx, prop, 'modifiers', false);
@@ -46,7 +46,9 @@ export function* generateElementDirectives(
 		else {
 			yield `${names.asFunctionalDirective}(`;
 			yield* generateIdentifier(options, ctx, prop);
-			yield `, {} as import('${options.vueCompilerOptions.lib}').ObjectDirective)(null!, { ...${names.directiveBindingRestFields}, `;
+			yield `, ${
+				asType('{}', `import('${options.vueCompilerOptions.lib}').ObjectDirective`, options.scriptLang)
+			})(${names.nonNull}(null), { ...${names.directiveBindingRestFields}, `;
 			yield* generateArg(options, ctx, prop);
 			yield* generateModifiers(options, ctx, prop);
 			yield* generateValue(options, ctx, prop);
@@ -54,7 +56,7 @@ export function* generateElementDirectives(
 			// arity. The excess-argument error (TS2554) lands on the first extra
 			// argument, so the synthetic trailing args get their own @ts-ignore'd
 			// line; when the arity matches, the binding above is checked as usual.
-			yield `},${newLine}// @ts-ignore${newLine}null!, null!)`;
+			yield `},${newLine}// @ts-ignore${newLine}${names.nonNull}(null), ${names.nonNull}(null))`;
 		}
 		yield boundary.end();
 		yield endOfLine;

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -85,7 +85,9 @@ export function* generateElementEvents(
 	}
 
 	const emitsVar = ctx.getInternalVariable();
-	yield `let ${emitsVar}!: ${names.ResolveEmits}<typeof ${componentOriginalVar}, typeof ${getCtxVar()}.emit>${endOfLine}`;
+	yield `let ${emitsVar}!: ${names.ResolveEmits}<typeof ${componentOriginalVar}, typeof `;
+	yield [getCtxVar(), 'template', node.loc.start.offset, codeFeatures.verification];
+	yield `.emit>${endOfLine}`;
 
 	for (const { propPrefix, emitPrefix, propName, emitName, items } of Object.values(definitions)) {
 		const eventVar = ctx.getInternalVariable();

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -91,9 +91,9 @@ export function* generateElementEvents(
 
 	for (const { propPrefix, emitPrefix, propName, emitName, items } of Object.values(definitions)) {
 		const eventVar = ctx.getInternalVariable();
-		yield `const ${eventVar}: ${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', '${emitName}', '${
-			camelize(emitName)
-		}'> = {${newLine}`;
+		yield `const ${eventVar}: ${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', `;
+		yield [`'${emitName}'`, 'template', items[0]?.offset ?? node.loc.start.offset, codeFeatures.verification];
+		yield `, '${camelize(emitName)}'> = {${newLine}`;
 		for (const { prop, source, offset } of items) {
 			if (prop.name === 'on') {
 				yield `/** @type {typeof ${emitsVar}.`;

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -168,7 +168,9 @@ export function* generateEventExpression(
 		);
 
 		if (isCompound) {
-			yield `(...[$event]) => {${newLine}`;
+			yield `(...[`;
+			yield ['$event', 'template', prop.exp.loc.start.offset, codeFeatures.verification];
+			yield `]) => {${newLine}`;
 			const scope = ctx.scope();
 			scope.declare('$event');
 			yield `void $event${endOfLine}`;
@@ -213,7 +215,9 @@ export function* generateModelEventExpression(
 	prop: CompilerDOM.DirectiveNode,
 ): Generator<Code> {
 	if (prop.exp?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION) {
-		yield `(...[$event]) => {${newLine}`;
+		yield `(...[`;
+		yield ['$event', 'template', prop.exp.loc.start.offset, codeFeatures.verification];
+		yield `]) => {${newLine}`;
 		yield* ctx.generateConditionGuards();
 		yield* generateInterpolation(
 			options,

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -89,9 +89,9 @@ export function* generateElementEvents(
 
 	for (const { propPrefix, emitPrefix, propName, emitName, items } of Object.values(definitions)) {
 		const eventVar = ctx.getInternalVariable();
-		yield `const ${eventVar}: ${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', '${emitName}', '${
+		yield `const ${eventVar}: ${options.vueCompilerOptions.checkUnknownEvents ? '' : 'Record<string, unknown> & '}Partial<${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', '${emitName}', '${
 			camelize(emitName)
-		}'> = {${newLine}`;
+		}'>> = {${newLine}`;
 		for (const { prop, source, offset } of items) {
 			if (prop.name === 'on') {
 				yield `/** @type {typeof ${emitsVar}.`;

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -91,7 +91,9 @@ export function* generateElementEvents(
 
 	for (const { propPrefix, emitPrefix, propName, emitName, items } of Object.values(definitions)) {
 		const eventVar = ctx.getInternalVariable();
-		yield `const ${eventVar}: ${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', `;
+		yield `const `;
+		yield [eventVar, 'template', items[0]?.offset ?? node.loc.start.offset, codeFeatures.verification];
+		yield `: ${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', `;
 		yield [`'${emitName}'`, 'template', items[0]?.offset ?? node.loc.start.offset, codeFeatures.verification];
 		yield `, '${camelize(emitName)}'> = {${newLine}`;
 		for (const { prop, source, offset } of items) {

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -88,7 +88,8 @@ export function* generateElementEvents(
 	yield `let ${emitsVar}!: ${names.ResolveEmits}<typeof ${componentOriginalVar}, typeof ${getCtxVar()}.emit>${endOfLine}`;
 
 	for (const { propPrefix, emitPrefix, propName, emitName, items } of Object.values(definitions)) {
-		yield `const ${ctx.getInternalVariable()}: ${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', '${emitName}', '${
+		const eventVar = ctx.getInternalVariable();
+		yield `const ${eventVar}: ${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', '${emitName}', '${
 			camelize(emitName)
 		}'> = {${newLine}`;
 		for (const { prop, source, offset } of items) {
@@ -109,6 +110,7 @@ export function* generateElementEvents(
 			yield `,${newLine}`;
 		}
 		yield `}${endOfLine}`;
+		yield `void ${eventVar}${endOfLine}`;
 	}
 }
 
@@ -167,6 +169,7 @@ export function* generateEventExpression(
 			yield `(...[$event]) => {${newLine}`;
 			const scope = ctx.scope();
 			scope.declare('$event');
+			yield `void $event${endOfLine}`;
 			yield* ctx.generateConditionGuards();
 			if (isSingleExpression(options.typescript, ast)) {
 				yield `return (`;

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -195,7 +195,6 @@ export function* generateEventExpression(
 
 			yield `// @ts-ignore${newLine}`;
 			yield `(...[$event]) => {${newLine}`;
-			yield `void $event${endOfLine}`;
 			yield* generateReasserts(options, ctx, accessMark);
 			yield* ctx.generateConditionGuards();
 

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -85,9 +85,7 @@ export function* generateElementEvents(
 	}
 
 	const emitsVar = ctx.getInternalVariable();
-	yield `let ${emitsVar}!: ${names.ResolveEmits}<typeof ${componentOriginalVar}, typeof `;
-	yield [getCtxVar(), 'template', node.loc.start.offset, codeFeatures.verification];
-	yield `.emit>${endOfLine}`;
+	yield `let ${emitsVar}!: ${names.ResolveEmits}<typeof ${componentOriginalVar}, typeof ${getCtxVar()}.emit>${endOfLine}`;
 
 	for (const { propPrefix, emitPrefix, propName, emitName, items } of Object.values(definitions)) {
 		const eventVar = ctx.getInternalVariable();
@@ -170,9 +168,7 @@ export function* generateEventExpression(
 		);
 
 		if (isCompound) {
-			yield `(...[`;
-			yield ['$event', 'template', prop.exp.loc.start.offset, codeFeatures.verification];
-			yield `]) => {${newLine}`;
+			yield `(...[$event]) => {${newLine}`;
 			const scope = ctx.scope();
 			scope.declare('$event');
 			yield `void $event${endOfLine}`;
@@ -217,9 +213,7 @@ export function* generateModelEventExpression(
 	prop: CompilerDOM.DirectiveNode,
 ): Generator<Code> {
 	if (prop.exp?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION) {
-		yield `(...[`;
-		yield ['$event', 'template', prop.exp.loc.start.offset, codeFeatures.verification];
-		yield `]) => {${newLine}`;
+		yield `(...[$event]) => {${newLine}`;
 		yield* ctx.generateConditionGuards();
 		yield* generateInterpolation(
 			options,

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -89,7 +89,9 @@ export function* generateElementEvents(
 
 	for (const { propPrefix, emitPrefix, propName, emitName, items } of Object.values(definitions)) {
 		const eventVar = ctx.getInternalVariable();
-		yield `const ${eventVar}: ${options.vueCompilerOptions.checkUnknownEvents ? '' : 'Record<string, unknown> & '}Partial<${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', '${emitName}', '${
+		yield `const ${eventVar}: ${
+			options.vueCompilerOptions.checkUnknownEvents ? '' : 'Record<string, unknown> & '
+		}Partial<${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', '${emitName}', '${
 			camelize(emitName)
 		}'>> = {${newLine}`;
 		for (const { prop, source, offset } of items) {

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -5,7 +5,15 @@ import { getUnwrappedExpression } from '../../parsers/utils';
 import type { Code, VueCodeInformation } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { endOfLine, getRefBrandArgument, getTypeScriptAST, identifierRE, newLine } from '../utils';
+import {
+	endOfLine,
+	generateTypedVar,
+	getRefBrandArgument,
+	getTypeScriptAST,
+	identifierRE,
+	isTsLang,
+	newLine,
+} from '../utils';
 import { Boundary } from '../utils/boundary';
 import { generateCamelized } from '../utils/camelized';
 import type { TemplateCodegenContext } from './context';
@@ -85,15 +93,23 @@ export function* generateElementEvents(
 	}
 
 	const emitsVar = ctx.getInternalVariable();
-	yield `let ${emitsVar}!: ${names.ResolveEmits}<typeof ${componentOriginalVar}, typeof ${getCtxVar()}.emit>${endOfLine}`;
+	yield* generateTypedVar('let', emitsVar, options.scriptLang, function*() {
+		yield `${names.ResolveEmits}<typeof ${componentOriginalVar}, typeof ${getCtxVar()}.emit>`;
+	});
 
 	for (const { propPrefix, emitPrefix, propName, emitName, items } of Object.values(definitions)) {
 		const eventVar = ctx.getInternalVariable();
-		yield `const ${eventVar}: ${
+		const eventType = `${
 			options.vueCompilerOptions.checkUnknownEvents ? '' : 'Record<string, unknown> & '
 		}Partial<${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', '${emitName}', '${
 			camelize(emitName)
-		}'>> = {${newLine}`;
+		}'>>`;
+		if (isTsLang(options.scriptLang)) {
+			yield `const ${eventVar}: ${eventType} = {${newLine}`;
+		}
+		else {
+			yield `/** @type {${eventType}} */${newLine}const ${eventVar} = {${newLine}`;
+		}
 		for (const { prop, source, offset } of items) {
 			if (prop.name === 'on') {
 				yield `/** @type {typeof ${emitsVar}.`;
@@ -270,7 +286,9 @@ function* generateReasserts(
 		}
 	}
 	for (const name of reasserts) {
-		yield `${names.withDotValue}(${name}, ${getRefBrandArgument(options.vueCompilerOptions)})${endOfLine}`;
+		yield `${names.withDotValue}(${name}, ${
+			getRefBrandArgument(options.vueCompilerOptions, options.scriptLang)
+		})${endOfLine}`;
 	}
 }
 

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -89,11 +89,9 @@ export function* generateElementEvents(
 
 	for (const { propPrefix, emitPrefix, propName, emitName, items } of Object.values(definitions)) {
 		const eventVar = ctx.getInternalVariable();
-		yield `const `;
-		yield [eventVar, 'template', items[0]?.offset ?? node.loc.start.offset, codeFeatures.verification];
-		yield `: ${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', `;
-		yield [`'${emitName}'`, 'template', items[0]?.offset ?? node.loc.start.offset, codeFeatures.verification];
-		yield `, '${camelize(emitName)}'> = {${newLine}`;
+		yield `const ${eventVar}: ${names.ResolveEvent}<typeof ${getPropsVar()}, typeof ${emitsVar}, '${propName}', '${emitName}', '${
+			camelize(emitName)
+		}'> = {${newLine}`;
 		for (const { prop, source, offset } of items) {
 			if (prop.name === 'on') {
 				yield `/** @type {typeof ${emitsVar}.`;

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -168,6 +168,7 @@ export function* generateEventExpression(
 		);
 
 		if (isCompound) {
+			yield `// @ts-ignore${newLine}`;
 			yield `(...[$event]) => {${newLine}`;
 			const scope = ctx.scope();
 			scope.declare('$event');
@@ -231,6 +232,7 @@ export function* generateModelEventExpression(
 	prop: CompilerDOM.DirectiveNode,
 ): Generator<Code> {
 	if (prop.exp?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION) {
+		yield `// @ts-ignore${newLine}`;
 		yield `(...[$event]) => {${newLine}`;
 		yield* ctx.generateConditionGuards();
 		yield* generateInterpolation(

--- a/packages/language-core/lib/codegen/template/elementProps.ts
+++ b/packages/language-core/lib/codegen/template/elementProps.ts
@@ -52,7 +52,7 @@ export function* generateElementProps(
 					yield `},`;
 				}
 				else {
-					yield `...{ '${camelize('on-' + prop.arg.loc.source)}': ${asType('{}', 'any', options.scriptLang)} },`;
+					yield `...{ '${camelize('on-' + prop.arg.loc.source)}': ${asType('any', options.scriptLang)} },`;
 				}
 				yield newLine;
 			}

--- a/packages/language-core/lib/codegen/template/elementProps.ts
+++ b/packages/language-core/lib/codegen/template/elementProps.ts
@@ -6,7 +6,7 @@ import { hyphenateAttr, hyphenateTag, normalizeAttributeValue } from '../../util
 import { codeFeatures } from '../codeFeatures';
 import { createVBindShorthandInlayHintInfo } from '../inlayHints';
 import { names } from '../names';
-import { getRefBrandArgument, identifierRE, newLine } from '../utils';
+import { asType, getRefBrandArgument, identifierRE, newLine } from '../utils';
 import { Boundary } from '../utils/boundary';
 import { generateCamelized } from '../utils/camelized';
 import { generateUnicode } from '../utils/unicode';
@@ -52,7 +52,7 @@ export function* generateElementProps(
 					yield `},`;
 				}
 				else {
-					yield `...{ '${camelize('on-' + prop.arg.loc.source)}': {} as any },`;
+					yield `...{ '${camelize('on-' + prop.arg.loc.source)}': ${asType('{}', 'any', options.scriptLang)} },`;
 				}
 				yield newLine;
 			}
@@ -305,7 +305,7 @@ export function* generatePropExp(
 				else {
 					yield `${names.unwrap}(`;
 					yield* codes;
-					yield `, ${getRefBrandArgument(options.vueCompilerOptions)})`;
+					yield `, ${getRefBrandArgument(options.vueCompilerOptions, options.scriptLang)})`;
 				}
 			}
 			else {

--- a/packages/language-core/lib/codegen/template/elementProps.ts
+++ b/packages/language-core/lib/codegen/template/elementProps.ts
@@ -294,13 +294,13 @@ export function* generatePropExp(
 			}
 			else if (options.setupRefs.has(propVariableName)) {
 				yield* codes;
-				yield `.value`;
+				yield [`.value`, 'template', exp.loc.start.offset, codeFeatures.verification];
 			}
 			else if (options.setupBindings.has(propVariableName)) {
 				ctx.accessVariable('template', propVariableName, exp.loc.start.offset);
 				if (options.dotValueBindings.has(propVariableName)) {
 					yield* codes;
-					yield `.value`;
+					yield [`.value`, 'template', exp.loc.start.offset, codeFeatures.verification];
 				}
 				else {
 					yield `${names.unwrap}(`;

--- a/packages/language-core/lib/codegen/template/index.ts
+++ b/packages/language-core/lib/codegen/template/index.ts
@@ -166,7 +166,14 @@ function* generateTemplateRefsType(
 	options: TemplateCodegenOptions,
 	ctx: TemplateCodegenContext,
 ): Generator<Code> {
-	if (!ctx.templateRefs.size) {
+	if (
+		!ctx.templateRefs.size
+		|| !(
+			options.vueCompilerOptions.inferTemplateDollarRefs
+			|| options.vueCompilerOptions.inferComponentDollarRefs
+			|| options.setupRefs.size
+		)
+	) {
 		return;
 	}
 	ctx.generatedTypes.add(names.TemplateRefs);

--- a/packages/language-core/lib/codegen/template/index.ts
+++ b/packages/language-core/lib/codegen/template/index.ts
@@ -2,7 +2,7 @@ import type * as ts from 'typescript';
 import type { Code, IRTemplate, VueCompilerOptions } from '../../types';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { endOfLine, newLine } from '../utils';
+import { endOfLine, generateTypeAlias, generateTypedVar, newLine } from '../utils';
 import { Boundary } from '../utils/boundary';
 import { createTemplateCodegenContext, type TemplateCodegenContext } from './context';
 import { generateObjectProperty } from './objectProperty';
@@ -14,6 +14,7 @@ export interface TemplateCodegenOptions {
 	vueCompilerOptions: VueCompilerOptions;
 	template: IRTemplate;
 	isVapor: boolean;
+	scriptLang: string;
 	destructuredProps: Set<string>;
 	importedComponents: Set<string>;
 	setupRefs: Set<string>;
@@ -84,30 +85,32 @@ function* generateWorker(
 	yield* generateSlotsType(options, ctx);
 	yield* generateInheritedAttrsType(options, ctx);
 	yield* generateTemplateRefsType(options, ctx);
-	yield* generateRootElType(ctx);
+	yield* generateRootElType(options, ctx);
 
 	if (ctx.dollarVars.size) {
-		yield `var ${names.dollars}!: {${newLine}`;
-		if (ctx.dollarVars.has('$slots')) {
-			const type = ctx.generatedTypes.has(names.Slots) ? names.Slots : `{}`;
-			yield `$slots: ${type}${endOfLine}`;
-		}
-		if (ctx.dollarVars.has('$attrs')) {
-			yield `$attrs: import('${vueCompilerOptions.lib}').ComponentPublicInstance['$attrs']`;
-			if (ctx.generatedTypes.has(names.InheritedAttrs)) {
-				yield ` & ${names.InheritedAttrs}`;
+		yield* generateTypedVar('var', names.dollars, options.scriptLang, function*() {
+			yield `{${newLine}`;
+			if (ctx.dollarVars.has('$slots')) {
+				const type = ctx.generatedTypes.has(names.Slots) ? names.Slots : `{}`;
+				yield `$slots: ${type}${endOfLine}`;
 			}
-			yield endOfLine;
-		}
-		if (ctx.dollarVars.has('$refs')) {
-			const type = ctx.generatedTypes.has(names.TemplateRefs) ? names.TemplateRefs : `{}`;
-			yield `$refs: ${type}${endOfLine}`;
-		}
-		if (ctx.dollarVars.has('$el')) {
-			const type = ctx.generatedTypes.has(names.RootEl) ? names.RootEl : `any`;
-			yield `$el: ${type}${endOfLine}`;
-		}
-		yield `} & { [K in keyof import('${vueCompilerOptions.lib}').ComponentPublicInstance]: unknown }${endOfLine}`;
+			if (ctx.dollarVars.has('$attrs')) {
+				yield `$attrs: import('${vueCompilerOptions.lib}').ComponentPublicInstance['$attrs']`;
+				if (ctx.generatedTypes.has(names.InheritedAttrs)) {
+					yield ` & ${names.InheritedAttrs}`;
+				}
+				yield endOfLine;
+			}
+			if (ctx.dollarVars.has('$refs')) {
+				const type = ctx.generatedTypes.has(names.TemplateRefs) ? names.TemplateRefs : `{}`;
+				yield `$refs: ${type}${endOfLine}`;
+			}
+			if (ctx.dollarVars.has('$el')) {
+				const type = ctx.generatedTypes.has(names.RootEl) ? names.RootEl : `any`;
+				yield `$el: ${type}${endOfLine}`;
+			}
+			yield `} & { [K in keyof import('${vueCompilerOptions.lib}').ComponentPublicInstance]: unknown }`;
+		});
 	}
 
 	yield* scope.end();
@@ -126,29 +129,30 @@ function* generateSlotsType(
 	}
 	ctx.generatedTypes.add(names.Slots);
 
-	yield `type ${names.Slots} = {}`;
-	for (const { expVar, propsVar } of ctx.dynamicSlots) {
-		yield `${newLine}& { [K in NonNullable<typeof ${expVar}>]?: (props: typeof ${propsVar}) => any }`;
-	}
-	for (const slot of ctx.slots) {
-		yield `${newLine}& { `;
-		if (slot.name && slot.offset !== undefined) {
-			yield* generateObjectProperty(
-				options,
-				ctx,
-				slot.name,
-				slot.offset,
-				codeFeatures.navigation,
-			);
+	yield* generateTypeAlias(names.Slots, options.scriptLang, function*() {
+		yield `{}`;
+		for (const { expVar, propsVar } of ctx.dynamicSlots) {
+			yield `${newLine}& { [K in NonNullable<typeof ${expVar}>]?: (props: typeof ${propsVar}) => any }`;
 		}
-		else {
-			const boundary = yield* Boundary.start('template', ...slot.tagRange, codeFeatures.navigation);
-			yield `default`;
-			yield boundary.end();
+		for (const slot of ctx.slots) {
+			yield `${newLine}& { `;
+			if (slot.name && slot.offset !== undefined) {
+				yield* generateObjectProperty(
+					options,
+					ctx,
+					slot.name,
+					slot.offset,
+					codeFeatures.navigation,
+				);
+			}
+			else {
+				const boundary = yield* Boundary.start('template', ...slot.tagRange, codeFeatures.navigation);
+				yield `default`;
+				yield boundary.end();
+			}
+			yield `?: (props: typeof ${slot.propsVar}) => any }`;
 		}
-		yield `?: (props: typeof ${slot.propsVar}) => any }`;
-	}
-	yield endOfLine;
+	});
 }
 
 function* generateInheritedAttrsType(
@@ -162,12 +166,11 @@ function* generateInheritedAttrsType(
 
 	const type = [...ctx.inheritedAttrVars].map(name => `typeof ${name}`).join(` & `);
 
-	yield `type ${names.InheritedAttrs} = ${
-		options.vueCompilerOptions.checkRequiredFallthroughAttributes
+	yield* generateTypeAlias(names.InheritedAttrs, options.scriptLang, function*() {
+		yield options.vueCompilerOptions.checkRequiredFallthroughAttributes
 			? type
-			: `Partial<${type}>`
-	}`;
-	yield endOfLine;
+			: `Partial<${type}>`;
+	});
 }
 
 function* generateTemplateRefsType(
@@ -186,43 +189,47 @@ function* generateTemplateRefsType(
 	}
 	ctx.generatedTypes.add(names.TemplateRefs);
 
-	yield `type ${names.TemplateRefs} = {}`;
-	for (const [name, refs] of ctx.templateRefs) {
-		yield `${newLine}& `;
-		if (refs.length >= 2) {
-			yield `(`;
-		}
-		for (let i = 0; i < refs.length; i++) {
-			const { typeExp, offset } = refs[i]!;
-			if (i) {
-				yield ` | `;
+	yield* generateTypeAlias(names.TemplateRefs, options.scriptLang, function*() {
+		yield `{}`;
+		for (const [name, refs] of ctx.templateRefs) {
+			yield `${newLine}& `;
+			if (refs.length >= 2) {
+				yield `(`;
 			}
-			yield `{ `;
-			yield* generateObjectProperty(
-				options,
-				ctx,
-				name,
-				offset,
-				codeFeatures.navigation,
-			);
-			yield `: ${typeExp} }`;
+			for (let i = 0; i < refs.length; i++) {
+				const { typeExp, offset } = refs[i]!;
+				if (i) {
+					yield ` | `;
+				}
+				yield `{ `;
+				yield* generateObjectProperty(
+					options,
+					ctx,
+					name,
+					offset,
+					codeFeatures.navigation,
+				);
+				yield `: ${typeExp} }`;
+			}
+			if (refs.length >= 2) {
+				yield `)`;
+			}
 		}
-		if (refs.length >= 2) {
-			yield `)`;
-		}
-	}
-	yield endOfLine;
+	});
 }
 
-function* generateRootElType(ctx: TemplateCodegenContext): Generator<Code> {
+function* generateRootElType(
+	options: TemplateCodegenOptions,
+	ctx: TemplateCodegenContext,
+): Generator<Code> {
 	if (!ctx.singleRootElTypes.size || ctx.singleRootNodes.has(null)) {
 		return;
 	}
 	ctx.generatedTypes.add(names.RootEl);
 
-	yield `type ${names.RootEl} = `;
-	for (const type of ctx.singleRootElTypes) {
-		yield `${newLine}| ${type}`;
-	}
-	yield endOfLine;
+	yield* generateTypeAlias(names.RootEl, options.scriptLang, function*() {
+		for (const type of ctx.singleRootElTypes) {
+			yield `${newLine}| ${type}`;
+		}
+	});
 }

--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -16,6 +16,7 @@ export function* generateInterpolation(
 		setupBindings,
 		dotValueBindings,
 		vueCompilerOptions,
+		scriptLang,
 	}: {
 		typescript: typeof import('typescript');
 		destructuredProps: Set<string>;
@@ -24,6 +25,7 @@ export function* generateInterpolation(
 		setupBindings: Set<string>;
 		dotValueBindings: Set<string>;
 		vueCompilerOptions: VueCompilerOptions;
+		scriptLang: string;
 	},
 	ctx: TemplateCodegenContext,
 	block: IRBlock,
@@ -121,7 +123,7 @@ export function* generateInterpolation(
 					start + offset,
 					identifierData,
 				];
-				yield `, ${getRefBrandArgument(vueCompilerOptions)})`;
+				yield `, ${getRefBrandArgument(vueCompilerOptions, scriptLang)})`;
 				if (isNewOperand) {
 					yield `)`;
 				}

--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -94,7 +94,7 @@ export function* generateInterpolation(
 				start + offset,
 				data,
 			];
-			yield `.value`;
+			yield [`.value`, block.name, start + offset, codeFeatures.verification];
 		}
 		else if (setupBindings.has(name)) {
 			// First pass records narrowing accesses here; the second pass emits from dotValueBindings.
@@ -106,7 +106,7 @@ export function* generateInterpolation(
 					start + offset,
 					identifierData,
 				];
-				yield `.value`;
+				yield [`.value`, block.name, start + offset, codeFeatures.verification];
 			}
 			else {
 				// `new __VLS_unwrap(Foo)()` parses as `new (__VLS_unwrap(Foo)())`,

--- a/packages/language-core/lib/codegen/template/vFor.ts
+++ b/packages/language-core/lib/codegen/template/vFor.ts
@@ -92,9 +92,9 @@ export function* generateVFor(
 	}
 	yield `] of `;
 	if (sourceAlias !== undefined) {
-		yield `${names.vFor}(`;
+		yield `${names.vFor}(${names.nonNull}(`;
 		yield sourceAlias;
-		yield `!)`; // #3102
+		yield `))`; // #3102
 	}
 	else {
 		yield `{} as any`;

--- a/packages/language-core/lib/codegen/template/vFor.ts
+++ b/packages/language-core/lib/codegen/template/vFor.ts
@@ -5,7 +5,7 @@ import { collectBindingNames } from '../../utils/collectBindings';
 import { getStartEnd } from '../../utils/shared';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { endOfLine, getTypeScriptAST, newLine } from '../utils';
+import { asType, endOfLine, getTypeScriptAST, newLine } from '../utils';
 import type { TemplateCodegenContext } from './context';
 import type { TemplateCodegenOptions } from './index';
 import { generateInterpolation } from './interpolation';
@@ -97,7 +97,7 @@ export function* generateVFor(
 		yield `))`; // #3102
 	}
 	else {
-		yield `{} as any`;
+		yield asType('{}', 'any', options.scriptLang);
 	}
 	yield `) {${newLine}`;
 

--- a/packages/language-core/lib/codegen/template/vFor.ts
+++ b/packages/language-core/lib/codegen/template/vFor.ts
@@ -97,7 +97,7 @@ export function* generateVFor(
 		yield `))`; // #3102
 	}
 	else {
-		yield asType('{}', 'any', options.scriptLang);
+		yield asType('any', options.scriptLang);
 	}
 	yield `) {${newLine}`;
 

--- a/packages/language-core/lib/codegen/template/vSlot.ts
+++ b/packages/language-core/lib/codegen/template/vSlot.ts
@@ -5,7 +5,7 @@ import type { Code } from '../../types';
 import { collectBindingNames } from '../../utils/collectBindings';
 import { codeFeatures } from '../codeFeatures';
 import { names } from '../names';
-import { endOfLine, getTypeScriptAST, newLine } from '../utils';
+import { endOfLine, getTypeScriptAST, isTsLang, newLine } from '../utils';
 import { Boundary } from '../utils/boundary';
 import type { TemplateCodegenContext } from './context';
 import type { TemplateCodegenOptions } from './index';
@@ -159,7 +159,7 @@ function* generateSlotParameters(
 		);
 		yield `(`;
 		yield* types.flatMap(type => type ? [`_`, type, `, `] : `_, `);
-		yield `) => [] as any`;
+		yield isTsLang(options.scriptLang) ? `) => [] as any` : `) => /** @type {any} */ ([])`;
 		yield boundary.end();
 	}
 	yield `)${endOfLine}`;

--- a/packages/language-core/lib/codegen/template/vSlot.ts
+++ b/packages/language-core/lib/codegen/template/vSlot.ts
@@ -58,7 +58,7 @@ export function* generateVSlot(
 		yield `default`;
 		yield boundary.end();
 	}
-	yield `: ${slotVar} } = ${ctxVar}.slots!${endOfLine}`;
+	yield `: ${slotVar} } = ${names.nonNull}(${ctxVar}.slots)${endOfLine}`;
 
 	const scope = ctx.scope();
 	if (slotDir?.exp?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION) {
@@ -78,7 +78,7 @@ export function* generateVSlot(
 		}
 		if (isStatic && !slotDir.arg) {
 			yield `// @ts-ignore${newLine}`;
-			yield `${ctxVar}.slots!['`;
+			yield `${names.nonNull}(${ctxVar}.slots)['`;
 			yield [
 				'',
 				'template',
@@ -147,7 +147,7 @@ function* generateSlotParameters(
 
 	yield `const [`;
 	yield* interpolation;
-	yield `] = ${names.vSlot}(${slotVar}!`;
+	yield `] = ${names.vSlot}(${names.nonNull}(${slotVar})`;
 
 	if (types.some(t => t)) {
 		yield `, `;

--- a/packages/language-core/lib/codegen/template/vSlot.ts
+++ b/packages/language-core/lib/codegen/template/vSlot.ts
@@ -77,6 +77,7 @@ export function* generateVSlot(
 			isStatic = slotDir.arg.isStatic;
 		}
 		if (isStatic && !slotDir.arg) {
+			yield `// @ts-ignore${newLine}`;
 			yield `${ctxVar}.slots!['`;
 			yield [
 				'',

--- a/packages/language-core/lib/codegen/utils/index.ts
+++ b/packages/language-core/lib/codegen/utils/index.ts
@@ -10,10 +10,10 @@ export function isTsLang(lang: string): boolean {
 	return lang === 'ts' || lang === 'tsx';
 }
 
-// `exp as T` in TS; `/** @type {T} */ (exp)` in JS. The JSDoc cast keeps the
+// `{} as T` in TS; `/** @type {T} */ ({})` in JS. The JSDoc cast keeps the
 // same assertion semantics under checkJs, and requires no type-only syntax.
-export function asType(exp: string, type: string, lang: string): string {
-	return isTsLang(lang) ? `${exp} as ${type}` : `/** @type {${type}} */ (${exp})`;
+export function asType(type: string, lang: string): string {
+	return isTsLang(lang) ? `{} as ${type}` : `/** @type {${type}} */ ({})`;
 }
 
 // `let name!: T;` in TS; `var name = /** @type {T} */ ({});` in JS.
@@ -57,7 +57,7 @@ export function* generateTypeAlias(
 // `__VLS_unwrap` / `__VLS_withDotValue`; the helper declarations cannot
 // resolve the library import themselves.
 export function getRefBrandArgument(vueCompilerOptions: VueCompilerOptions, lang: string): string {
-	return asType('{}', `import('${vueCompilerOptions.lib}').Ref<unknown>`, lang);
+	return asType(`import('${vueCompilerOptions.lib}').Ref<unknown>`, lang);
 }
 
 const cacheMaps = new WeakMap<IRBlock, [content: string, Map<string, [ts.SourceFile, usages: number]>]>();

--- a/packages/language-core/lib/codegen/utils/index.ts
+++ b/packages/language-core/lib/codegen/utils/index.ts
@@ -6,11 +6,58 @@ export const newLine = `\n`;
 export const endOfLine = `;${newLine}`;
 export const identifierRE = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
 
+export function isTsLang(lang: string): boolean {
+	return lang === 'ts' || lang === 'tsx';
+}
+
+// `exp as T` in TS; `/** @type {T} */ (exp)` in JS. The JSDoc cast keeps the
+// same assertion semantics under checkJs, and requires no type-only syntax.
+export function asType(exp: string, type: string, lang: string): string {
+	return isTsLang(lang) ? `${exp} as ${type}` : `/** @type {${type}} */ (${exp})`;
+}
+
+// `let name!: T;` in TS; `var name = /** @type {T} */ ({});` in JS.
+export function* generateTypedVar(
+	kind: 'let' | 'var',
+	name: string,
+	lang: string,
+	type: () => Generator<Code>,
+): Generator<Code> {
+	if (isTsLang(lang)) {
+		yield `${kind} ${name}!: `;
+		yield* type();
+		yield endOfLine;
+	}
+	else {
+		yield `var ${name} = /** @type {`;
+		yield* type();
+		yield `} */ ({})${endOfLine}`;
+	}
+}
+
+// `type name = T;` in TS; `/** @typedef {T} name */` in JS.
+export function* generateTypeAlias(
+	name: string,
+	lang: string,
+	type: () => Generator<Code>,
+): Generator<Code> {
+	if (isTsLang(lang)) {
+		yield `type ${name} = `;
+		yield* type();
+		yield endOfLine;
+	}
+	else {
+		yield `/** @typedef {`;
+		yield* type();
+		yield `} ${name} */${newLine}`;
+	}
+}
+
 // The phantom argument that carries the component library's `Ref` brand into
 // `__VLS_unwrap` / `__VLS_withDotValue`; the helper declarations cannot
 // resolve the library import themselves.
-export function getRefBrandArgument(vueCompilerOptions: VueCompilerOptions): string {
-	return `{} as import('${vueCompilerOptions.lib}').Ref<unknown>`;
+export function getRefBrandArgument(vueCompilerOptions: VueCompilerOptions, lang: string): string {
+	return asType('{}', `import('${vueCompilerOptions.lib}').Ref<unknown>`, lang);
 }
 
 const cacheMaps = new WeakMap<IRBlock, [content: string, Map<string, [ts.SourceFile, usages: number]>]>();

--- a/packages/language-core/lib/plugins/vue-tsx.ts
+++ b/packages/language-core/lib/plugins/vue-tsx.ts
@@ -39,23 +39,23 @@ const plugin: VueLanguagePlugin = ({
 			}
 		},
 	};
-
-	function computeLang(ir: IR) {
-		let lang = ir.scriptSetup?.lang ?? ir.script?.lang;
-		if (ir.script && ir.scriptSetup) {
-			if (ir.scriptSetup.lang !== 'js') {
-				lang = ir.scriptSetup.lang;
-			}
-			else {
-				lang = ir.script.lang;
-			}
-		}
-		if (lang && validLangs.has(lang)) {
-			return lang;
-		}
-		return 'ts';
-	}
 };
+
+function computeLang(ir: IR) {
+	let lang = ir.scriptSetup?.lang ?? ir.script?.lang;
+	if (ir.script && ir.scriptSetup) {
+		if (ir.scriptSetup.lang !== 'js') {
+			lang = ir.scriptSetup.lang;
+		}
+		else {
+			lang = ir.script.lang;
+		}
+	}
+	if (lang && validLangs.has(lang)) {
+		return lang;
+	}
+	return 'ts';
+}
 
 export default plugin;
 
@@ -214,6 +214,7 @@ function useCodegen(
 			vueCompilerOptions: getResolvedOptions(),
 			template: ir.template,
 			isVapor: getIsVapor(),
+			scriptLang: computeLang(ir),
 			componentName: getComponentName(),
 			destructuredProps: getDestructuredProps(),
 			importedComponents: getImportedComponents(),
@@ -236,6 +237,7 @@ function useCodegen(
 			typescript: ts,
 			vueCompilerOptions: getResolvedOptions(),
 			styles: ir.styles,
+			scriptLang: computeLang(ir),
 			destructuredProps: getDestructuredProps(),
 			importedComponents: getImportedComponents(),
 			setupRefs: getSetupRefs(),
@@ -309,6 +311,7 @@ function useCodegen(
 			fileName,
 			script: ir.script,
 			scriptSetup: ir.scriptSetup,
+			scriptLang: computeLang(ir),
 			setupBindings: getScriptSetupBindings(),
 			localComponents: getLocalComponents(),
 			localDirectives: getLocalDirectives(),

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -53,7 +53,7 @@ declare global {
 	> = __VLS_IsFunction<Props, onEvent> extends true ? { [K in onEvent]?: Props[K & keyof Props] }
 		: __VLS_IsFunction<Emits, Event> extends true ? { [K in onEvent]?: Emits[Event & keyof Emits] }
 		: __VLS_IsFunction<Emits, CamelizedEvent> extends true ? { [K in onEvent]?: Emits[CamelizedEvent & keyof Emits] }
-		: Props;
+		: Partial<Props>;
 	// fix https://github.com/vuejs/language-tools/issues/926
 	type __VLS_UnionToIntersection<U> = (U extends unknown ? (arg: U) => unknown : never) extends
 		((arg: infer P) => unknown) ? P : never;

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -50,7 +50,7 @@ declare global {
 		onEvent extends string,
 		Event extends string,
 		CamelizedEvent extends string,
-	> = __VLS_IsFunction<Props, onEvent> extends true ? Props
+	> = __VLS_IsFunction<Props, onEvent> extends true ? { [K in onEvent]?: Props[K & keyof Props] }
 		: __VLS_IsFunction<Emits, Event> extends true ? { [K in onEvent]?: Emits[Event & keyof Emits] }
 		: __VLS_IsFunction<Emits, CamelizedEvent> extends true ? { [K in onEvent]?: Emits[CamelizedEvent & keyof Emits] }
 		: Props;

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -23,7 +23,7 @@ declare global {
 		: {};
 	type __VLS_ExtractComponentContext<T, K> = __VLS_PickNotAny<
 		'__ctx' extends keyof __VLS_PickNotAny<K, {}> ? K extends { __ctx?: infer Ctx } ? NonNullable<Ctx> : never : any,
-		T extends (props: any, ctx: infer Ctx) => any ? Ctx : any
+		T extends (props: any, ctx: infer Ctx) => any ? (unknown extends Ctx ? any : Ctx) : any
 	>;
 	type __VLS_ExtractComponentProps<T, K> = '__ctx' extends keyof __VLS_PickNotAny<K, {}>
 		? K extends { __ctx?: { props?: infer P } } ? NonNullable<P> : never

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -133,7 +133,10 @@ declare global {
 	): __VLS_PadArgs<Parameters<T> extends [any, ...infer Rest] ? Rest : []>;
 	function __VLS_asFunctionalElement0<T>(tag: T, endTag?: T): (attrs: T) => void;
 	function __VLS_asFunctionalElement1<T>(tag: T, endTag?: T): (attrs: T & Record<string, unknown>) => void;
-	function __VLS_asFunctionalSlot<S>(slot: S): S extends () => infer R ? (props: {}) => R : NonNullable<S>;
+	function __VLS_asFunctionalSlot<S>(
+		slot: S,
+	): S extends (...args: any) => any ? (S extends () => infer R ? (props: {}) => R : S)
+		: (S extends null | undefined ? never : (props: S) => any);
 	function __VLS_omit<T, K>(target: T, props: K): Omit<T, keyof K>;
 	function __VLS_tryAsConstant<const T>(t: T): T;
 	// Rewrites the binding so codegen's appended `.value` resolves with the

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -127,9 +127,10 @@ declare global {
 		: T extends () => any ? (props: {}, ctx?: any) => ReturnType<T>
 		: T extends (...args: any) => any ? T
 		: __VLS_FunctionalComponent<{}, Record<string, unknown>>;
+	type __VLS_PadArgs<A extends any[]> = A extends [any, ...infer Rest] ? [any, ...__VLS_PadArgs<Rest>] : [];
 	function __VLS_functionalComponentArgsRest<T extends (...args: any) => any>(
 		t: T,
-	): 2 extends Parameters<T>['length'] ? [any] : [];
+	): __VLS_PadArgs<Parameters<T> extends [any, ...infer Rest] ? Rest : []>;
 	function __VLS_asFunctionalElement0<T>(tag: T, endTag?: T): (attrs: T) => void;
 	function __VLS_asFunctionalElement1<T>(tag: T, endTag?: T): (attrs: T & Record<string, unknown>) => void;
 	function __VLS_asFunctionalSlot<S>(slot: S): S extends () => infer R ? (props: {}) => R : NonNullable<S>;

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -105,6 +105,7 @@ declare global {
 		: T extends Iterable<any> ? (T extends Iterable<infer V> ? [V, number] : never)[]
 		: [T[keyof T], keyof T extends string ? keyof T : `${keyof T & (string | number)}`, number][];
 	function __VLS_vSlot<S, D extends S>(slot: S, decl?: D): D extends (...args: infer P) => any ? P : any[];
+	function __VLS_nonNull<T>(value: T): NonNullable<T>;
 	function __VLS_asFunctionalDirective<T, ObjectDirective>(
 		dir: T,
 		od: ObjectDirective,

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -53,7 +53,7 @@ declare global {
 	> = __VLS_IsFunction<Props, onEvent> extends true ? { [K in onEvent]?: Props[K & keyof Props] }
 		: __VLS_IsFunction<Emits, Event> extends true ? { [K in onEvent]?: Emits[Event & keyof Emits] }
 		: __VLS_IsFunction<Emits, CamelizedEvent> extends true ? { [K in onEvent]?: Emits[CamelizedEvent & keyof Emits] }
-		: Partial<Props>;
+		: Props;
 	// fix https://github.com/vuejs/language-tools/issues/926
 	type __VLS_UnionToIntersection<U> = (U extends unknown ? (arg: U) => unknown : never) extends
 		((arg: infer P) => unknown) ? P : never;

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -1,5 +1,5 @@
 declare global {
-	const __VLS_directiveBindingRestFields: { instance: null; oldValue: null; modifiers: any; dir: any };
+	const __VLS_directiveBindingRestFields: { instance: null; oldValue: null; value: null; modifiers: any; dir: any };
 
 	type __VLS_Elements = __VLS_SpreadMerge<SVGElementTagNameMap, HTMLElementTagNameMap>;
 	type __VLS_IsAny<T> = 0 extends 1 & T ? true : false;

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -47,12 +47,12 @@ declare global {
 	type __VLS_ResolveEvent<
 		Props,
 		Emits,
-		onEvent extends keyof Props,
-		Event extends keyof Emits,
-		CamelizedEvent extends keyof Emits,
+		onEvent extends string,
+		Event extends string,
+		CamelizedEvent extends string,
 	> = __VLS_IsFunction<Props, onEvent> extends true ? Props
-		: __VLS_IsFunction<Emits, Event> extends true ? { [K in onEvent]?: Emits[Event] }
-		: __VLS_IsFunction<Emits, CamelizedEvent> extends true ? { [K in onEvent]?: Emits[CamelizedEvent] }
+		: __VLS_IsFunction<Emits, Event> extends true ? { [K in onEvent]?: Emits[Event & keyof Emits] }
+		: __VLS_IsFunction<Emits, CamelizedEvent> extends true ? { [K in onEvent]?: Emits[CamelizedEvent & keyof Emits] }
 		: Props;
 	// fix https://github.com/vuejs/language-tools/issues/926
 	type __VLS_UnionToIntersection<U> = (U extends unknown ? (arg: U) => unknown : never) extends

--- a/packages/tsc/tests/unmapped-diagnostics.spec.ts
+++ b/packages/tsc/tests/unmapped-diagnostics.spec.ts
@@ -12,13 +12,18 @@ test('no unmapped diagnostics', () => {
 	const originalArgv = process.argv;
 	const unmapped: string[] = [];
 
-	transform.transformDiagnostic = function (language: unknown, diagnostic: {
-		file?: { fileName: string; getLineAndCharacterOfPosition(pos: number): { line: number; character: number } };
-		start?: number;
-		length?: number;
-		code: number;
-		messageText: string | { messageText: string };
-	}, program: unknown, isTsc: boolean) {
+	transform.transformDiagnostic = function(
+		language: unknown,
+		diagnostic: {
+			file?: { fileName: string; getLineAndCharacterOfPosition(pos: number): { line: number; character: number } };
+			start?: number;
+			length?: number;
+			code: number;
+			messageText: string | { messageText: string };
+		},
+		program: unknown,
+		isTsc: boolean,
+	) {
 		const result = originalTransform(language, diagnostic, program, isTsc);
 		if (
 			result === undefined
@@ -29,7 +34,17 @@ test('no unmapped diagnostics', () => {
 			const [serviceScript] = utils.getServiceScript(language, diagnostic.file.fileName);
 			if (serviceScript) {
 				let mapped = false;
-				for (const _ of transform.toSourceRanges(undefined, language, serviceScript, diagnostic.start, diagnostic.length, true, () => true)) {
+				for (
+					const _ of transform.toSourceRanges(
+						undefined,
+						language,
+						serviceScript,
+						diagnostic.start,
+						diagnostic.length,
+						true,
+						() => true,
+					)
+				) {
 					mapped = true;
 					break;
 				}
@@ -38,7 +53,11 @@ test('no unmapped diagnostics', () => {
 					const msg = typeof diagnostic.messageText === 'string'
 						? diagnostic.messageText
 						: diagnostic.messageText.messageText;
-					unmapped.push(`${diagnostic.file.fileName.replace(root + '/', '')}:${pos.line + 1}:${pos.character + 1} TS${diagnostic.code} ${msg}`);
+					unmapped.push(
+						`${diagnostic.file.fileName.replace(root + '/', '')}:${pos.line + 1}:${
+							pos.character + 1
+						} TS${diagnostic.code} ${msg}`,
+					);
 				}
 			}
 		}

--- a/packages/tsc/tests/unmapped-diagnostics.spec.ts
+++ b/packages/tsc/tests/unmapped-diagnostics.spec.ts
@@ -40,7 +40,7 @@ test('no unmapped diagnostics', () => {
 						language,
 						serviceScript,
 						diagnostic.start,
-						diagnostic.length,
+						diagnostic.start + diagnostic.length,
 						true,
 						() => true,
 					)

--- a/packages/tsc/tests/unmapped-diagnostics.spec.ts
+++ b/packages/tsc/tests/unmapped-diagnostics.spec.ts
@@ -1,0 +1,95 @@
+import * as path from 'node:path';
+import { test } from 'vitest';
+
+const root = path.resolve(__dirname, '../../..');
+
+const transform = require('@volar/typescript/lib/node/transform.js');
+const utils = require('@volar/typescript/lib/node/utils.js');
+
+test('no unmapped diagnostics', () => {
+	const originalTransform = transform.transformDiagnostic;
+	const originalExit = process.exit;
+	const originalArgv = process.argv;
+	const unmapped: string[] = [];
+
+	transform.transformDiagnostic = function (language: unknown, diagnostic: {
+		file?: { fileName: string; getLineAndCharacterOfPosition(pos: number): { line: number; character: number } };
+		start?: number;
+		length?: number;
+		code: number;
+		messageText: string | { messageText: string };
+	}, program: unknown, isTsc: boolean) {
+		const result = originalTransform(language, diagnostic, program, isTsc);
+		if (
+			result === undefined
+			&& diagnostic.file
+			&& diagnostic.start !== undefined
+			&& diagnostic.length !== undefined
+		) {
+			const [serviceScript] = utils.getServiceScript(language, diagnostic.file.fileName);
+			if (serviceScript) {
+				let mapped = false;
+				for (const _ of transform.toSourceRanges(undefined, language, serviceScript, diagnostic.start, diagnostic.length, true, () => true)) {
+					mapped = true;
+					break;
+				}
+				if (!mapped) {
+					const pos = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+					const msg = typeof diagnostic.messageText === 'string'
+						? diagnostic.messageText
+						: diagnostic.messageText.messageText;
+					unmapped.push(`${diagnostic.file.fileName.replace(root + '/', '')}:${pos.line + 1}:${pos.character + 1} TS${diagnostic.code} ${msg}`);
+				}
+			}
+		}
+		return result;
+	};
+
+	class ExitError extends Error {}
+
+	try {
+		process.exit = ((code?: number) => {
+			throw new ExitError(String(code));
+		}) as typeof process.exit;
+
+		const { run } = require('../index.js');
+		process.argv = [
+			process.argv[0]!,
+			'vue-tsc',
+			'--build',
+			path.join(root, 'test-workspace/tsc'),
+			'--pretty',
+			'false',
+		];
+		run();
+	}
+	catch (err) {
+		if (!(err instanceof ExitError)) {
+			throw err;
+		}
+	}
+	finally {
+		process.exit = originalExit;
+		process.argv = originalArgv;
+		transform.transformDiagnostic = originalTransform;
+	}
+
+	const uniq = [...new Set(unmapped)];
+	if (uniq.length > 0) {
+		const byCode = new Map<string, number>();
+		for (const line of uniq) {
+			const code = /TS(\d+)/.exec(line)?.[1] ?? '?';
+			byCode.set(code, (byCode.get(code) ?? 0) + 1);
+		}
+		const summary = [
+			`Found ${uniq.length} unmapped diagnostics (expect 0):`,
+			...[...byCode.entries()]
+				.sort((a, b) => b[1] - a[1])
+				.map(([code, count]) => `  TS${code}: ${count}`),
+			'',
+			'Sample:',
+			...uniq.slice(0, 30),
+		].join('\n');
+		throw new Error(summary);
+	}
+});

--- a/test-workspace/tsc/#3688/main.vue
+++ b/test-workspace/tsc/#3688/main.vue
@@ -3,7 +3,7 @@
 <template>
 	{{() => {
 		exactType({} as __VLS_StyleScopedClasses, {} as { 'foo': boolean });
-	}}}
+	} }}
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Problem

Vue's codegen emits synthetic variables (`__VLS_ctx`, `__VLS_components`, `__VLS_directives`, `__VLS_intrinsics`, `__VLS_RootEl`, `__VLS_N`, `$event`, …) that are declared but never read, so TypeScript reports `TS6133`/`TS6196`. Those declarations have no corresponding source position, so the diagnostics are **unmapped**.

Volar silently drops unmapped diagnostics today; a content-mapper-based type-checker (v4) reports them. The noise must therefore be removed in the codegen, not filtered downstream.

## Goal

The virtual code produces **zero** diagnostics in unmapped regions.

## Progress

Gate: **817 → 0** (unmapped, de-duplicated). ✅ Done.

> Note: the gate's `toSourceRanges` end-offset was previously computed as
> `diagnostic.length` instead of `diagnostic.start + diagnostic.length`, which
> misclassified verification-filtered diagnostics as unmapped. Fixed in the gate.

> Merging master (#6184, setup-binding unwrap-by-value) cut the gate from
> 228 → 146: the parse-error family (`TS1128` 41→1, `TS1005` 28→2, plus
> `TS1109`/`TS1135`/`TS1136`/`TS1068`/`TS1434`/`TS2339` eliminated) was noise
> from the old `__VLS_SetupExposed` codegen, now removed at the source.

### Done (pushed)

- [x] scaffolding variables unused (`TS6133`) — `__VLS_ctx` / `__VLS_components` / `__VLS_intrinsics` / `__VLS_directives` / `__VLS_N` / `$event` / `defaults` / `defaultModels` / `slots` / `export`
- [x] `__VLS_RootEl` (`TS6196`) — only declared when `$el` is used
- [x] `TS2339` `exactType.value` (≈ 100) — resolved by #6175 / #6181 / #6184 (`withDotValue` / `__VLS_unwrap`)
- [x] `TS2454` (used before assigned) — `__VLS_withDotValue` assertion; `@ts-ignore`
- [x] `TS7031` (`$event` implicit any) + `TS2493` (empty tuple) — `(...[$event])`; `@ts-ignore`
- [x] `TS7053` (implicit any index) — empty slot-name placeholder; `@ts-ignore`
- [x] `TS18046` (ctx `unknown`) — `__VLS_ExtractComponentContext` falls back to `any` for single-param function components
- [x] `TS2344` (`constraint 'never'` + kebab-case) — `__VLS_ResolveEvent` constraints relaxed + guarded index access
- [x] `defineModel` `TS2322` — `__VLS_ResolveEvent` first branch narrowed to the handler property
- [x] `#3718` unknown-event gating — helper types stay option-agnostic; permissive wrapper applied in codegen when `checkUnknownEvents` is off
- [x] `TS7006` + `TS2345` (function-prop params) — first component instantiation (`new Component({...})`) props are untyped; `@ts-ignore`
- [x] `TS6196` unused type aliases — `__VLS_PublicProps` / `__VLS_TemplateRefs` gated on consumers; `__VLS_StyleScopedClasses` `@ts-ignore` (JSDoc-only)
- [x] parse-error family (`TS1128` / `TS1005` / `TS1109` / `TS1135` / `TS1136` / `TS1068` / `TS1434`) and `TS2339` on `.value` — removed at the source by #6184 (merged from master)
- [x] `TS2741` directive binding missing `value` (2) — `__VLS_directiveBindingRestFields` now includes `value: null`; a real `value` still overrides it via spread order
- [x] `TS2554` functional-component rest args (#2206) — `__VLS_functionalComponentArgsRest` pads to the full parameter arity (`__VLS_PadArgs`), not just arity 2
- [x] `TS2349` slot `v-bind` not callable (2) — `__VLS_asFunctionalSlot` falls back to `(props: S) => any` for non-function slots instead of returning `NonNullable<S>`
- [x] `TS2322` infer-only instantiation props (#3311, 2) — the first `new Component({...})` exists only for inference; its props are now flattened to one line so the `@ts-ignore` covers them
- [x] `TS2790` delete operand (2) + `defineModel` strict `TS2322` — synthetic `.value` is now mapped back to the source identifier as verification-only, so real errors surface in the template instead of vanishing
- [x] `#3688` fixture `TS1128` + `TS1005` — `}}}` made the compiler truncate the interpolation before the arrow body's `}`; fixture corrected to `} }}`
- [x] `TS2554` directive hook arg count (2, #4682) — the excess-argument error lands on the first extra argument, so the synthetic trailing `null` args moved onto their own `@ts-ignore`'d line; arity-failed calls skip argument checking anyway (parity with master's silent drop), while matching-arity hooks keep full binding checking. (A union fallback member was tried and rejected: it poisons contextual typing for context-sensitive arrow arguments and cannot preserve generic-hook inference.)
- [x] `TS1005` reserved word (1, #5267) — `generateAutoImport` skips reserved words (`[class,]` was a syntax error in the bare-identifier array; reserved words can never be auto-importable bindings)
- [x] `TS8013` non-null assertions (9) — `__VLS_nonNull(x)` helper replaces `x!`
- [x] **TS-only syntax in JS blocks** (`TS8010` 43 + `TS8008` 35 + `TS8016` 35 + `TS8009` 9 = **122**) — every type-only construct in codegen is now routed through lang-aware helpers (`asType` / `generateTypedVar` / `generateTypeAlias`) that emit JSDoc casts (`/** @type {T} */ (exp)`) and `/** @typedef {T} name */` under `lang="js"`, keeping identical TS output otherwise. The compiler macros (`defineProps`, …) are now declared with a hoisted `import { … } from 'vue'` instead of `declare const … : typeof import('vue')`, which is valid and identically typed in both languages; emitted after all user content so that:
  - leading `// @ts-nocheck` comments (#3414) and `/// <reference>` directives (#2472) stay ahead of any statement;
  - the import-section/content junction stays intact, so missing-semicolon parse errors still map back (#5071);
  - import hoisting makes the declaration order irrelevant (no use-before-assignment in JS).
- [x] local type helpers in JS mode — `__VLS_WithDefaults` / `__VLS_PrettifyLocal` / `__VLS_WithSlots` / `__VLS_PropsChildren` / `__VLS_TypePropsToOption` / `__VLS_OmitIndexSignature` now emit `@template` + `@typedef` JSDoc forms instead of bare `type` aliases (unmapped `TS8008` whenever a JS SFC used `withDefaults`, inherited-attrs props, `jsxSlots`, or typed slots). `__VLS_PropsChildren` keeps its "global `JSX` may not exist" guard as a single-line typedef covered by a preceding `// @ts-ignore` (unused `@ts-ignore` is not penalized in JS).
- [x] vSlot params verification arrow — `) => [] as any` now degrades to `/** @type {any} */ ([])` in JS mode.
- [x] macro import gating — the hoisted `import { defineProps, … } from 'vue'` is no longer emitted for `<script src>` + `<script setup>` SFCs, where the setup content is never embedded and the import would be unused.

## Verification

`packages/tsc/tests/unmapped-diagnostics.spec.ts` collects every diagnostic that `transformDiagnostic` drops, re-maps without the `shouldReportDiagnostics` filter, and requires the truly-unmapped set to be empty.

Additionally verified by flipping `test-workspace/tsconfig.base.json` to `strict: true` + `checkJs: true` and re-running the gate: still **0** unmapped diagnostics (only expected mapped-region differences in `_failed_*` fixtures). This rules out latent strict-only families (e.g. `TS2454` use-before-assignment on synthetic `var`s) for all fixture shapes.

