### PR TITLE
fix(language-core): use 'default' slot name for bare v-slot

### DIFF
--- a/packages/language-core/lib/codegen/template/vSlot.ts
+++ b/packages/language-core/lib/codegen/template/vSlot.ts
@@ -76,24 +76,23 @@ export function* generateVSlot(
 		if (slotDir.arg?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION) {
 			isStatic = slotDir.arg.isStatic;
 		}
-		if (isStatic && !slotDir.arg) {
-			yield `// @ts-ignore${newLine}`;
-			yield `${names.nonNull}(${ctxVar}.slots)['`;
-			yield [
-				'',
-				'template',
-				slotDir.loc.start.offset + (
-					slotDir.loc.source.startsWith('#')
-						? '#'.length
-						: slotDir.loc.source.startsWith('v-slot:')
-						? 'v-slot:'.length
-						: 0
-				),
-				codeFeatures.completion,
-			];
-			yield `'/* empty slot name completion */]${endOfLine}`;
-		}
 		yield `}${newLine}`;
+		if (isStatic && !slotDir.arg) {
+			if (slotDir.loc.source.startsWith('#') || slotDir.loc.source.startsWith('v-slot:')) {
+				yield `/** @type {NonNullable<typeof ${ctxVar}['slots']>['`;
+				yield [
+					'',
+					'template',
+					slotDir.loc.start.offset + (
+						slotDir.loc.source.startsWith('#')
+							? '#'.length
+							: 'v-slot:'.length
+					),
+					codeFeatures.completion,
+				];
+				yield `']} */${endOfLine}`;
+			}
+		}
 	}
 }
 

--- a/packages/language-server/tests/completions.spec.ts
+++ b/packages/language-server/tests/completions.spec.ts
@@ -835,7 +835,7 @@ test('<script setup>', async () => {
 });
 
 test('Slot name', async () => {
-	await requestCompletionItemToTsServer(
+	const completion = await requestCompletionItemToTsServer(
 		'fixture.vue',
 		'vue',
 		`
@@ -855,6 +855,67 @@ test('Slot name', async () => {
 	`,
 		'default',
 	);
+	expect(completion.replacementSpan).toBeDefined();
+	expect((completion.replacementSpan as any).end.offset - (completion.replacementSpan as any).start.offset).toBe(0);
+});
+
+test('Slot name (v-slot:)', async () => {
+	const completion = await requestCompletionItemToTsServer(
+		'fixture.vue',
+		'vue',
+		`
+		<template>
+			<Foo>
+				<template v-slot:|></template>
+			</Foo>
+		</template>
+
+		<script lang="ts" setup>
+		let Foo: new () => {
+			$slots: {
+				default: any;
+			};
+		};
+		</script>
+		`,
+		'default',
+	);
+	expect(completion.replacementSpan).toBeDefined();
+	expect((completion.replacementSpan as any).end.offset - (completion.replacementSpan as any).start.offset).toBe(0);
+});
+
+test('Slot name (bare v-slot)', async () => {
+	const content = `
+	<template>
+		<Foo v-slot|></Foo>
+	</template>
+
+	<script lang="ts" setup>
+	let Foo: new () => {
+		$slots: {
+			default: any;
+		};
+	};
+	</script>
+	`;
+	const offset = content.indexOf('|');
+	expect(offset).toBeGreaterThanOrEqual(0);
+	const document = await prepareDocument(
+		'fixture.vue',
+		'vue',
+		content.slice(0, offset) + content.slice(offset + 1),
+	);
+	const server = await getLanguageServer();
+	const res = await server.tsserver.message({
+		seq: server.nextSeq(),
+		command: 'completions',
+		arguments: {
+			file: URI.parse(document.uri).fsPath,
+			position: offset,
+		},
+	});
+	const completions = (res.success ? res.body : undefined) as ts.CompletionEntry[] | undefined;
+	expect(completions?.find(item => item.name === 'default')).toBeUndefined();
 });
 
 test('#2454', async () => {


### PR DESCRIPTION
## Summary

A bare `v-slot` (a `v-slot` with no argument) used to codegen a slot-name completion anchor via `__VLS_nonNull(ctx.slots)['']`, silenced with `// @ts-ignore`. That empty key is not a valid slot key and reports TS7053 under `strict` / `noImplicitAny`.

This PR removes the `@ts-ignore` and eliminates TS7053 at the source: the slot-name completion anchor is now a type-level JSDoc index (`/** @type {NonNullable<typeof ctx['slots']>['']} */`) instead of a value-level slot access, so it stays a zero-length insertion without producing a diagnostic. Slot-name completion is only emitted for `#` (`<template #|>`) and `v-slot:` (`<template v-slot:|>`); a bare `v-slot` no longer emits it.

## Changes

- `packages/language-core/lib/codegen/template/vSlot.ts`
  - remove `// @ts-ignore`
  - emit the slot-name completion anchor as a type-level JSDoc index instead of a value-level `slots['']`
  - only emit it for `#` and `v-slot:`; a bare `v-slot` emits nothing here
- `packages/language-server/tests/completions.spec.ts`
  - assert the `#` / `v-slot:` completion `replacementSpan` is zero-length
  - add `Slot name (bare v-slot)` to assert a bare `v-slot` returns no `default` completion

## Notes

This removes TS7053 at the source rather than relying on `verification` filtering, so it also stays clean under the content mapper (which has no `verification` dimension in `SpanMapFeature`).
