### PR TITLE
fix(language-core): support calling template bindings without .value

### DIFF
--- a/packages/language-core/lib/codegen/script/template.ts
+++ b/packages/language-core/lib/codegen/script/template.ts
@@ -14,7 +14,7 @@ export function* generateTemplate(
 	yield* generateTemplateDirectives(options);
 
 	for (const name of options.withDotValueBindings) {
-		yield `${names.withDotValue}(${name}, {} as import('${options.vueCompilerOptions.lib}').Ref)${endOfLine}`;
+		yield `${names.withDotValue}(${name}, {} as import('${options.vueCompilerOptions.lib}').Ref<unknown>)${endOfLine}`;
 	}
 
 	if (options.templateAndStyleCodes.length) {

--- a/packages/language-core/lib/codegen/template/context.ts
+++ b/packages/language-core/lib/codegen/template/context.ts
@@ -161,6 +161,7 @@ export function createTemplateCodegenContext() {
 	// context accesses -----------------------------------------------------------
 
 	const contextAccesses = new Map<string, Map<string, Set<number>>>();
+	const callAccessedBindings = new Set<string>();
 
 	function accessVariable(source: string, name: string, offset?: number) {
 		let map = contextAccesses.get(name);
@@ -174,6 +175,10 @@ export function createTemplateCodegenContext() {
 		if (offset !== undefined) {
 			arr.add(offset);
 		}
+	}
+
+	function accessVariableAsCall(name: string) {
+		callAccessedBindings.add(name);
 	}
 
 	function* generateAutoImport(): Generator<Code> {
@@ -268,6 +273,8 @@ export function createTemplateCodegenContext() {
 		scope,
 		contextAccesses,
 		accessVariable,
+		callAccessedBindings,
+		accessVariableAsCall,
 		generateAutoImport,
 		conditions,
 		generateConditionGuards,

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -168,13 +168,31 @@ export function* generateEventExpression(
 			const scope = ctx.scope();
 			scope.declare('$event');
 			yield* ctx.generateConditionGuards();
+
+			// The top-level `__VLS_withDotValue` assertion does not narrow imported
+			// bindings inside this closure (TS control-flow limitation), so re-assert
+			// the setup bindings that are called by this handler right here. Only
+			// called bindings are re-asserted: for local bindings the top-level
+			// assertion already flows into this closure, and re-asserting non-call
+			// accesses would double-narrow them.
+			const before = new Set(ctx.callAccessedBindings);
+			const codes: Code[] = [];
+			for (const code of interpolation) {
+				codes.push(code);
+			}
+			for (const name of ctx.callAccessedBindings) {
+				if (!before.has(name) && options.setupBindings.has(name)) {
+					yield `${names.withDotValue}(${name}, {} as import('${options.vueCompilerOptions.lib}').Ref<unknown>)${endOfLine}`;
+				}
+			}
+
 			if (isSingleExpression(options.typescript, ast)) {
 				yield `return (`;
-				yield* interpolation;
+				yield* codes;
 				yield `)`;
 			}
 			else {
-				yield* interpolation;
+				yield* codes;
 			}
 			yield endOfLine;
 			yield* scope.end();

--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -175,13 +175,13 @@ export function* generateEventExpression(
 			// called bindings are re-asserted: for local bindings the top-level
 			// assertion already flows into this closure, and re-asserting non-call
 			// accesses would double-narrow them.
-			const before = new Set(ctx.callAccessedBindings);
+			ctx.callAccessedBindings.clear();
 			const codes: Code[] = [];
 			for (const code of interpolation) {
 				codes.push(code);
 			}
 			for (const name of ctx.callAccessedBindings) {
-				if (!before.has(name) && options.setupBindings.has(name)) {
+				if (options.setupBindings.has(name)) {
 					yield `${names.withDotValue}(${name}, {} as import('${options.vueCompilerOptions.lib}').Ref<unknown>)${endOfLine}`;
 				}
 			}

--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -192,13 +192,12 @@ function* forEachIdentifiers(
 
 	const scope = ctx.scope();
 	const ast = getTypeScriptAST(ts, block, prefix + code + suffix);
-	const callIdentifiers = new Set<ts.Identifier>();
-	for (const [id, isShorthand] of forEachDeclarations(ts, ast, ast, ctx, scope, callIdentifiers)) {
+	for (const [id, isShorthand, isCall] of forEachDeclarations(ts, ast, ast, ctx, scope, false)) {
 		const text = getNodeText(ts, id, ast);
 		if (shouldIdentifierSkipped(ctx, text)) {
 			continue;
 		}
-		yield [text, getStartEnd(ts, id, ast).start - prefix.length, isShorthand, callIdentifiers.has(id)];
+		yield [text, getStartEnd(ts, id, ast).start - prefix.length, isShorthand, isCall];
 	}
 	scope.end();
 }
@@ -209,61 +208,88 @@ function* forEachDeclarations(
 	ast: ts.SourceFile,
 	ctx: TemplateCodegenContext,
 	scope: ReturnType<TemplateCodegenContext['scope']>,
-	callIdentifiers: Set<ts.Identifier>,
-): Generator<[ts.Identifier, boolean]> {
+	inCallPosition: boolean,
+): Generator<[ts.Identifier, boolean, boolean]> {
 	if (ts.isIdentifier(node)) {
-		yield [node, false];
+		yield [node, false, inCallPosition];
 	}
 	else if (ts.isShorthandPropertyAssignment(node)) {
-		yield [node.name, true];
+		yield [node.name, true, inCallPosition];
 	}
 	else if (ts.isPropertyAccessExpression(node)) {
-		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope, callIdentifiers);
+		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope, false);
 	}
 	else if (ts.isCallExpression(node)) {
-		if (ts.isIdentifier(node.expression)) {
-			callIdentifiers.add(node.expression);
-		}
-		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope, callIdentifiers);
+		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope, true);
 		for (const arg of node.arguments) {
-			yield* forEachDeclarations(ts, arg, ast, ctx, scope, callIdentifiers);
+			yield* forEachDeclarations(ts, arg, ast, ctx, scope, false);
 		}
+	}
+	else if (ts.isTaggedTemplateExpression(node)) {
+		yield* forEachDeclarations(ts, node.tag, ast, ctx, scope, true);
+		yield* forEachDeclarations(ts, node.template, ast, ctx, scope, false);
+	}
+	else if (ts.isParenthesizedExpression(node)) {
+		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope, inCallPosition);
+	}
+	else if (ts.isNonNullExpression(node)) {
+		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope, inCallPosition);
+	}
+	else if (ts.isTypeAssertionExpression(node)) {
+		yield* forEachDeclarationsInTypeNode(ts, node.type);
+		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope, inCallPosition);
+	}
+	else if (ts.isAsExpression(node) || ts.isSatisfiesExpression(node)) {
+		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope, inCallPosition);
+		yield* forEachDeclarationsInTypeNode(ts, node.type);
+	}
+	else if (ts.isBinaryExpression(node)) {
+		const isLogical = node.operatorToken.kind === ts.SyntaxKind.BarBarToken
+			|| node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+			|| node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken;
+		yield* forEachDeclarations(ts, node.left, ast, ctx, scope, isLogical ? inCallPosition : false);
+		yield* forEachDeclarations(ts, node.right, ast, ctx, scope, isLogical ? inCallPosition : false);
+	}
+	else if (ts.isConditionalExpression(node)) {
+		yield* forEachDeclarations(ts, node.condition, ast, ctx, scope, false);
+		yield* forEachDeclarations(ts, node.whenTrue, ast, ctx, scope, inCallPosition);
+		yield* forEachDeclarations(ts, node.whenFalse, ast, ctx, scope, inCallPosition);
 	}
 	else if (ts.isVariableDeclaration(node)) {
 		scope.declare(...collectBindingNames(ts, node.name, ast));
-		yield* forEachDeclarationsInBinding(ts, node, ast, ctx, scope, callIdentifiers);
+		yield* forEachDeclarationsInBinding(ts, node, ast, ctx, scope);
 	}
 	else if (ts.isArrayBindingPattern(node) || ts.isObjectBindingPattern(node)) {
 		for (const element of node.elements) {
 			if (ts.isBindingElement(element)) {
-				yield* forEachDeclarationsInBinding(ts, element, ast, ctx, scope, callIdentifiers);
+				yield* forEachDeclarationsInBinding(ts, element, ast, ctx, scope);
 			}
 		}
 	}
 	else if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
-		yield* forEachDeclarationsInFunction(ts, node, ast, ctx, callIdentifiers);
+		yield* forEachDeclarationsInFunction(ts, node, ast, ctx);
 	}
 	else if (ts.isObjectLiteralExpression(node)) {
 		for (const prop of node.properties) {
 			if (ts.isPropertyAssignment(prop)) {
 				// fix https://github.com/vuejs/language-tools/issues/1176
 				if (ts.isComputedPropertyName(prop.name)) {
-					yield* forEachDeclarations(ts, prop.name.expression, ast, ctx, scope, callIdentifiers);
+					yield* forEachDeclarations(ts, prop.name.expression, ast, ctx, scope, false);
 				}
-				yield* forEachDeclarations(ts, prop.initializer, ast, ctx, scope, callIdentifiers);
+				yield* forEachDeclarations(ts, prop.initializer, ast, ctx, scope, false);
 			}
 			// fix https://github.com/vuejs/language-tools/issues/1156
 			else if (ts.isShorthandPropertyAssignment(prop)) {
-				yield* forEachDeclarations(ts, prop, ast, ctx, scope, callIdentifiers);
+				yield* forEachDeclarations(ts, prop, ast, ctx, scope, false);
 			}
 			// fix https://github.com/vuejs/language-tools/issues/1148#issuecomment-1094378126
 			else if (ts.isSpreadAssignment(prop)) {
 				// TODO: cannot report "Spread types may only be created from object types.ts(2698)"
-				yield* forEachDeclarations(ts, prop.expression, ast, ctx, scope, callIdentifiers);
+				yield* forEachDeclarations(ts, prop.expression, ast, ctx, scope, false);
 			}
 			// fix https://github.com/vuejs/language-tools/issues/4604
 			else if (ts.isFunctionLike(prop) && prop.body) {
-				yield* forEachDeclarationsInFunction(ts, prop, ast, ctx, callIdentifiers);
+				yield* forEachDeclarationsInFunction(ts, prop, ast, ctx);
 			}
 		}
 	}
@@ -274,13 +300,13 @@ function* forEachDeclarations(
 	else if (ts.isBlock(node)) {
 		const scope = ctx.scope();
 		for (const child of forEachNode(ts, node)) {
-			yield* forEachDeclarations(ts, child, ast, ctx, scope, callIdentifiers);
+			yield* forEachDeclarations(ts, child, ast, ctx, scope, false);
 		}
 		scope.end();
 	}
 	else {
 		for (const child of forEachNode(ts, node)) {
-			yield* forEachDeclarations(ts, child, ast, ctx, scope, callIdentifiers);
+			yield* forEachDeclarations(ts, child, ast, ctx, scope, false);
 		}
 	}
 }
@@ -291,16 +317,15 @@ function* forEachDeclarationsInBinding(
 	ast: ts.SourceFile,
 	ctx: TemplateCodegenContext,
 	scope: ReturnType<TemplateCodegenContext['scope']>,
-	callIdentifiers: Set<ts.Identifier>,
-): Generator<[ts.Identifier, boolean]> {
+): Generator<[ts.Identifier, boolean, boolean]> {
 	if ('type' in node && node.type) {
 		yield* forEachDeclarationsInTypeNode(ts, node.type);
 	}
 	if (!ts.isIdentifier(node.name)) {
-		yield* forEachDeclarations(ts, node.name, ast, ctx, scope, callIdentifiers);
+		yield* forEachDeclarations(ts, node.name, ast, ctx, scope, false);
 	}
 	if (node.initializer) {
-		yield* forEachDeclarations(ts, node.initializer, ast, ctx, scope, callIdentifiers);
+		yield* forEachDeclarations(ts, node.initializer, ast, ctx, scope, false);
 	}
 }
 
@@ -309,15 +334,14 @@ function* forEachDeclarationsInFunction(
 	node: ts.ArrowFunction | ts.FunctionExpression | ts.AccessorDeclaration | ts.MethodDeclaration,
 	ast: ts.SourceFile,
 	ctx: TemplateCodegenContext,
-	callIdentifiers: Set<ts.Identifier>,
-): Generator<[ts.Identifier, boolean]> {
+): Generator<[ts.Identifier, boolean, boolean]> {
 	const scope = ctx.scope();
 	for (const param of node.parameters) {
 		scope.declare(...collectBindingNames(ts, param.name, ast));
-		yield* forEachDeclarationsInBinding(ts, param, ast, ctx, scope, callIdentifiers);
+		yield* forEachDeclarationsInBinding(ts, param, ast, ctx, scope);
 	}
 	if (node.body) {
-		yield* forEachDeclarations(ts, node.body, ast, ctx, scope, callIdentifiers);
+		yield* forEachDeclarations(ts, node.body, ast, ctx, scope, false);
 	}
 	scope.end();
 }
@@ -325,13 +349,13 @@ function* forEachDeclarationsInFunction(
 function* forEachDeclarationsInTypeNode(
 	ts: typeof import('typescript'),
 	node: ts.Node,
-): Generator<[ts.Identifier, boolean]> {
+): Generator<[ts.Identifier, boolean, boolean]> {
 	if (ts.isTypeQueryNode(node)) {
 		let id = node.exprName;
 		while (!ts.isIdentifier(id)) {
 			id = id.left;
 		}
-		yield [id, false];
+		yield [id, false, false];
 	}
 	else {
 		for (const child of forEachNode(ts, node)) {

--- a/packages/language-core/lib/codegen/template/interpolation.ts
+++ b/packages/language-core/lib/codegen/template/interpolation.ts
@@ -34,7 +34,7 @@ export function* generateInterpolation(
 
 	let prevEnd = 0;
 	for (
-		const [name, offset, isShorthand] of forEachIdentifiers(
+		const [name, offset, isShorthand, isCall] of forEachIdentifiers(
 			typescript,
 			ctx,
 			block,
@@ -89,6 +89,9 @@ export function* generateInterpolation(
 		}
 		else if (setupBindings.has(name)) {
 			ctx.accessVariable(block.name, name, start + offset);
+			if (isCall) {
+				ctx.accessVariableAsCall(name);
+			}
 			yield [
 				name,
 				block.name,
@@ -97,7 +100,9 @@ export function* generateInterpolation(
 					? { ...data, __shorthandExpression: 'js' }
 					: data,
 			];
-			yield `.value`;
+			if (!isCall) {
+				yield `.value`;
+			}
 		}
 		else {
 			// #1205, #1264
@@ -179,20 +184,21 @@ function* forEachIdentifiers(
 	code: string,
 	prefix: string,
 	suffix: string,
-): Generator<[string, number, boolean]> {
+): Generator<[string, number, boolean, boolean]> {
 	if (identifierRE.test(code) && !shouldIdentifierSkipped(ctx, code)) {
-		yield [code, 0, false];
+		yield [code, 0, false, false];
 		return;
 	}
 
 	const scope = ctx.scope();
 	const ast = getTypeScriptAST(ts, block, prefix + code + suffix);
-	for (const [id, isShorthand] of forEachDeclarations(ts, ast, ast, ctx, scope)) {
+	const callIdentifiers = new Set<ts.Identifier>();
+	for (const [id, isShorthand] of forEachDeclarations(ts, ast, ast, ctx, scope, callIdentifiers)) {
 		const text = getNodeText(ts, id, ast);
 		if (shouldIdentifierSkipped(ctx, text)) {
 			continue;
 		}
-		yield [text, getStartEnd(ts, id, ast).start - prefix.length, isShorthand];
+		yield [text, getStartEnd(ts, id, ast).start - prefix.length, isShorthand, callIdentifiers.has(id)];
 	}
 	scope.end();
 }
@@ -203,6 +209,7 @@ function* forEachDeclarations(
 	ast: ts.SourceFile,
 	ctx: TemplateCodegenContext,
 	scope: ReturnType<TemplateCodegenContext['scope']>,
+	callIdentifiers: Set<ts.Identifier>,
 ): Generator<[ts.Identifier, boolean]> {
 	if (ts.isIdentifier(node)) {
 		yield [node, false];
@@ -211,43 +218,52 @@ function* forEachDeclarations(
 		yield [node.name, true];
 	}
 	else if (ts.isPropertyAccessExpression(node)) {
-		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope);
+		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope, callIdentifiers);
+	}
+	else if (ts.isCallExpression(node)) {
+		if (ts.isIdentifier(node.expression)) {
+			callIdentifiers.add(node.expression);
+		}
+		yield* forEachDeclarations(ts, node.expression, ast, ctx, scope, callIdentifiers);
+		for (const arg of node.arguments) {
+			yield* forEachDeclarations(ts, arg, ast, ctx, scope, callIdentifiers);
+		}
 	}
 	else if (ts.isVariableDeclaration(node)) {
 		scope.declare(...collectBindingNames(ts, node.name, ast));
-		yield* forEachDeclarationsInBinding(ts, node, ast, ctx, scope);
+		yield* forEachDeclarationsInBinding(ts, node, ast, ctx, scope, callIdentifiers);
 	}
 	else if (ts.isArrayBindingPattern(node) || ts.isObjectBindingPattern(node)) {
 		for (const element of node.elements) {
 			if (ts.isBindingElement(element)) {
-				yield* forEachDeclarationsInBinding(ts, element, ast, ctx, scope);
+				yield* forEachDeclarationsInBinding(ts, element, ast, ctx, scope, callIdentifiers);
 			}
 		}
 	}
 	else if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
-		yield* forEachDeclarationsInFunction(ts, node, ast, ctx);
+		yield* forEachDeclarationsInFunction(ts, node, ast, ctx, callIdentifiers);
 	}
 	else if (ts.isObjectLiteralExpression(node)) {
 		for (const prop of node.properties) {
 			if (ts.isPropertyAssignment(prop)) {
 				// fix https://github.com/vuejs/language-tools/issues/1176
 				if (ts.isComputedPropertyName(prop.name)) {
-					yield* forEachDeclarations(ts, prop.name.expression, ast, ctx, scope);
+					yield* forEachDeclarations(ts, prop.name.expression, ast, ctx, scope, callIdentifiers);
 				}
-				yield* forEachDeclarations(ts, prop.initializer, ast, ctx, scope);
+				yield* forEachDeclarations(ts, prop.initializer, ast, ctx, scope, callIdentifiers);
 			}
 			// fix https://github.com/vuejs/language-tools/issues/1156
 			else if (ts.isShorthandPropertyAssignment(prop)) {
-				yield* forEachDeclarations(ts, prop, ast, ctx, scope);
+				yield* forEachDeclarations(ts, prop, ast, ctx, scope, callIdentifiers);
 			}
 			// fix https://github.com/vuejs/language-tools/issues/1148#issuecomment-1094378126
 			else if (ts.isSpreadAssignment(prop)) {
 				// TODO: cannot report "Spread types may only be created from object types.ts(2698)"
-				yield* forEachDeclarations(ts, prop.expression, ast, ctx, scope);
+				yield* forEachDeclarations(ts, prop.expression, ast, ctx, scope, callIdentifiers);
 			}
 			// fix https://github.com/vuejs/language-tools/issues/4604
 			else if (ts.isFunctionLike(prop) && prop.body) {
-				yield* forEachDeclarationsInFunction(ts, prop, ast, ctx);
+				yield* forEachDeclarationsInFunction(ts, prop, ast, ctx, callIdentifiers);
 			}
 		}
 	}
@@ -258,13 +274,13 @@ function* forEachDeclarations(
 	else if (ts.isBlock(node)) {
 		const scope = ctx.scope();
 		for (const child of forEachNode(ts, node)) {
-			yield* forEachDeclarations(ts, child, ast, ctx, scope);
+			yield* forEachDeclarations(ts, child, ast, ctx, scope, callIdentifiers);
 		}
 		scope.end();
 	}
 	else {
 		for (const child of forEachNode(ts, node)) {
-			yield* forEachDeclarations(ts, child, ast, ctx, scope);
+			yield* forEachDeclarations(ts, child, ast, ctx, scope, callIdentifiers);
 		}
 	}
 }
@@ -275,15 +291,16 @@ function* forEachDeclarationsInBinding(
 	ast: ts.SourceFile,
 	ctx: TemplateCodegenContext,
 	scope: ReturnType<TemplateCodegenContext['scope']>,
+	callIdentifiers: Set<ts.Identifier>,
 ): Generator<[ts.Identifier, boolean]> {
 	if ('type' in node && node.type) {
 		yield* forEachDeclarationsInTypeNode(ts, node.type);
 	}
 	if (!ts.isIdentifier(node.name)) {
-		yield* forEachDeclarations(ts, node.name, ast, ctx, scope);
+		yield* forEachDeclarations(ts, node.name, ast, ctx, scope, callIdentifiers);
 	}
 	if (node.initializer) {
-		yield* forEachDeclarations(ts, node.initializer, ast, ctx, scope);
+		yield* forEachDeclarations(ts, node.initializer, ast, ctx, scope, callIdentifiers);
 	}
 }
 
@@ -292,14 +309,15 @@ function* forEachDeclarationsInFunction(
 	node: ts.ArrowFunction | ts.FunctionExpression | ts.AccessorDeclaration | ts.MethodDeclaration,
 	ast: ts.SourceFile,
 	ctx: TemplateCodegenContext,
+	callIdentifiers: Set<ts.Identifier>,
 ): Generator<[ts.Identifier, boolean]> {
 	const scope = ctx.scope();
 	for (const param of node.parameters) {
 		scope.declare(...collectBindingNames(ts, param.name, ast));
-		yield* forEachDeclarationsInBinding(ts, param, ast, ctx, scope);
+		yield* forEachDeclarationsInBinding(ts, param, ast, ctx, scope, callIdentifiers);
 	}
 	if (node.body) {
-		yield* forEachDeclarations(ts, node.body, ast, ctx, scope);
+		yield* forEachDeclarations(ts, node.body, ast, ctx, scope, callIdentifiers);
 	}
 	scope.end();
 }

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -135,7 +135,9 @@ declare global {
 	function __VLS_asFunctionalSlot<S>(slot: S): S extends () => infer R ? (props: {}) => R : NonNullable<S>;
 	function __VLS_omit<T, K>(target: T, props: K): Omit<T, keyof K>;
 	function __VLS_tryAsConstant<const T>(t: T): T;
-	function __VLS_withDotValue<T, Ref>(t: T, ref: Ref): asserts t is T extends Ref ? T : T & { value: T };
+	function __VLS_withDotValue<T, Ref>(t: T, ref: Ref): asserts t is T extends Ref
+		? T extends { value: infer V } ? V extends (...args: any) => any ? T & V : T : T
+		: T & { value: T };
 }
 
 export {};

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -135,8 +135,10 @@ declare global {
 	function __VLS_asFunctionalSlot<S>(slot: S): S extends () => infer R ? (props: {}) => R : NonNullable<S>;
 	function __VLS_omit<T, K>(target: T, props: K): Omit<T, keyof K>;
 	function __VLS_tryAsConstant<const T>(t: T): T;
-	function __VLS_withDotValue<T, Ref>(t: T, ref: Ref): asserts t is T extends Ref
-		? T extends { value: infer V } ? V extends (...args: any) => any ? T & V : T : T
+	function __VLS_withDotValue<T, Ref>(
+		t: T,
+		ref: Ref,
+	): asserts t is T extends Ref ? T extends { value: infer V } ? V extends (...args: any) => any ? T & V : T : T
 		: T & { value: T };
 }
 

--- a/packages/tsc/tests/typecheck.spec.ts
+++ b/packages/tsc/tests/typecheck.spec.ts
@@ -43,6 +43,10 @@ test(`vue-tsc`, () => {
 		  "test-workspace/tsc/useTemplateRef-dynamic-arg/main.vue(3,7): error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.",
 		  "test-workspace/tsc/useTemplateRef-nullable/main.vue(3,5): error TS18047: 'foo.value' is possibly 'null'.",
 		  "test-workspace/tsc/useTemplateRef-nullable/main.vue(3,9): error TS2339: Property 'bar' does not exist on type 'HTMLInputElement'.",
+		  "test-workspace/tsc/withDotValue/main.vue(2,25): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
+		  "test-workspace/tsc/withDotValue/main.vue(3,17): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
+		  "test-workspace/tsc/withDotValue/main.vue(4,28): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
+		  "test-workspace/tsc/withDotValue/main.vue(5,20): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
 		]
 	`);
 });

--- a/packages/tsc/tests/typecheck.spec.ts
+++ b/packages/tsc/tests/typecheck.spec.ts
@@ -43,11 +43,15 @@ test(`vue-tsc`, () => {
 		  "test-workspace/tsc/useTemplateRef-dynamic-arg/main.vue(3,7): error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.",
 		  "test-workspace/tsc/useTemplateRef-nullable/main.vue(3,5): error TS18047: 'foo.value' is possibly 'null'.",
 		  "test-workspace/tsc/useTemplateRef-nullable/main.vue(3,9): error TS2339: Property 'bar' does not exist on type 'HTMLInputElement'.",
+		  "test-workspace/tsc/withDotValue/main.vue(10,19): error TS2740: Type 'TemplateStringsArray' is missing the following properties from type 'Event': bubbles, cancelBubble, cancelable, composed, and 18 more.",
 		  "test-workspace/tsc/withDotValue/main.vue(2,25): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
 		  "test-workspace/tsc/withDotValue/main.vue(3,17): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
 		  "test-workspace/tsc/withDotValue/main.vue(4,28): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
 		  "test-workspace/tsc/withDotValue/main.vue(5,28): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
 		  "test-workspace/tsc/withDotValue/main.vue(6,20): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
+		  "test-workspace/tsc/withDotValue/main.vue(7,24): error TS2740: Type 'TemplateStringsArray' is missing the following properties from type 'Event': bubbles, cancelBubble, cancelable, composed, and 18 more.",
+		  "test-workspace/tsc/withDotValue/main.vue(8,16): error TS2740: Type 'TemplateStringsArray' is missing the following properties from type 'Event': bubbles, cancelBubble, cancelable, composed, and 18 more.",
+		  "test-workspace/tsc/withDotValue/main.vue(9,27): error TS2740: Type 'TemplateStringsArray' is missing the following properties from type 'Event': bubbles, cancelBubble, cancelable, composed, and 18 more.",
 		]
 	`);
 });

--- a/packages/tsc/tests/typecheck.spec.ts
+++ b/packages/tsc/tests/typecheck.spec.ts
@@ -46,7 +46,8 @@ test(`vue-tsc`, () => {
 		  "test-workspace/tsc/withDotValue/main.vue(2,25): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
 		  "test-workspace/tsc/withDotValue/main.vue(3,17): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
 		  "test-workspace/tsc/withDotValue/main.vue(4,28): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
-		  "test-workspace/tsc/withDotValue/main.vue(5,20): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
+		  "test-workspace/tsc/withDotValue/main.vue(5,28): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
+		  "test-workspace/tsc/withDotValue/main.vue(6,20): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Event'.",
 		]
 	`);
 });

--- a/test-workspace/tsc/tsconfig.json
+++ b/test-workspace/tsc/tsconfig.json
@@ -675,6 +675,9 @@
 		},
 		{
 			"path": "./withDefaults/tsconfig.json"
+		},
+		{
+			"path": "./withDotValue/tsconfig.json"
 		}
 	]
 }

--- a/test-workspace/tsc/withDotValue/helper.ts
+++ b/test-workspace/tsc/withDotValue/helper.ts
@@ -1,0 +1,1 @@
+export function helper(_e: Event) {}

--- a/test-workspace/tsc/withDotValue/main.vue
+++ b/test-workspace/tsc/withDotValue/main.vue
@@ -4,6 +4,10 @@
 	<button @click="refHelper(123)"></button>
 	<button @click="refHelper(456)"></button>
 	<div>{{ refHelper(123) }}</div>
+	<button @click="helper`foo`"></button>
+	<div>{{ helper`foo` }}</div>
+	<button @click="refHelper`foo`"></button>
+	<div>{{ refHelper`foo` }}</div>
 </template>
 <script setup lang="ts">
 import { helper } from './helper';

--- a/test-workspace/tsc/withDotValue/main.vue
+++ b/test-workspace/tsc/withDotValue/main.vue
@@ -2,6 +2,7 @@
 	<button @click="helper(123)"></button>
 	<div>{{ helper(123) }}</div>
 	<button @click="refHelper(123)"></button>
+	<button @click="refHelper(456)"></button>
 	<div>{{ refHelper(123) }}</div>
 </template>
 <script setup lang="ts">

--- a/test-workspace/tsc/withDotValue/main.vue
+++ b/test-workspace/tsc/withDotValue/main.vue
@@ -1,0 +1,10 @@
+<template>
+	<button @click="helper(123)"></button>
+	<div>{{ helper(123) }}</div>
+	<button @click="refHelper(123)"></button>
+	<div>{{ refHelper(123) }}</div>
+</template>
+<script setup lang="ts">
+import { helper } from './helper';
+import { refHelper } from './refHelper';
+</script>

--- a/test-workspace/tsc/withDotValue/refHelper.ts
+++ b/test-workspace/tsc/withDotValue/refHelper.ts
@@ -1,0 +1,2 @@
+import { ref } from 'vue';
+export const refHelper = ref((_e: Event) => {});

--- a/test-workspace/tsc/withDotValue/tsconfig.json
+++ b/test-workspace/tsc/withDotValue/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../tsconfig.base.json", "include": ["**/*"] }


### PR DESCRIPTION
## Problem

Template expressions that reference a setup binding (a "maybe ref" — could be a `ref` or a plain value) used to always append `.value` and lean on `__VLS_withDotValue` to justify it. That assertion is a no-op for **function declarations**: `asserts t is fn & { value: fn }` does not add `.value` to a function, so a function binding became `fn.value(...)` → TS2339 on an unmapped region → silently dropped, and the call was never type-checked.

## Solution

- `generateInterpolation` now propagates a **call position** through the callee subtree. A binding that is being called no longer gets `.value`, whether the callee is a direct identifier (`fn(1)`), grouped (`(fn)(1)`), a logical/binary operand (`(fn || g)(1)`), a conditional branch, a type assertion, or a tagged-template tag (`` fn`x` ``).
- Property/element-access receivers, call arguments and conditions still get `.value`.
- `__VLS_withDotValue` narrows three cases:
  - non-ref (function or otherwise) → `T & { value: T }`
  - ref + non-function → `T`
  - ref + function → `T & V` (callable)
- The helper is re-asserted inside event-handler closures, since the top-level assertion does not narrow imported bindings within a closure.
- `{} as Ref` → `{} as Ref<unknown>` so the second argument's `value: any` no longer leaks into the narrowing of union refs.

## Tests

`test-workspace/tsc/withDotValue` covers `@click` / `{{ }}` with a plain function and a `ref(fn)`, including tagged-template call sites and a binding called from two handlers.

## Known issue / next step

Value-position function bindings still fail: `foo(bar)` (argument) and `{ foo: bar }` (shorthand) append `.value` to `bar`, and `withDotValue` cannot add `.value` to function declarations. The plan is to move **read** positions to a structural `__VLS_unwrap(...)` helper — its return type is a conditional, so it works for functions — and keep `.value` + `withDotValue` only where narrowing (`v-if`) or assignment (`v-model`) is required.
