### PR TITLE
fix(language-core): eliminate synthesized ignore in codegen

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -365,17 +365,22 @@ export function* generateSetupFunction(
 // of any statement, and the import-section/content junction stays intact.
 export function* generateMacros(options: ScriptCodegenOptions): Generator<Code> {
 	if (options.vueCompilerOptions.target >= 3.3) {
-		let emitted = false;
-		for (const macro of Object.keys(options.vueCompilerOptions.macros)) {
-			if (!options.setupBindings.has(macro)) {
-				if (!emitted) {
-					yield `// @ts-ignore${newLine}import { `;
-					emitted = true;
-				}
+		const scriptSetupRanges = options.scriptSetupRanges;
+		const usedMacros = [
+			scriptSetupRanges?.defineProps && 'defineProps',
+			scriptSetupRanges?.defineEmits && 'defineEmits',
+			scriptSetupRanges?.defineModel?.length && 'defineModel',
+			scriptSetupRanges?.defineSlots && 'defineSlots',
+			scriptSetupRanges?.defineExpose && 'defineExpose',
+			scriptSetupRanges?.defineOptions && 'defineOptions',
+			scriptSetupRanges?.withDefaults && 'withDefaults',
+		].filter((macro): macro is string => !!macro && !options.setupBindings.has(macro));
+
+		if (usedMacros.length) {
+			yield `import { `;
+			for (const macro of usedMacros) {
 				yield `${macro}, `;
 			}
-		}
-		if (emitted) {
 			yield `} from '${options.vueCompilerOptions.lib}'${endOfLine}`;
 		}
 	}

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -365,21 +365,36 @@ export function* generateSetupFunction(
 // of any statement, and the import-section/content junction stays intact.
 export function* generateMacros(options: ScriptCodegenOptions): Generator<Code> {
 	if (options.vueCompilerOptions.target >= 3.3) {
+		const scriptSetup = options.scriptSetup;
 		const scriptSetupRanges = options.scriptSetupRanges;
-		const usedMacros = [
-			scriptSetupRanges?.defineProps && 'defineProps',
-			scriptSetupRanges?.defineEmits && 'defineEmits',
-			scriptSetupRanges?.defineModel?.length && 'defineModel',
-			scriptSetupRanges?.defineSlots && 'defineSlots',
-			scriptSetupRanges?.defineExpose && 'defineExpose',
-			scriptSetupRanges?.defineOptions && 'defineOptions',
-			scriptSetupRanges?.withDefaults && 'withDefaults',
-		].filter((macro): macro is string => !!macro && !options.setupBindings.has(macro));
+		if (!scriptSetup || !scriptSetupRanges) {
+			return;
+		}
 
-		if (usedMacros.length) {
+		const usedMacros: { canonical: string; alias: string }[] = [];
+		const add = (canonical: string, exp: TextRange | undefined) => {
+			if (exp) {
+				usedMacros.push({ canonical, alias: getRangeText(scriptSetup, exp) });
+			}
+		};
+		add('defineProps', scriptSetupRanges.defineProps?.exp);
+		add('defineEmits', scriptSetupRanges.defineEmits?.exp);
+		add('defineSlots', scriptSetupRanges.defineSlots?.exp);
+		add('defineExpose', scriptSetupRanges.defineExpose?.exp);
+		add('withDefaults', scriptSetupRanges.withDefaults?.exp);
+		if (scriptSetupRanges.defineModel.length) {
+			usedMacros.push({ canonical: 'defineModel', alias: 'defineModel' });
+		}
+		if (scriptSetupRanges.defineOptions) {
+			usedMacros.push({ canonical: 'defineOptions', alias: 'defineOptions' });
+		}
+
+		const toImport = usedMacros.filter(({ alias }) => !options.setupBindings.has(alias));
+
+		if (toImport.length) {
 			yield `import { `;
-			for (const macro of usedMacros) {
-				yield `${macro}, `;
+			for (const { canonical, alias } of toImport) {
+				yield alias === canonical ? `${canonical}, ` : `${canonical} as ${alias}, `;
 			}
 			yield `} from '${options.vueCompilerOptions.lib}'${endOfLine}`;
 		}

--- a/packages/language-core/lib/codegen/template/context.ts
+++ b/packages/language-core/lib/codegen/template/context.ts
@@ -289,10 +289,14 @@ export function createTemplateCodegenContext() {
 	function* generateHoistVariables() {
 		// trick to avoid TS 4081 (#5186)
 		if (hoistVars.size) {
-			yield `// @ts-ignore${newLine}`;
 			yield `var `;
+			let first = true;
 			for (const [originalVar, hoistVar] of hoistVars) {
-				yield `${hoistVar} = ${originalVar}, `;
+				if (!first) {
+					yield `, `;
+				}
+				first = false;
+				yield `${hoistVar} = ${originalVar}!`;
 			}
 			yield endOfLine;
 		}

--- a/packages/language-core/lib/codegen/template/element.ts
+++ b/packages/language-core/lib/codegen/template/element.ts
@@ -258,14 +258,17 @@ export function* generateComponent(
 	const isSingleRoot = ctx.singleRootNodes.has(node)
 		&& !options.vueCompilerOptions.fallthroughComponentNames.includes(hyphenateTag(tag));
 	const inferRootEl = ctx.dollarVars.has('$el') || options.vueCompilerOptions.inferComponentDollarEl;
+	const inferTemplateRefs = options.vueCompilerOptions.inferTemplateDollarRefs
+		|| options.vueCompilerOptions.inferComponentDollarRefs
+		|| options.setupRefs.size > 0;
 
-	if (templateRef || (isSingleRoot && inferRootEl)) {
+	if ((templateRef && inferTemplateRefs) || (isSingleRoot && inferRootEl)) {
 		const componentInstanceVar = ctx.getInternalVariable();
 		yield* generateTypedVar('var', componentInstanceVar, options.scriptLang, function*() {
 			yield `Parameters<NonNullable<typeof ${getCtxVar()}['expose']>>[0]`;
 		});
 
-		if (templateRef) {
+		if (templateRef && inferTemplateRefs) {
 			let typeExp = `typeof ${ctx.getHoistVariable(componentInstanceVar)} | null`;
 			if (ctx.inVFor) {
 				typeExp = `(${typeExp})[]`;

--- a/test-workspace/tsc/macros-alias/main.vue
+++ b/test-workspace/tsc/macros-alias/main.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import { defineProps as dp } from 'vue';
+const props = dp<{ foo: string }>();
+</script>
+
+<template>
+	{{ props.foo }}
+</template>

--- a/test-workspace/tsc/macros-alias/tsconfig.json
+++ b/test-workspace/tsc/macros-alias/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"strict": true
+	},
+	"vueCompilerOptions": {
+		"macros": {
+			"defineProps": ["dp"]
+		}
+	},
+	"include": ["**/*"]
+}

--- a/test-workspace/tsc/tsconfig.json
+++ b/test-workspace/tsc/tsconfig.json
@@ -614,6 +614,9 @@
 			"path": "./intrinsicProps/tsconfig.json"
 		},
 		{
+			"path": "./macros-alias/tsconfig.json"
+		},
+		{
 			"path": "./namespace-component/tsconfig.json"
 		},
 		{


### PR DESCRIPTION
## Summary

Two codegen sites used a blanket `@ts-ignore` to silence synthesized diagnostics. This PR removes both `@ts-ignore`s and eliminates the diagnostics at the source.

## Changes

### Hoisted template refs

`generateHoistVariables` emitted a single `var` statement with a trailing comma and read variables declared inside loops/conditionals:

- `context.ts` — drop `// @ts-ignore`, join with `, `, and emit `${hoistVar} = ${originalVar}!` (the non-null assertion suppresses TS2454 while keeping the inferred structural type, avoiding TS4081/TS4025 in declaration emit).
- `element.ts` — only create the component-instance / hoist variables when template refs are actually inferred, so no unused variable is emitted.

Diagnostics eliminated: TS1009 (trailing comma), TS2454 ×6 (used before assigned), TS6133 (never read).

### Script setup macros

`generateMacros` imported every configured macro regardless of use, which produced unused-import diagnostics under `noUnusedLocals`:

- `scriptSetup.ts` — import only the macros actually used in this SFC (`defineProps` / `defineEmits` / `defineModel` / `defineSlots` / `defineExpose` / `defineOptions` / `withDefaults`), filtered by `setupBindings`.

Diagnostics eliminated: TS6192 (all imports unused) / TS6133 (unused import).

## Notes

The hoist initializer stays `= ${originalVar}!` rather than `!: typeof ${originalVar}` — `= y` lets TS infer and inline a structural type during declaration emit, while `typeof y` would leak the private name into the emitted `.d.ts`.

## Verification

- `npx tsc -b packages/language-core` — clean
- `npx vitest run packages/tsc/tests/unmapped-diagnostics.spec.ts` — 0 unmapped diagnostics
- `npx vitest run packages/tsc/tests/dts.spec.ts` — 30 passed (declaration emit unchanged)
- full test suite — 221 passed / 4 skipped
