### PR TITLE
fix(language-core): consume synthesized $event in compound event handlers

### DIFF
--- a/packages/language-core/lib/codegen/template/elementEvents.ts
+++ b/packages/language-core/lib/codegen/template/elementEvents.ts
@@ -195,6 +195,9 @@ export function* generateEventExpression(
 
 			yield `// @ts-ignore${newLine}`;
 			yield `(...[$event]) => {${newLine}`;
+			// consume $event to avoid TS6133 when the expression doesn't use it
+			yield `void $event${endOfLine}`;
+
 			yield* generateReasserts(options, ctx, accessMark);
 			yield* ctx.generateConditionGuards();
 


### PR DESCRIPTION
Related #6170

Fix for "remaining synthesized `@ts-ignore`" > compound event handlers
- Only TS6133 can be fixed
- TS7031/TS2493 remain structural, as the `(...[$event])` shape is what preserves contextual typing of `$event`.