### PR TITLE
fix(language-core): eliminate synthesized ignore for style scoped classes alias

### DIFF
--- a/packages/language-core/lib/codegen/style/scopedClasses.ts
+++ b/packages/language-core/lib/codegen/style/scopedClasses.ts
@@ -2,7 +2,7 @@ import type { Code } from '../../types';
 import { names } from '../names';
 import type { TemplateCodegenContext } from '../template/context';
 import { generateStyleScopedClassReference } from '../template/styleScopedClasses';
-import { generateTypeAlias, newLine } from '../utils';
+import { endOfLine, generateTypeAlias, isTsLang } from '../utils';
 import type { StyleCodegenOptions } from '.';
 import { generateClassProperty, generateStyleImports } from './common';
 
@@ -22,7 +22,6 @@ export function* generateStyleScopedClasses(
 
 	const visited = new Set<string>();
 	const deferredGenerates: Generator<Code>[] = [];
-	yield `// @ts-ignore${newLine}`;
 	yield* generateTypeAlias(names.StyleScopedClasses, scriptLang, function*() {
 		yield `{}`;
 		for (const style of scopedStyles) {
@@ -42,6 +41,10 @@ export function* generateStyleScopedClasses(
 			}
 		}
 	});
+	if (isTsLang(scriptLang)) {
+		// trick to avoid TS6196; the alias is otherwise only referenced from JSDoc casts
+		yield `0 as unknown as ${names.StyleScopedClasses}${endOfLine}`;
+	}
 
 	for (const generate of deferredGenerates) {
 		yield* generate;

--- a/packages/language-core/lib/codegen/style/scopedClasses.ts
+++ b/packages/language-core/lib/codegen/style/scopedClasses.ts
@@ -42,8 +42,8 @@ export function* generateStyleScopedClasses(
 		}
 	});
 	if (isTsLang(scriptLang)) {
-		// trick to avoid TS6196; the alias is otherwise only referenced from JSDoc casts
-		yield `0 as unknown as ${names.StyleScopedClasses}${endOfLine}`;
+		// avoid TS6196: JSDoc refs don't count as usage; JS @typedefs skip the check
+		yield `void ({} as ${names.StyleScopedClasses})${endOfLine}`;
 	}
 
 	for (const generate of deferredGenerates) {


### PR DESCRIPTION
Related #6170

Fix for "remaining synthesized @ts-ignore" > scoped classes type alias TS6196