### PR TITLE
test(tsc): assert emitted declarations are self-contained and add jsxSlots test

### DIFF
--- a/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
+++ b/packages/tsc/tests/__snapshots__/dts.spec.ts.snap
@@ -158,6 +158,76 @@ export default _default;
 "
 `;
 
+exports[`Input: jsx-slots/generic-slots.vue, Output: jsx-slots/generic-slots.vue.d.ts 1`] = `
+"declare const __VLS_export: <T>(__VLS_props: NonNullable<Awaited<typeof __VLS_setup>>["props"], __VLS_ctx?: __VLS_PrettifyLocal<Pick<NonNullable<Awaited<typeof __VLS_setup>>, "attrs" | "emit" | "slots">>, __VLS_exposed?: NonNullable<Awaited<typeof __VLS_setup>>["expose"], __VLS_setup?: Promise<{
+    props: import("vue").PublicProps & __VLS_PrettifyLocal<__VLS_PropsChildren<{
+        default?: (props: {
+            item: T;
+        }) => any;
+    }> & {
+        items: T[];
+    }> & (typeof globalThis extends {
+        __VLS_PROPS_FALLBACK: infer P;
+    } ? P : {});
+    expose: (exposed: {}) => void;
+    attrs: any;
+    slots: {
+        default?: (props: {
+            item: T;
+        }) => any;
+    };
+    emit: {};
+}>) => import("vue").VNode & {
+    __ctx?: NonNullable<Awaited<typeof __VLS_setup>>;
+};
+declare const _default: typeof __VLS_export;
+export default _default;
+type __VLS_PrettifyLocal<T> = (T extends any ? {
+    [K in keyof T]: T[K];
+} : {
+    [K in keyof T as K]: T[K];
+}) & {};
+type __VLS_PropsChildren<S> = {
+    [K in keyof (boolean extends (JSX.ElementChildrenAttribute extends never ? true : false) ? never : JSX.ElementChildrenAttribute)]?: S;
+};
+"
+`;
+
+exports[`Input: jsx-slots/no-slots.vue, Output: jsx-slots/no-slots.vue.d.ts 1`] = `
+"type __VLS_Props = {
+    msg: string;
+};
+declare const __VLS_export: import("vue").DefineComponent<__VLS_Props, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<__VLS_Props> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, false, {}, any>;
+declare const _default: typeof __VLS_export;
+export default _default;
+"
+`;
+
+exports[`Input: jsx-slots/slots.vue, Output: jsx-slots/slots.vue.d.ts 1`] = `
+"type __VLS_Props = {
+    msg: string;
+};
+type __VLS_Slots = {
+    default?: (props: {
+        msg: string;
+    }) => any;
+};
+type __VLS_PublicProps = __VLS_PropsChildren<__VLS_Slots> & __VLS_Props;
+declare const __VLS_base: import("vue").DefineComponent<__VLS_PublicProps, {}, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<__VLS_PublicProps> & Readonly<{}>, {}, {}, {}, {}, string, import("vue").ComponentProvideOptions, false, {}, any>;
+declare const __VLS_export: __VLS_WithSlots<typeof __VLS_base, __VLS_Slots>;
+declare const _default: typeof __VLS_export;
+export default _default;
+type __VLS_PropsChildren<S> = {
+    [K in keyof (boolean extends (JSX.ElementChildrenAttribute extends never ? true : false) ? never : JSX.ElementChildrenAttribute)]?: S;
+};
+type __VLS_WithSlots<T, S> = T & {
+    new (): {
+        $slots: S;
+    };
+};
+"
+`;
+
 exports[`Input: non-component/component.ts, Output: non-component/component.d.ts 1`] = `
 "declare const _default: {};
 export default _default;

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -67,6 +67,53 @@ for (const intputFile of options.rootNames) {
 	});
 }
 
+// Global `__VLS_` helpers don't exist for .d.ts consumers,
+// recheck each output as plain .ts so no `__VLS_` name dangles.
+test(`Self-contained d.ts emit: ${shortenPath(workspace)}`, () => {
+	const emitted = new Map<string, string>();
+	for (const inputFile of options.rootNames) {
+		const sourceFile = program.getSourceFile(inputFile);
+		program.emit(
+			sourceFile,
+			(outputFile, text) => emitted.set(normalizePath(outputFile), text),
+			undefined,
+			true,
+		);
+	}
+	expect(emitted.size).toBeGreaterThan(0);
+	for (const text of emitted.values()) {
+		expect(text).not.toContain('/// <reference');
+	}
+
+	const checkFiles = new Map<string, string>(
+		[...emitted].map(([outputFile, text]) => [outputFile.slice(0, -'.d.ts'.length) + '.check.ts', text]),
+	);
+	const checkOptions: ts.CompilerOptions = {
+		noEmit: true,
+		skipLibCheck: true,
+		target: ts.ScriptTarget.ESNext,
+		module: ts.ModuleKind.ESNext,
+		moduleResolution: ts.ModuleResolutionKind.Bundler,
+	};
+	const checkHost = ts.createCompilerHost(checkOptions);
+	const { fileExists, getSourceFile } = checkHost;
+	checkHost.fileExists = fileName => checkFiles.has(normalizePath(fileName)) || fileExists.call(checkHost, fileName);
+	checkHost.getSourceFile = (fileName, languageVersion, ...args) => {
+		const text = checkFiles.get(normalizePath(fileName));
+		return text !== undefined
+			? ts.createSourceFile(fileName, text, languageVersion)
+			: getSourceFile.call(checkHost, fileName, languageVersion, ...args);
+	};
+	const checkProgram = ts.createProgram([...checkFiles.keys()], checkOptions, checkHost);
+	const danglingReferences = checkProgram.getSemanticDiagnostics()
+		.map(diagnostic => ({
+			file: diagnostic.file ? shortenPath(diagnostic.file.fileName) : '',
+			message: ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+		}))
+		.filter(({ message }) => /Cannot find (name|namespace) '__VLS_/.test(message));
+	expect(danglingReferences).toEqual([]);
+});
+
 function readFilesRecursive(dir: string) {
 	if (path.relative(workspace, dir).startsWith('#')) {
 		return [];

--- a/packages/tsc/tests/dts.spec.ts
+++ b/packages/tsc/tests/dts.spec.ts
@@ -5,116 +5,128 @@ import * as path from 'node:path';
 import * as ts from 'typescript';
 import { expect, test } from 'vitest';
 
-const workspace = path.resolve(__dirname, '../../../test-workspace/component-meta');
 const normalizePath = (filename: string) => filename.replace(/\\/g, '/');
 const normalizeNewline = (text: string) => text.replace(/\r\n/g, '\n');
 const windowsPathRE = /\\/g;
 
-const compilerOptions: ts.CompilerOptions = {
-	rootDir: workspace,
-	declaration: true,
-	emitDeclarationOnly: true,
-	allowNonTsExtensions: true,
-};
-const host = ts.createCompilerHost(compilerOptions);
-const options: ts.CreateProgramOptions = {
-	host,
-	rootNames: readFilesRecursive(workspace),
-	options: compilerOptions,
-};
+defineDtsEmitTests(
+	path.resolve(__dirname, '../../../test-workspace/component-meta'),
+);
+defineDtsEmitTests(
+	path.resolve(__dirname, '../../../test-workspace/dts/jsx-slots'),
+	true,
+);
 
-let vueOptions: core.VueCompilerOptions;
+function defineDtsEmitTests(workspace: string, useWorkspaceTsconfig = false) {
+	const compilerOptions: ts.CompilerOptions = {
+		rootDir: workspace,
+		declaration: true,
+		emitDeclarationOnly: true,
+		allowNonTsExtensions: true,
+	};
+	const host = ts.createCompilerHost(compilerOptions);
+	const options: ts.CreateProgramOptions = {
+		host,
+		rootNames: readFilesRecursive(workspace, workspace),
+		options: compilerOptions,
+	};
 
-const createProgram = proxyCreateProgram(ts, ts.createProgram, (ts, options) => {
-	const { configFilePath } = options.options;
-	if (typeof configFilePath === 'string') {
-		vueOptions = core.createParsedCommandLine(ts, ts.sys, configFilePath.replace(windowsPathRE, '/')).vueOptions;
-	}
-	else {
-		vueOptions = core.createParsedCommandLineByJson(ts, ts.sys, workspace.replace(windowsPathRE, '/'), {}).vueOptions;
-		vueOptions.target = 99;
-		vueOptions.extensions = ['vue', 'cext'];
-	}
-	const vueLanguagePlugin = core.createVueLanguagePlugin<string>(
-		ts,
-		options.options,
-		vueOptions,
-		id => id,
-	);
-	return [vueLanguagePlugin];
-});
-const program = createProgram(options);
+	let vueOptions: core.VueCompilerOptions;
 
-for (const intputFile of options.rootNames) {
-	const expectedOutputFile = intputFile.endsWith('.ts')
-		? intputFile.slice(0, -'.ts'.length) + '.d.ts'
-		: intputFile.endsWith('.tsx')
-		? intputFile.slice(0, -'.tsx'.length) + '.d.ts'
-		: intputFile + '.d.ts';
-	test(`Input: ${shortenPath(intputFile)}, Output: ${shortenPath(expectedOutputFile)}`, () => {
-		let outputText: string | undefined;
-		const sourceFile = program.getSourceFile(intputFile);
-		program.emit(
-			sourceFile,
-			(outputFile, text) => {
-				expect(outputFile.replace(windowsPathRE, '/')).toBe(expectedOutputFile.replace(windowsPathRE, '/'));
-				outputText = text;
-			},
-			undefined,
-			true,
+	const createProgram = proxyCreateProgram(ts, ts.createProgram, (ts, options) => {
+		if (useWorkspaceTsconfig) {
+			const tsconfigPath = normalizePath(path.join(workspace, 'tsconfig.json'));
+			vueOptions = core.createParsedCommandLine(ts, ts.sys, tsconfigPath).vueOptions;
+		}
+		else {
+			vueOptions = core.createParsedCommandLineByJson(ts, ts.sys, workspace.replace(windowsPathRE, '/'), {}).vueOptions;
+			vueOptions.target = 99;
+			vueOptions.extensions = ['vue', 'cext'];
+		}
+		const vueLanguagePlugin = core.createVueLanguagePlugin<string>(
+			ts,
+			options.options,
+			vueOptions,
+			id => id,
 		);
-		expect(outputText ? normalizeNewline(outputText) : undefined).toMatchSnapshot();
+		return [vueLanguagePlugin];
+	});
+	const program = createProgram(options);
+
+	for (const intputFile of options.rootNames) {
+		if (intputFile.endsWith('.d.ts')) {
+			continue;
+		}
+		const expectedOutputFile = intputFile.endsWith('.ts')
+			? intputFile.slice(0, -'.ts'.length) + '.d.ts'
+			: intputFile.endsWith('.tsx')
+			? intputFile.slice(0, -'.tsx'.length) + '.d.ts'
+			: intputFile + '.d.ts';
+		test(`Input: ${shortenPath(intputFile)}, Output: ${shortenPath(expectedOutputFile)}`, () => {
+			let outputText: string | undefined;
+			const sourceFile = program.getSourceFile(intputFile);
+			program.emit(
+				sourceFile,
+				(outputFile, text) => {
+					expect(outputFile.replace(windowsPathRE, '/')).toBe(expectedOutputFile.replace(windowsPathRE, '/'));
+					outputText = text;
+				},
+				undefined,
+				true,
+			);
+			expect(outputText ? normalizeNewline(outputText) : undefined).toMatchSnapshot();
+		});
+	}
+
+	// Global `__VLS_` helpers don't exist for .d.ts consumers,
+	// recheck each output as plain .ts so no `__VLS_` name dangles.
+	test(`Self-contained d.ts emit: ${shortenPath(workspace)}`, () => {
+		const emitted = new Map<string, string>();
+		for (const inputFile of options.rootNames) {
+			const sourceFile = program.getSourceFile(inputFile);
+			program.emit(
+				sourceFile,
+				(outputFile, text) => emitted.set(normalizePath(outputFile), text),
+				undefined,
+				true,
+			);
+		}
+		expect(emitted.size).toBeGreaterThan(0);
+		for (const text of emitted.values()) {
+			expect(text).not.toContain('/// <reference');
+		}
+
+		const checkFiles = new Map<string, string>(
+			[...emitted].map(([outputFile, text]) => [outputFile.slice(0, -'.d.ts'.length) + '.check.ts', text]),
+		);
+		const checkOptions: ts.CompilerOptions = {
+			noEmit: true,
+			skipLibCheck: true,
+			target: ts.ScriptTarget.ESNext,
+			module: ts.ModuleKind.ESNext,
+			moduleResolution: ts.ModuleResolutionKind.Bundler,
+		};
+		const checkHost = ts.createCompilerHost(checkOptions);
+		const { fileExists, getSourceFile } = checkHost;
+		checkHost.fileExists = fileName => checkFiles.has(normalizePath(fileName)) || fileExists.call(checkHost, fileName);
+		checkHost.getSourceFile = (fileName, languageVersion, ...args) => {
+			const text = checkFiles.get(normalizePath(fileName));
+			return text !== undefined
+				? ts.createSourceFile(fileName, text, languageVersion)
+				: getSourceFile.call(checkHost, fileName, languageVersion, ...args);
+		};
+		const checkProgram = ts.createProgram([...checkFiles.keys()], checkOptions, checkHost);
+		const danglingReferences = checkProgram.getSemanticDiagnostics()
+			.map(diagnostic => ({
+				file: diagnostic.file ? shortenPath(diagnostic.file.fileName) : '',
+				message: ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+			}))
+			.filter(({ message }) => /Cannot find (name|namespace) '__VLS_/.test(message));
+		expect(danglingReferences).toEqual([]);
 	});
 }
 
-// Global `__VLS_` helpers don't exist for .d.ts consumers,
-// recheck each output as plain .ts so no `__VLS_` name dangles.
-test(`Self-contained d.ts emit: ${shortenPath(workspace)}`, () => {
-	const emitted = new Map<string, string>();
-	for (const inputFile of options.rootNames) {
-		const sourceFile = program.getSourceFile(inputFile);
-		program.emit(
-			sourceFile,
-			(outputFile, text) => emitted.set(normalizePath(outputFile), text),
-			undefined,
-			true,
-		);
-	}
-	expect(emitted.size).toBeGreaterThan(0);
-	for (const text of emitted.values()) {
-		expect(text).not.toContain('/// <reference');
-	}
-
-	const checkFiles = new Map<string, string>(
-		[...emitted].map(([outputFile, text]) => [outputFile.slice(0, -'.d.ts'.length) + '.check.ts', text]),
-	);
-	const checkOptions: ts.CompilerOptions = {
-		noEmit: true,
-		skipLibCheck: true,
-		target: ts.ScriptTarget.ESNext,
-		module: ts.ModuleKind.ESNext,
-		moduleResolution: ts.ModuleResolutionKind.Bundler,
-	};
-	const checkHost = ts.createCompilerHost(checkOptions);
-	const { fileExists, getSourceFile } = checkHost;
-	checkHost.fileExists = fileName => checkFiles.has(normalizePath(fileName)) || fileExists.call(checkHost, fileName);
-	checkHost.getSourceFile = (fileName, languageVersion, ...args) => {
-		const text = checkFiles.get(normalizePath(fileName));
-		return text !== undefined
-			? ts.createSourceFile(fileName, text, languageVersion)
-			: getSourceFile.call(checkHost, fileName, languageVersion, ...args);
-	};
-	const checkProgram = ts.createProgram([...checkFiles.keys()], checkOptions, checkHost);
-	const danglingReferences = checkProgram.getSemanticDiagnostics()
-		.map(diagnostic => ({
-			file: diagnostic.file ? shortenPath(diagnostic.file.fileName) : '',
-			message: ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
-		}))
-		.filter(({ message }) => /Cannot find (name|namespace) '__VLS_/.test(message));
-	expect(danglingReferences).toEqual([]);
-});
-
-function readFilesRecursive(dir: string) {
+function readFilesRecursive(workspace: string, dir: string) {
 	if (path.relative(workspace, dir).startsWith('#')) {
 		return [];
 	}
@@ -127,7 +139,7 @@ function readFilesRecursive(dir: string) {
 		const filepath = path.join(dir, file);
 		const stat = fs.statSync(filepath);
 		if (stat.isDirectory()) {
-			result.push(...readFilesRecursive(filepath));
+			result.push(...readFilesRecursive(workspace, filepath));
 		}
 		else {
 			result.push(filepath);

--- a/test-workspace/dts/jsx-slots/env.d.ts
+++ b/test-workspace/dts/jsx-slots/env.d.ts
@@ -1,0 +1,5 @@
+declare namespace JSX {
+	interface ElementChildrenAttribute {
+		$children: {};
+	}
+}

--- a/test-workspace/dts/jsx-slots/generic-slots.vue
+++ b/test-workspace/dts/jsx-slots/generic-slots.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts" generic="T">
+defineProps<{
+	items: T[];
+}>();
+
+defineSlots<{
+	default?: (props: { item: T }) => any;
+}>();
+</script>
+
+<template>
+	<slot v-for="item of items" :item="item" />
+</template>

--- a/test-workspace/dts/jsx-slots/no-slots.vue
+++ b/test-workspace/dts/jsx-slots/no-slots.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{
+	msg: string;
+}>();
+</script>
+
+<template>
+	{{ msg }}
+</template>

--- a/test-workspace/dts/jsx-slots/slots.vue
+++ b/test-workspace/dts/jsx-slots/slots.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+defineProps<{
+	msg: string;
+}>();
+
+defineSlots<{
+	default?: (props: { msg: string }) => any;
+}>();
+</script>
+
+<template>
+	<slot :msg="msg" />
+</template>

--- a/test-workspace/dts/jsx-slots/tsconfig.json
+++ b/test-workspace/dts/jsx-slots/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"vueCompilerOptions": {
+		"jsxSlots": true
+	},
+	"include": ["**/*"]
+}


### PR DESCRIPTION
Related #6195

Global `__VLS_` helpers don't exist for .d.ts consumers, recheck each output as plain .ts so no `__VLS_` name dangles.