### PR TITLE
fix(language-core): keep union props when using withDefaults (#6180)

### DIFF
--- a/packages/language-core/lib/codegen/localTypes.ts
+++ b/packages/language-core/lib/codegen/localTypes.ts
@@ -9,7 +9,7 @@ export function getLocalTypesGenerator(vueCompilerOptions: VueCompilerOptions) {
 		() =>
 			`
 type __VLS_WithDefaults<P, D> = {
-	[K in keyof Pick<P, keyof P>]: K extends keyof D
+	[K in keyof P & string]: K extends keyof D
 		? ${PrettifyLocal.name}<P[K] & { default: D[K] }>
 		: P[K]
 };
@@ -55,7 +55,7 @@ type __VLS_PropsChildren<S> = {
 		() =>
 			`
 type __VLS_TypePropsToOption<T> = {
-	[K in keyof T]-?: {} extends Pick<T, K>
+	[K in keyof T & string]-?: {} extends Pick<T, K>
 		? { type: import('${vueCompilerOptions.lib}').PropType<Required<T>[K]> }
 		: { type: import('${vueCompilerOptions.lib}').PropType<T[K]>, required: true }
 };

--- a/test-workspace/tsc/#6180/Button.vue
+++ b/test-workspace/tsc/#6180/Button.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+interface SharedProps {
+	size?: 'sm' | 'md' | 'lg';
+}
+
+interface NativeProps extends SharedProps {
+	as?: 'button';
+	type?: 'button' | 'submit';
+	href?: never;
+}
+
+interface LinkProps extends SharedProps {
+	as: 'a';
+	href: string;
+	type?: never;
+}
+
+type Props = NativeProps | LinkProps;
+
+withDefaults(defineProps<Props>(), {
+	as: 'button',
+	type: 'button',
+	size: 'md',
+});
+</script>
+
+<template>
+	<slot />
+</template>

--- a/test-workspace/tsc/#6180/main.vue
+++ b/test-workspace/tsc/#6180/main.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { exactType } from '../shared';
+import Button from './Button.vue';
+
+type Props = InstanceType<typeof Button>['$props'];
+
+// #6180: withDefaults + discriminated union must not collapse to Record<string, any>
+exactType({} as string extends keyof Props ? true : false, false);
+</script>
+
+<template>
+	<Button as="a" href="/" />
+</template>

--- a/test-workspace/tsc/#6180/tsconfig.json
+++ b/test-workspace/tsc/#6180/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"vueCompilerOptions": {
+		"target": 3.5
+	},
+	"include": ["**/*"]
+}

--- a/test-workspace/tsc/tsconfig.json
+++ b/test-workspace/tsc/tsconfig.json
@@ -527,6 +527,9 @@
 			"path": "./#6094/tsconfig.json"
 		},
 		{
+			"path": "./#6180/tsconfig.json"
+		},
+		{
 			"path": "./#625/tsconfig.json"
 		},
 		{


### PR DESCRIPTION
## Summary
- Fixes https://github.com/vuejs/language-tools/issues/6180: `withDefaults(defineProps<A | B>())` no longer emits `DefineSetupFnComponent<Record<string, any>>`.
- Homomorphic `[K in keyof T]` distributed `__VLS_TypePropsToOption` over the union, so `defineComponent`'s `props` option became two incompatible runtime option objects and fell back to the setup overload.
- Use a non-homomorphic remap (`keyof T & string` / `keyof P & string`) so runtime props stay a single object while `__typeProps` still carries the discriminated union.

## Test plan
- [x] `packages/tsc` typecheck + dts (31 tests) pass
- [x] Added `test-workspace/tsc/#6180` with `vueCompilerOptions.target: 3.5` (issue pin: Vue 3.5 + vue-tsc 3.3.x)
- [x] Declaration emit of the issue SFC keeps `DefineComponent<NativeProps | LinkProps, …>`
- [x] Controls still green: `defineProps<Union>()` without `withDefaults`, and `withDefaults` on a flat interface