### PR TITLE
refactor(language-core): move `__VLS_PropsChildren` into global template helpers

### DIFF
--- a/packages/language-core/lib/codegen/localTypes.ts
+++ b/packages/language-core/lib/codegen/localTypes.ts
@@ -46,29 +46,6 @@ type __VLS_WithSlots<T, S> = T & {
 `.trimStart()
 				: jsTypedef(`T, S`, `__VLS_WithSlots`, `T & { new(): { $slots: S; } }`),
 	);
-	const PropsChildren = defineHelper(
-		`__VLS_PropsChildren`,
-		() =>
-			isTs
-				? `
-type __VLS_PropsChildren<S> = {
-	[K in keyof (
-		boolean extends (
-			// @ts-ignore
-			JSX.ElementChildrenAttribute extends never
-				? true
-				: false
-		)
-			? never
-			// @ts-ignore
-			: JSX.ElementChildrenAttribute
-	)]?: S;
-};
-`.trimStart()
-				// The single-line form lets the preceding @ts-ignore cover the whole typedef,
-				// mirroring the inline @ts-ignore guards of the TS form.
-				: `// @ts-ignore${newLine}/** @template S @typedef {{ [K in keyof (boolean extends (JSX.ElementChildrenAttribute extends never ? true : false) ? never : JSX.ElementChildrenAttribute)]?: S; }} __VLS_PropsChildren */${newLine}`,
-	);
 	const TypePropsToOption = defineHelper(
 		`__VLS_TypePropsToOption`,
 		() =>
@@ -101,7 +78,6 @@ type __VLS_TypePropsToOption<T> = {
 		[PrettifyLocal.name]: PrettifyLocal,
 		[WithDefaults.name]: WithDefaults,
 		[WithSlots.name]: WithSlots,
-		[PropsChildren.name]: PropsChildren,
 		[TypePropsToOption.name]: TypePropsToOption,
 		[OmitIndexSignature.name]: OmitIndexSignature,
 	};
@@ -117,9 +93,6 @@ type __VLS_TypePropsToOption<T> = {
 		},
 		get WithSlots() {
 			return WithSlots.name;
-		},
-		get PropsChildren() {
-			return PropsChildren.name;
 		},
 		get TypePropsToOption() {
 			return TypePropsToOption.name;

--- a/packages/language-core/lib/codegen/names.ts
+++ b/packages/language-core/lib/codegen/names.ts
@@ -66,6 +66,7 @@ const raw = {
 	OverloadUnionInner: '',
 	PickNotAny: '',
 	PrettifyGlobal: '',
+	PropsChildren: '',
 	ResolveDirectives: '',
 	ResolveEmits: '',
 	ResolveEvent: '',

--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -480,7 +480,7 @@ function* generatePublicProps(
 
 	const propTypes: string[] = [];
 	if (options.vueCompilerOptions.jsxSlots && hasSlotsType(options)) {
-		propTypes.push(`${ctx.localTypes.PropsChildren}<${names.Slots}>`);
+		propTypes.push(`${names.PropsChildren}<${names.Slots}>`);
 	}
 	if (scriptSetupRanges.defineProps?.typeArg) {
 		propTypes.push(names.Props);

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -98,6 +98,19 @@ declare global {
 		[K in keyof T & string as `v${Capitalize<K>}`]: T[K];
 	};
 	type __VLS_PrettifyGlobal<T> = (T extends any ? { [K in keyof T]: T[K] } : { [K in keyof T as K]: T[K] }) & {};
+	type __VLS_PropsChildren<S> = {
+		[
+			K in keyof (
+				boolean extends (
+					// @ts-ignore
+					JSX.ElementChildrenAttribute extends never ? true
+						: false
+				) ? never
+					// @ts-ignore
+					: JSX.ElementChildrenAttribute
+			)
+		]?: S;
+	};
 
 	function __VLS_vFor<const T>(source: T): T extends number ? [number, number][]
 		: T extends string ? [string, number][]


### PR DESCRIPTION
Related #6170

Fix for "remaining synthesized @ts-ignore" > JS typedef guards TS2503

The error is structural, but the `@ts-ignore` can live in the static `template-helpers.d.ts` instead of generated code. Behavior stays the same, and the content mapper never sees it.