### PR TITLE
fix(typescript-plugin): don't abort reference span fix-up at style-less files

### DIFF
--- a/packages/typescript-plugin/lib/common.ts
+++ b/packages/typescript-plugin/lib/common.ts
@@ -435,7 +435,7 @@ export function postprocessLanguageService<T>(
 					}
 					const styles = root.ir.styles;
 					if (!styles.length) {
-						return result;
+						continue;
 					}
 					const isInStyle = styles.some(style =>
 						reference.textSpan.start >= style.startTagEnd


### PR DESCRIPTION
Fix: when a vue file had no `<style>` block, the code gave up on all the rest for finding reference. It should keep going to find.